### PR TITLE
Use the correct denomination while doing apple pay.

### DIFF
--- a/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
@@ -118,7 +118,7 @@ extension UIViewController {
         let alertCtrl = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
         for product in products {
-            let buyAction = UIAlertAction(title: product.name, style: .default) {_ in
+            let buyAction = UIAlertAction(title: product.label, style: .default) {_ in
                 self.startApplePay(product: product, delegate: delegate)
             }
             alertCtrl.addAction(buyAction)

--- a/ostelco-ios-client/Extensions/UIViewController+StartApplePay.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+StartApplePay.swift
@@ -9,6 +9,7 @@
 import Stripe
 import Siesta
 
+
 extension UIViewController {
     func startApplePay(product: Product, delegate: PKPaymentAuthorizationViewControllerDelegate) {
         let merchantIdentifier = Environment().configuration(.AppleMerchantId)
@@ -28,10 +29,11 @@ extension UIViewController {
             self.showAlert(title: "Payment Error", msg: "Wallet empty or does not contain any of the supported card types. Should give user option to open apple wallet to add a card.")
             return
         }
-        
+        // Convert to acutal amount (prime uses currency’s smallest unit)
+        let applePayAmount = convertStripeToNormalCurrency(amount: product.amount, currency: product.currency)
         // Configure the line items on the payment request
         paymentRequest.paymentSummaryItems = [
-            PKPaymentSummaryItem(label: product.name, amount: product.amount as NSDecimalNumber),
+            PKPaymentSummaryItem(label: product.name, amount: applePayAmount),
         ]
         
         // Continued in next step
@@ -59,6 +61,23 @@ extension UIViewController {
                     self.showAlert(title: "There is a problem with your Apple Pay configuration", msg: "Apple pay in production mode failed for unknown reason.")
                 #endif
             #endif
+        }
+    }
+
+    // Stripe (& Prime) expects amounts to be provided in currency's smallest unit.
+    // https://stripe.com/docs/currencies#zero-decimal
+    // https://github.com/stripe/stripe-ios/blob/v15.0.1/Stripe/NSDecimalNumber%2BStripe_Currency.m
+    func convertStripeToNormalCurrency(amount: Decimal, currency: String) -> NSDecimalNumber {
+        let zeroDecimalCountries = [
+            "bif", "clp", "djf", "gnf", "jpy",
+            "kmf", "krw", "mga", "pyg", "rwf",
+            "vnd", "vuv", "xaf", "xof", "xpf"
+        ]
+        let amountInCurrency = NSDecimalNumber(decimal: amount)
+        if zeroDecimalCountries.contains(currency.lowercased()) {
+            return amountInCurrency
+        } else {
+            return amountInCurrency.multiplying(byPowerOf10: -2)
         }
     }
 }

--- a/ostelco-ios-client/Extensions/UIViewController+StartApplePay.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+StartApplePay.swift
@@ -12,18 +12,20 @@ import Siesta
 extension UIViewController {
     func startApplePay(product: Product, delegate: PKPaymentAuthorizationViewControllerDelegate) {
         let merchantIdentifier = Environment().configuration(.AppleMerchantId)
+        // TODO: Consult with Payment Service Provider (Stripe in our case) to determine which country code value to use
+        // https://developer.apple.com/documentation/passkit/pkpaymentrequest/1619246-countrycode
         let paymentRequest = Stripe.paymentRequest(withMerchantIdentifier: merchantIdentifier, country: product.country, currency: product.currency)
-        
+
         if !PKPaymentAuthorizationViewController.canMakePayments() {
             self.showAlert(title: "Payment Error", msg: "Your device does not support apple pay")
             return
         }
-        
+
         if !Stripe.deviceSupportsApplePay() {
             self.showAlert(title: "Payment Error", msg: "You need to setup a card in your wallet, we support the following cards: American Express, Visa, Mastercard, Discover")
             return
         }
-        
+
         if !PKPaymentAuthorizationViewController.canMakePayments() {
             self.showAlert(title: "Payment Error", msg: "Wallet empty or does not contain any of the supported card types. Should give user option to open apple wallet to add a card.")
             return
@@ -33,14 +35,15 @@ extension UIViewController {
         // Configure the line items on the payment request
         paymentRequest.paymentSummaryItems = [
             PKPaymentSummaryItem(label: product.name, amount: applePayAmount),
+            PKPaymentSummaryItem(label: "Red Otter", amount: applePayAmount),
         ]
-        
+
         // Continued in next step
         if Stripe.canSubmitPaymentRequest(paymentRequest) {
             // Setup payment authorization view controller
             let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: paymentRequest)
             paymentAuthorizationViewController!.delegate = delegate
-            
+
             // Present payment authorization view controller
             present(paymentAuthorizationViewController!, animated: true)
         } else {

--- a/ostelco-ios-client/Extensions/UIViewController+StartApplePay.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+StartApplePay.swift
@@ -9,7 +9,6 @@
 import Stripe
 import Siesta
 
-
 extension UIViewController {
     func startApplePay(product: Product, delegate: PKPaymentAuthorizationViewControllerDelegate) {
         let merchantIdentifier = Environment().configuration(.AppleMerchantId)

--- a/ostelco-ios-client/Models/Product.swift
+++ b/ostelco-ios-client/Models/Product.swift
@@ -5,19 +5,32 @@
 //  Created by mac on 3/15/19.
 //  Copyright © 2019 mac. All rights reserved.
 //
+import ostelco_core
 
 public class Product {
     let name: String
+    let label: String
     let amount: Decimal
     let currency: String
     let country: String
     let sku: String
-    
-    init(name: String, amount: Decimal, country: String, currency: String, sku: String) {
+
+    @available(*, deprecated, message: "Construct a Product object from ProdctModel")
+    init(name: String, label: String, amount: Decimal, country: String, currency: String, sku: String) {
         self.name = name
+        self.label = label
         self.amount = amount
         self.country = country
         self.currency = currency
         self.sku = sku
+    }
+
+    init(from: ProductModel, countryCode: String) {
+        name = from.presentation.label
+        label = "Buy \(from.presentation.label) for \(from.presentation.price)"
+        amount = Decimal(from.price.amount)
+        country = countryCode
+        currency = from.price.currency
+        sku = from.sku
     }
 }

--- a/ostelco-ios-client/Models/Product.swift
+++ b/ostelco-ios-client/Models/Product.swift
@@ -26,7 +26,7 @@ public class Product {
     }
 
     init(from: ProductModel, countryCode: String) {
-        name = from.presentation.label
+        name = "\(from.presentation.label) of Data"
         label = "Buy \(from.presentation.label) for \(from.presentation.price)"
         amount = Decimal(from.price.amount)
         country = countryCode

--- a/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
@@ -53,7 +53,14 @@ class BecomeAMemberViewController: UIViewController {
     }
     
     @objc func buyButtonTapped() {
-        let product = Product(name: "membership fee, 1 year", amount: 1.0, country: "SG", currency: "SGD", sku: "123")
+        let product = Product(
+            name: "membership fee, 1 year",
+            label: "membership fee, 1 year for $1",
+            amount: 100.0,
+            country: "SG",
+            currency: "SGD",
+            sku: "123"
+        )
         paymentAuthorized = false
         startApplePay(product: product, delegate: self)
     }

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController2.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController2.swift
@@ -65,10 +65,11 @@ class HomeViewController2: UIViewController {
             self.removeSpinner(spinnerView)
             self.availableProducts = products
             if let error = error {
-                print("error fetching products \(error)")
+                debugPrint("error fetching products \(error)")
             } else if products.isEmpty {
-                print("No products available")
+                debugPrint("No products available")
             }
+            self.availableProducts.forEach {debugPrint($0.name, $0.amount, $0.currency, $0.country, $0.sku)}
             // TODO: check the if the customer is a member already.
             self.hasSubscription = false
         }

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController2.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController2.swift
@@ -152,14 +152,7 @@ class HomeViewController2: UIViewController {
             .onSuccess { entity in
                 DispatchQueue.main.async {
                     if let products: [ProductModel] = entity.typedContent(ifNone: nil) {
-                        let availableProducts: [Product] = products.map {
-                            Product(
-                                name: "Buy \($0.presentation.label) for \($0.presentation.price)",
-                                amount: Decimal($0.price.amount),
-                                country: "SG",
-                                currency: $0.price.currency,
-                                sku: $0.sku)
-                        }
+                        let availableProducts: [Product] = products.map { Product(from: $0, countryCode: "SG") }
                         completionHandler(availableProducts, nil)
                     } else {
                         completionHandler([], nil)


### PR DESCRIPTION
Prime expects amount in currency’s smallest unit. For example, to
charge $10 USD, use an amount value of 1000 (i.e, 1000 cents).