### PR TITLE
Remove Swifty JSON in favor of Codable parsing

### DIFF
--- a/dev-ostelco-ios-clientTests/MyInfoTests.swift
+++ b/dev-ostelco-ios-clientTests/MyInfoTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-@testable import dev_ostelco_ios_client_app
+@testable import Oya_Development_app
 import XCTest
 
 class MyInfoTests: XCTestCase {

--- a/dev-ostelco-ios-clientTests/MyInfoTests.swift
+++ b/dev-ostelco-ios-clientTests/MyInfoTests.swift
@@ -1,0 +1,45 @@
+//
+//  MyInfoTests.swift
+//  dev-ostelco-ios-clientTests
+//
+//  Created by Ellen Shapiro on 4/16/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+@testable import dev_ostelco_ios_client_app
+import XCTest
+
+class MyInfoTests: XCTestCase {
+    
+    func testMyInfoDetailsParsesCorrectlyFromLocalData() {
+        guard let testInfo = MyInfoDetails.testInfo else {
+            XCTFail("Could not parse test info!")
+            return
+        }
+        
+        XCTAssertEqual(testInfo.name, "TAN XIAO HUI")
+        XCTAssertEqual(testInfo.sex, "F")
+        XCTAssertEqual(testInfo.dob, "1970-05-17")
+        XCTAssertEqual(testInfo.residentialStatus, "C")
+        XCTAssertEqual(testInfo.nationality, "SG")
+        XCTAssertEqual(testInfo.email, "myinfotesting@gmail.com")
+        
+        let address = testInfo.address
+        XCTAssertEqual(address.country, "SG")
+        XCTAssertEqual(address.unit, "128")
+        XCTAssertEqual(address.street, "BEDOK NORTH AVENUE 4")
+        XCTAssertEqual(address.block, "102")
+        XCTAssertEqual(address.postal, "460102")
+        XCTAssertEqual(address.floor, "09")
+        XCTAssertEqual(address.building, "PEARL GARDEN")
+        
+        guard let mobileNumber = testInfo.mobileNumber else {
+            XCTFail("Could not access mobile number!")
+            return
+        }
+        XCTAssertEqual(mobileNumber.code, "65")
+        XCTAssertEqual(mobileNumber.prefix, "+")
+        XCTAssertEqual(mobileNumber.number, "97399245")
+        XCTAssertEqual(mobileNumber.formattedNumber, "+6597399245")
+    }
+}

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B920F64225B8EC6001EF9CD /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		9B9B3251225E7CCD00227EA3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		9BBF70462265D45700E4B9B4 /* MyInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoTests.swift; sourceTree = "<group>"; };
 		9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MyInfoDetails+Testing.swift"; sourceTree = "<group>"; };
 		9BE2D441225B5D5100B51999 /* UIView+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Shadow.swift"; sourceTree = "<group>"; };
 		9BE2D446225B5E3100B51999 /* UIColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
@@ -635,6 +636,7 @@
 			children = (
 				9BE2D459225B625500B51999 /* EnumHelperTests.swift */,
 				C2236F0E218A414C00B135C0 /* Info.plist */,
+				9BBF70462265D45700E4B9B4 /* MyInfoTests.swift */,
 			);
 			path = "dev-ostelco-ios-clientTests";
 			sourceTree = "<group>";
@@ -1282,6 +1284,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BE2D45A225B625500B51999 /* EnumHelperTests.swift in Sources */,
+				9BBF70472265D45700E4B9B4 /* MyInfoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		9B920F66225B8EE1001EF9CD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F64225B8EC6001EF9CD /* Theme.swift */; };
 		9BBF70492265D4D200E4B9B4 /* MyInfoDetails+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */; };
 		9BBF704A2265D51600E4B9B4 /* MyInfoDetails+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */; };
