### PR TITLE
Better handling for system-wide location disabling

### DIFF
--- a/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
@@ -105,10 +105,13 @@ class LocationProblemViewController: UIViewController {
         switch status {
         case .restricted:
             self.locationProblem = .restrictedByParentalControls
+            self.listenForChanges()
         case .denied:
             self.locationProblem = .deniedByUser
+            self.listenForChanges()
         case .notDetermined:
             self.locationProblem = .notDetermined
+            self.listenForChanges()
         case .authorizedAlways,
              .authorizedWhenInUse:
             self.checkLocation()

--- a/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
@@ -31,6 +31,24 @@ class LocationProblemViewController: UIViewController {
         
         self.configureForCurrentProblem()
         self.listenForChanges()
+        
+        NotificationCenter.default
+            .addObserver(self,
+                         selector: #selector(applicationEnteredForeground),
+                         name: UIApplication.willEnterForegroundNotification,
+                         object: nil)
+    }
+    
+    @objc private func applicationEnteredForeground() {
+        switch self.locationProblem {
+        case .disabledInSettings?:
+            if LocationController.shared.locationServicesEnabled {
+                LocationController.shared.requestAuthorization()
+            }
+        default:
+            // Other situations should be handled by the permission change callback.
+            break
+        }
     }
     
     private func configureForCurrentProblem() {


### PR DESCRIPTION
This adds handling for returning from the background after enabling location services at the system rather than app level. This also improves handling if the user declines location services for our app once they've enabled them at the system level. 

One unfortunate note: There's no way to kick the user to the root of settings rather than the root of our app's settings without using private API - we may need to consider a slight adjustment to the illustration because of this, since it adds an extra step. cc @oisinzimmermann 