### PR TITLE
Fix for empty eSimActivationCode

### DIFF
--- a/ostelco-ios-client/Models/SimProfile.swift
+++ b/ostelco-ios-client/Models/SimProfile.swift
@@ -14,7 +14,7 @@ enum SimProfileStatus: String, Codable {
 }
 
 struct SimProfile: Codable {
-    let eSimActivationCode: String
+    let eSimActivationCode: String?
     let alias: String
     let iccId: String
     let status: SimProfileStatus

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -55,7 +55,7 @@ class ESIMPendingDownloadViewController: UIViewController {
             .onSuccess { data in
                 if let simProfiles: [SimProfile] = data.typedContent(ifNone: nil) {
                     if let simProfile = simProfiles.first(where: {
-                        $0.eSimActivationCode == self.simProfile?.eSimActivationCode
+                        $0.iccId == self.simProfile?.iccId
                     }) {
                         self.simProfile = simProfile
                         switch simProfile.status {

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -54,6 +54,7 @@ class ESIMPendingDownloadViewController: UIViewController {
         APIManager.sharedInstance.regions.child(countryCode).child("simProfiles").load()
             .onSuccess { data in
                 if let simProfiles: [SimProfile] = data.typedContent(ifNone: nil) {
+                    #warning("Make sure prime returns a valid eSimActivationCode")
                     if let simProfile = simProfiles.first(where: {
                         $0.iccId == self.simProfile?.iccId
                     }) {


### PR DESCRIPTION
A recent change in Prime has made the eSimActivationCode a nullable field.
This is a temporary fix for the crash we are getting while parsing the context