+		9BBF704B2265DAC300E4B9B4 /* MyInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70462265D45700E4B9B4 /* MyInfoTests.swift */; };
 		9BE2D442225B5D5100B51999 /* UIView+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE2D441225B5D5100B51999 /* UIView+Shadow.swift */; };
 		9BE2D447225B5E3100B51999 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE2D446225B5E3100B51999 /* UIColor+Hex.swift */; };
 		9BE2D448225B5E3100B51999 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE2D446225B5E3100B51999 /* UIColor+Hex.swift */; };
@@ -1284,7 +1285,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BE2D45A225B625500B51999 /* EnumHelperTests.swift in Sources */,
-				9BBF70472265D45700E4B9B4 /* MyInfoTests.swift in Sources */,
+				9BBF704B2265DAC300E4B9B4 /* MyInfoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B920F65225B8EC6001EF9CD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F64225B8EC6001EF9CD /* Theme.swift */; };
 		9B920F66225B8EE1001EF9CD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F64225B8EC6001EF9CD /* Theme.swift */; };
+		9BBF70492265D4D200E4B9B4 /* MyInfoDetails+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */; };
+		9BBF704A2265D51600E4B9B4 /* MyInfoDetails+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */; };
 		9BE2D442225B5D5100B51999 /* UIView+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE2D441225B5D5100B51999 /* UIView+Shadow.swift */; };
 		9BE2D447225B5E3100B51999 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE2D446225B5E3100B51999 /* UIColor+Hex.swift */; };
 		9BE2D448225B5E3100B51999 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE2D446225B5E3100B51999 /* UIColor+Hex.swift */; };
@@ -307,6 +309,7 @@
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B920F64225B8EC6001EF9CD /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		9B9B3251225E7CCD00227EA3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MyInfoDetails+Testing.swift"; sourceTree = "<group>"; };
 		9BE2D441225B5D5100B51999 /* UIView+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Shadow.swift"; sourceTree = "<group>"; };
 		9BE2D446225B5E3100B51999 /* UIColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
 		9BE2D449225B5E9600B51999 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
@@ -529,6 +532,7 @@
 				0437CF7F224D08660022A2B8 /* Scan.swift */,
 				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
 				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
+				9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1243,6 +1247,7 @@
 				041216A9222817EC00455278 /* ChooseCountryOnBoardingViewController.swift in Sources */,
 				9BE2D451225B609100B51999 /* TopUpButton.swift in Sources */,
 				048C787C2191C9660041F135 /* ThemeManager.swift in Sources */,
+				9BBF70492265D4D200E4B9B4 /* MyInfoDetails+Testing.swift in Sources */,
 				0412168F2226BEB100455278 /* TheLegalStuffViewController.swift in Sources */,
 				0412168C2226BBBA00455278 /* GetStartedViewController.swift in Sources */,
 				04834D50222FC2AF00A01500 /* ESIMPendingDownloadViewController.swift in Sources */,
@@ -1345,6 +1350,7 @@
 				C29802B72181EDA800FBC5C3 /* BundleModel.swift in Sources */,
 				0437CF84224D1DAE0022A2B8 /* Region.swift in Sources */,
 				041216B022281CE000455278 /* AllowLocationAccessViewController.swift in Sources */,
+				9BBF704A2265D51600E4B9B4 /* MyInfoDetails+Testing.swift in Sources */,
 				C25A95972226FF7F005958EC /* MyInfoSummaryViewController.swift in Sources */,
 				0437CF87224D1E020022A2B8 /* SimProfile.swift in Sources */,
 				048533A4223C1ACA007C89F4 /* UIViewController+StartApplePay.swift in Sources */,

--- a/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
+++ b/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
@@ -75,8 +75,11 @@ extension MyInfoDetails {
     }
     
     static var testInfo: MyInfoDetails? {
+        guard let json = self.testJSONString.data(using: .utf8) else {
+            return nil
+        }
+        
         do {
-            let json = try JSONEncoder().encode(self.testJSONString)
             let myInfo = try JSONDecoder().decode(MyInfoDetails.self, from: json)
             print("MyInfo \(myInfo)")
             print("Address 1 \(myInfo.address.getAddressLine1())")

--- a/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
+++ b/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
@@ -1,0 +1,90 @@
+//
+//  MyInfoDetails+Testing.swift
+//  ostelco-ios-client
+//
+//  Created by Ellen Shapiro on 4/16/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+// TODO: Move this to test package once stabilized
+extension MyInfoDetails {
+    
+    private static var testJSONString: String {
+        return """
+{
+    "name": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "TAN XIAO HUI"
+    },
+    "sex": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "F"
+    },
+    "dob": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "1970-05-17"
+    },
+    "residentialstatus": {
+        "lastupdated": "2018-03-23",
+        "source": "1",
+        "classification": "C",
+        "value": "C"
+    },
+    "nationality": {
+        "lastupdated": "2018-03-20",
+        "source": "1",
+        "classification": "C",
+        "value": "SG"
+    },
+    "mobileno": {
+        "lastupdated": "2018-08-23",
+        "code": "65",
+        "source": "4",
+        "classification": "C",
+        "prefix": "+",
+        "nbr": "97399245"
+    },
+    "email": {
+        "lastupdated": "2018-08-23",
+        "source": "4",
+        "classification": "C",
+        "value": "myinfotesting@gmail.com"
+    },
+    "regadd": {
+        "country": "SG",
+        "unit": "128",
+        "street": "BEDOK NORTH AVENUE 4",
+        "lastupdated": "2018-03-20",
+        "block": "102",
+        "postal": "460102",
+        "source": "1",
+        "classification": "C",
+        "floor": "09",
+        "building": "PEARL GARDEN"
+    }
+}
+"""
+    }
+    
+    static var testInfo: MyInfoDetails? {
+        do {
+            let json = try JSONEncoder().encode(self.testJSONString)
+            let myInfo = try JSONDecoder().decode(MyInfoDetails.self, from: json)
+            print("MyInfo \(myInfo)")
+            print("Address 1 \(myInfo.address.getAddressLine1())")
+            print("Address 2 \(myInfo.address.getAddressLine2())")
+            return myInfo
+        } catch {
+            print("Error \(error)")
+            return nil
+        }
+    }
+}

--- a/ostelco-ios-client/Models/MyInfoDetails.swift
+++ b/ostelco-ios-client/Models/MyInfoDetails.swift
@@ -8,7 +8,7 @@
 
 import SwiftyJSON
 
-struct MyInfoAddress{
+struct MyInfoAddress: Codable {
     let country: String?
     let unit: String?
     let street: String?
@@ -17,78 +17,101 @@ struct MyInfoAddress{
     let floor: String?
     let building: String?
 
-    static func fromJSON(_ json: JSON) -> MyInfoAddress {
-        return MyInfoAddress(
-            country: json["country"].string,
-            unit: json["unit"].string,
-            street: json["street"].string,
-            block: json["block"].string,
-            postal: json["postal"].string,
-            floor: json["floor"].string,
-            building: json["building"].string
-        )
-    }
     func getAddressLine1() -> String {
         var addressLine1: String = ""
-        if let block = block {
+        if let block = self.block {
             addressLine1 = "\(block) "
         }
-        if let street = street {
+        if let street = self.street {
             addressLine1 += "\(street) "
         }
         return addressLine1
     }
+    
     func getAddressLine2() -> String {
         var addressLine2: String = ""
-        if let postal = postal {
+        if let postal = self.postal {
             addressLine2 = "\(postal) "
         }
-        if let country = country {
+        if let country = self.country {
             addressLine2 += "\(country) "
         }
         return addressLine2
     }
 }
 
-struct MyInfoDetails {
-    let name: String
-    let dob: String
-    let email: String
+struct MyInfoDetails: Codable {
+    private let _name: MyInfoRequiredValue
+    var name: String {
+        return _name.value
+    }
+    
+    private let _dob: MyInfoRequiredValue
+    var dob: String {
+        return _dob.value
+    }
+    private let _email: MyInfoRequiredValue
+    var email: String {
+        return _email.value
+    }
+    
+    private let _sex: MyInfoOptionalValue?
+    var sex: String? {
+        return _sex?.value
+    }
+    
+    private let _residentialStatus: MyInfoOptionalValue?
+    var residentialStatus: String? {
+        return _residentialStatus?.value
+    }
+    
+    private let _nationality: MyInfoOptionalValue?
+    var nationality: String? {
+        return _nationality?.value
+    }
+    
     let address: MyInfoAddress
-    let sex: String?
-    let residentialStatus: String?
-    let nationality: String?
-    let mobileNumber: String?
-
-    static func fromJSON(_ json: JSON) -> MyInfoDetails? {
-        let address = MyInfoAddress.fromJSON(json["regadd"])
-        let mobileno = mobileNumberFromJSON(json["mobileno"])
-        let nationality = json["nationality"]["value"].string
-        let residentialstatus = json["residentialstatus"]["value"].string
-        let sex = json["sex"]["value"].string
-        if let name = json["name"]["value"].string,
-            let email = json["email"]["value"].string,
-            let dob = json["dob"]["value"].string {
-            return MyInfoDetails(
-                name: name,
-                dob: dob,
-                email: email,
-                address: address,
-                sex:sex,
-                residentialStatus: residentialstatus,
-                nationality: nationality,
-                mobileNumber: mobileno
-            )
-        }
-        return nil
+    let mobileNumber: MyInfoMobileNumber?
+    
+    enum CodingKeys: String, CodingKey {
+        case _name = "name"
+        case _dob = "dob"
+        case _email = "email"
+        case address = "regadd"
+        case _sex = "sex"
+        case _residentialStatus = "residentialstatus"
+        case _nationality = "nationality"
+        case mobileNumber = "mobileno"
     }
-    static func mobileNumberFromJSON(_ json: JSON) -> String? {
-        if let number = json["nbr"].string,
-            let code = json["code"].string,
-            let prefix = json["prefix"].string {
-            return "\(prefix)\(code)\(number)"
-        }
-        return nil
-    }
+}
 
+struct MyInfoRequiredValue: Codable {
+    let value: String
+}
+
+struct MyInfoOptionalValue: Codable {
+    let value: String?
+}
+
+struct MyInfoMobileNumber: Codable {
+    let number: String?
+    let code: String?
+    let prefix: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case number = "nbr"
+        case code
+        case prefix
+    }
+    
+    var formattedNumber: String? {
+        guard
+            let number = self.number,
+            let code = self.code,
+            let prefix = self.prefix else {
+                return nil
+        }
+        
+        return "\(prefix)\(code)\(number)"
+    }
 }

--- a/ostelco-ios-client/Models/MyInfoDetails.swift
+++ b/ostelco-ios-client/Models/MyInfoDetails.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-import SwiftyJSON
+import Foundation
 
 struct MyInfoAddress: Codable {
     let country: String?

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -48,7 +48,7 @@ class APIManager: Service {
         }
 
         configureTransformer("/regions/sg/kyc/myInfo/*") {
-            try MyInfoDetails.fromJSON(JSON(data: $0.content))
+            try self.jsonDecoder.decode(MyInfoDetails.self, from: $0.content)
         }
 
         configureTransformer("/regions/*/simProfiles", requestMethods: [.get]) {

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -7,7 +7,6 @@
 //
 
 import Siesta
-import SwiftyJSON
 
 class APIManager: Service {
 

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import SwiftyJSON
 
 class MyInfoSummaryViewController: UIViewController {
     public var myInfoQueryItems: [URLQueryItem]?
@@ -47,7 +46,7 @@ class MyInfoSummaryViewController: UIViewController {
         }
         //TODO: Pass the code we retrieved to PRIME
         //TODO: Get the address & phone number form PRIME
-        // updateUI(getTempData()) // TODO: Remove this when API is stable.
+        // updateUI(MyInfoDetails.testInfo) // TODO: Remove this when API is stable.
     }
 
     private func getMyInfoCode() -> String? {
@@ -74,7 +73,7 @@ class MyInfoSummaryViewController: UIViewController {
         spinnerView = self.showSpinner(onView: self.view)
         APIManager.sharedInstance.regions.child("/sg/kyc/profile")
             .withParam("address", address.text!)
-            .withParam("phoneNumber", myInfoDetails!.mobileNumber!).request(.put)
+            .withParam("phoneNumber", myInfoDetails!.mobileNumber!.formattedNumber).request(.put)
             .onSuccess { _ in
                 DispatchQueue.main.async {
                     self.removeSpinner(self.spinnerView)
@@ -102,7 +101,7 @@ class MyInfoSummaryViewController: UIViewController {
         if let residentialStatus = myInfoDetails.residentialStatus {
             self.residentialStatus.text = residentialStatus
         }
-        if let mobileNumber = myInfoDetails.mobileNumber {
+        if let mobileNumber = myInfoDetails.mobileNumber?.formattedNumber {
             self.mobileNumber.text = mobileNumber
         }
         if let sex = myInfoDetails.sex {
@@ -115,80 +114,4 @@ extension MyInfoSummaryViewController: MyInfoDetailsUpdate {
     func handleUpdate(myInfoDetails: MyInfoDetails) {
         self.myInfoDetails = myInfoDetails
     }
-}
-
-// TODO: Remove this when API is stable.
-func getTempData() -> MyInfoDetails? {
-    let testData = """
-{
-    "name": {
-        "lastupdated": "2018-03-20",
-        "source": "1",
-        "classification": "C",
-        "value": "TAN XIAO HUI"
-    },
-    "sex": {
-        "lastupdated": "2018-03-20",
-        "source": "1",
-        "classification": "C",
-        "value": "F"
-    },
-    "dob": {
-        "lastupdated": "2018-03-20",
-        "source": "1",
-        "classification": "C",
-        "value": "1970-05-17"
-    },
-    "residentialstatus": {
-        "lastupdated": "2018-03-23",
-        "source": "1",
-        "classification": "C",
-        "value": "C"
-    },
-    "nationality": {
-        "lastupdated": "2018-03-20",
-        "source": "1",
-        "classification": "C",
-        "value": "SG"
-    },
-    "mobileno": {
-        "lastupdated": "2018-08-23",
-        "code": "65",
-        "source": "4",
-        "classification": "C",
-        "prefix": "+",
-        "nbr": "97399245"
-    },
-    "email": {
-        "lastupdated": "2018-08-23",
-        "source": "4",
-        "classification": "C",
-        "value": "myinfotesting@gmail.com"
-    },
-    "regadd": {
-        "country": "SG",
-        "unit": "128",
-        "street": "BEDOK NORTH AVENUE 4",
-        "lastupdated": "2018-03-20",
-        "block": "102",
-        "postal": "460102",
-        "source": "1",
-        "classification": "C",
-        "floor": "09",
-        "building": "PEARL GARDEN"
-    }
-}
-"""
-    do {
-        let json = try JSON(data: testData.data(using: .utf8)!)
-        if let myInfo = MyInfoDetails.fromJSON(json) {
-            print("MyInfo \(myInfo)")
-            print("Address 1 \(myInfo.address.getAddressLine1())")
-            print("Address 2 \(myInfo.address.getAddressLine2())")
-            return myInfo
-        }
-    } catch {
-        print("Error \(error)")
-    }
-    return nil
 }


### PR DESCRIPTION
We were using `SwiftyJSON` essentially for one piece of parsing - I've updated this to use `Codable` parsing instead, and added a test against some test data we were already using.

Note: Actually removing the framework will come in another PR, wanted to separate Pod changes from code changes here.