### PR TITLE
Start moving some APIs to `LoggedInAPI` for realsies

### DIFF
--- a/dev-ostelco-ios-clientTests/HeaderGeneratorTests.swift
+++ b/dev-ostelco-ios-clientTests/HeaderGeneratorTests.swift
@@ -68,4 +68,40 @@ class HeaderGeneratorTests: XCTestCase {
             XCTFail("Unexpected error creating headers: \(error)")
         }
     }
+    
+    func testAddingAnAdditionalHeader() {
+        let storage = MockSecureStorage()
+        let testToken = "I'M A TEST TOKEN!"
+        storage.setString(testToken, for: .Auth0Token)
+        
+        do {
+            var headers = try Headers(loggedIn: true, secureStorage: storage)
+            headers.addValue(.testing("TEST"), for: .testing)
+            
+            let headerDict = headers.toStringDict
+            XCTAssertEqual(headerDict.count, 3)
+            XCTAssertEqual(headerDict[HeaderKey.contentType.rawValue], HeaderValue.applicationJSON.toString)
+            XCTAssertEqual(headerDict[HeaderKey.authorization.rawValue], "Bearer \(testToken)")
+            XCTAssertEqual(headerDict[HeaderKey.testing.rawValue], "TEST")
+        } catch {
+            XCTFail("Unexpected error creating headers: \(error)")
+        }
+    }
+    
+    func testReplacingADefaultHeader() {
+        let storage = MockSecureStorage()
+        let testToken = "I'M A TEST TOKEN!"
+        storage.setString(testToken, for: .Auth0Token)
+        
+        do {
+            var headers = try Headers(loggedIn: true, secureStorage: storage)
+            headers.addValue(.testing("TEST"), for: .contentType)
+            let headerDict = headers.toStringDict
+            XCTAssertEqual(headerDict.count, 2)
+            XCTAssertEqual(headerDict[HeaderKey.contentType.rawValue], "TEST")
+            XCTAssertEqual(headerDict[HeaderKey.authorization.rawValue], "Bearer \(testToken)")
+        } catch {
+            XCTFail("Unexpected error creating headers: \(error)")
+        }
+    }
 }

--- a/dev-ostelco-ios-clientTests/Mocks/RegionResponse+Testing.swift
+++ b/dev-ostelco-ios-clientTests/Mocks/RegionResponse+Testing.swift
@@ -1,0 +1,37 @@
+//
+//  RegionResponse+Testing.swift
+//  dev-ostelco-ios-clientTests
+//
+//  Created by Ellen Shapiro on 5/1/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+@testable import ostelco_core
+
+extension RegionResponse {
+    
+    static var testApprovedRegionResponse: RegionResponse {
+        let region = Region(id: "1", name: "ApprovedRegion")
+        return RegionResponse(region: region,
+                              status: .APPROVED,
+                              simProfiles: nil,
+                              kycStatusMap: KYCStatusMap())
+    }
+    
+    static var testPendingRegionResponse: RegionResponse {
+        let region = Region(id: "2", name: "PendingRegion")
+        return RegionResponse(region: region,
+                              status: .PENDING,
+                              simProfiles: nil,
+                              kycStatusMap: KYCStatusMap())
+    }
+    
+    static var testRejectedRegionRepsonse: RegionResponse {
+        let region = Region(id: "3", name: "RejectedRegion")
+        return RegionResponse(region: region,
+                              status: .REJECTED,
+                              simProfiles: nil,
+                              kycStatusMap: KYCStatusMap())
+    }
+}

--- a/dev-ostelco-ios-clientTests/RegionResponseTests.swift
+++ b/dev-ostelco-ios-clientTests/RegionResponseTests.swift
@@ -1,0 +1,127 @@
+//
+//  RegionResponseTests.swift
+//  dev-ostelco-ios-clientTests
+//
+//  Created by Ellen Shapiro on 5/1/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import ostelco_core
+import XCTest
+
+class RegionResponseTests: XCTestCase {
+    
+    func testApprovedIsReturnedWhenAllArePresent() {
+        let regions = [
+            RegionResponse.testRejectedRegionRepsonse,
+            RegionResponse.testPendingRegionResponse,
+            RegionResponse.testApprovedRegionResponse
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "1")
+        XCTAssertEqual(region.region.name, "ApprovedRegion")
+        XCTAssertEqual(region.status, KycStatus.APPROVED)
+    }
+    
+    func testApprovedIsReturnedWhenOnlyApprovedRejectedPresent() {
+        let regions = [
+            RegionResponse.testRejectedRegionRepsonse,
+            RegionResponse.testApprovedRegionResponse
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "1")
+        XCTAssertEqual(region.region.name, "ApprovedRegion")
+        XCTAssertEqual(region.status, KycStatus.APPROVED)
+    }
+    
+    func testApprovedIsReturnedWhenOnlyApprovedPendingPresent() {
+        let regions = [
+            RegionResponse.testPendingRegionResponse,
+            RegionResponse.testApprovedRegionResponse
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "1")
+        XCTAssertEqual(region.region.name, "ApprovedRegion")
+        XCTAssertEqual(region.status, KycStatus.APPROVED)
+    }
+    
+    func testApprovedIsReturnedWhenThatsTheOnlyOption() {
+        let regions = [
+            RegionResponse.testApprovedRegionResponse
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "1")
+        XCTAssertEqual(region.region.name, "ApprovedRegion")
+        XCTAssertEqual(region.status, KycStatus.APPROVED)
+    }
+    
+    func testRejectedIsReturnedWhenPendingAndRejectedPresent() {
+        let regions = [
+            RegionResponse.testRejectedRegionRepsonse,
+            RegionResponse.testPendingRegionResponse,
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "3")
+        XCTAssertEqual(region.region.name, "RejectedRegion")
+        XCTAssertEqual(region.status, KycStatus.REJECTED)
+    }
+    
+    func testRejectedIsReturnedWhenThatsTheOnlyOption() {
+        let regions = [
+            RegionResponse.testRejectedRegionRepsonse,
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "3")
+        XCTAssertEqual(region.region.name, "RejectedRegion")
+        XCTAssertEqual(region.status, KycStatus.REJECTED)
+    }
+    
+    func testPendingIsReturnedWhenThatsTheOnlyOption() {
+        let regions = [
+            RegionResponse.testPendingRegionResponse,
+        ]
+        
+        guard let region = RegionResponse.getRegionFromRegionResponseArray(regions) else {
+            XCTFail("This should return a region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "2")
+        XCTAssertEqual(region.region.name, "PendingRegion")
+        XCTAssertEqual(region.status, KycStatus.PENDING)
+    }
+    
+    func testNilIsReturnedForAnEmptyArray() {
+        XCTAssertNil(RegionResponse.getRegionFromRegionResponseArray([]))
+    }
+}

--- a/dev-ostelco-ios-clientTests/RequestGeneratorTests.swift
+++ b/dev-ostelco-ios-clientTests/RequestGeneratorTests.swift
@@ -1,0 +1,99 @@
+//
+//  RequestGeneratorTests.swift
+//  dev-ostelco-ios-clientTests
+//
+//  Created by Ellen Shapiro on 5/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+import ostelco_core
+import XCTest
+
+class RequestGeneratorTests: XCTestCase {
+    
+    private lazy var baseURL: URL = {
+        guard let url = URL(string: "https://www.test.nl/api") else {
+            fatalError("This should create a URL!")
+        }
+        
+        return url
+    }()
+    
+    private lazy var storage: SecureStorage = {
+        let storage = MockSecureStorage()
+        storage.setString("Testing!", for: .Auth0Token)
+        return storage
+    }()
+    
+    func testBasicInitializationGivesAGetRequest() throws {
+        let request = Request(baseURL: self.baseURL,
+                              path: "test",
+                              loggedIn: false,
+                              secureStorage: self.storage)
+        
+        let urlRequest = try request.toURLRequest()
+        XCTAssertEqual(urlRequest.url?.absoluteString, "https://www.test.nl/api/test")
+        XCTAssertEqual(urlRequest.httpMethod, HTTPMethod.GET.rawValue)
+        XCTAssertNil(urlRequest.httpBody)
+        guard let headers = urlRequest.allHTTPHeaderFields else {
+            XCTFail("Could not access headers!")
+            return
+        }
+        
+        XCTAssertEqual(headers.count, 1)
+        XCTAssertEqual(headers[HeaderKey.contentType.rawValue], HeaderValue.applicationJSON.toString)
+    }
+    
+    func testAddingPutDataToRequestWorks() throws {
+        let data = "I'm a test string!".data(using: .utf8)!
+        var request = Request(baseURL: self.baseURL,
+                              path: "data",
+                              method: .PUT,
+                              loggedIn: true,
+                              secureStorage: self.storage)
+        request.bodyData = data
+        
+        let urlRequest = try request.toURLRequest()
+        XCTAssertEqual(urlRequest.url?.absoluteString, "https://www.test.nl/api/data")
+        XCTAssertEqual(urlRequest.httpMethod, HTTPMethod.PUT.rawValue)
+        
+        guard let bodyData = urlRequest.httpBody else {
+            XCTFail("Body data was not added properly!")
+            return
+        }
+        
+        XCTAssertEqual(bodyData, data)
+        
+        guard let headers = urlRequest.allHTTPHeaderFields else {
+            XCTFail("Could not access headers!")
+            return
+        }
+        
+        XCTAssertEqual(headers.count, 2)
+        XCTAssertEqual(headers[HeaderKey.contentType.rawValue], HeaderValue.applicationJSON.toString)
+        XCTAssertEqual(headers[HeaderKey.authorization.rawValue], "Bearer Testing!")
+    }
+    
+    func testSettingAdditionalHeadersUpdatesHeaderDict() throws {
+        var request = Request(baseURL: self.baseURL,
+                              path: "additional/headers",
+                              loggedIn: true,
+                              secureStorage: self.storage)
+        request.additionalHeaders = [ .contentType: .testing("TEST") ]
+        
+        let urlRequest = try request.toURLRequest()
+        XCTAssertEqual(urlRequest.url?.absoluteString, "https://www.test.nl/api/additional/headers")
+        XCTAssertEqual(urlRequest.httpMethod, HTTPMethod.GET.rawValue)
+        XCTAssertNil(urlRequest.httpBody)
+        
+        guard let headers = urlRequest.allHTTPHeaderFields else {
+            XCTFail("Could not access headers!")
+            return
+        }
+        
+        XCTAssertEqual(headers.count, 2)
+        XCTAssertEqual(headers[HeaderKey.contentType.rawValue], "TEST")
+        XCTAssertEqual(headers[HeaderKey.authorization.rawValue], "Bearer Testing!")
+    }
+}

--- a/ostelco-core/Extensions/String+Static.swift
+++ b/ostelco-core/Extensions/String+Static.swift
@@ -10,6 +10,9 @@ import Foundation
 
 public extension String {
     
+    /// Initializer which is inexplicably not in the stdlib
+    ///
+    /// - Parameter staticString: The static string to use to create a string
     init(staticString: StaticString) {
         self = staticString.withUTF8Buffer {
             String(decoding: $0, as: UTF8.self)

--- a/ostelco-core/Extensions/String+Static.swift
+++ b/ostelco-core/Extensions/String+Static.swift
@@ -1,0 +1,18 @@
+//
+//  String+Static.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public extension String {
+    
+    init(staticString: StaticString) {
+        self = staticString.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+    }
+}

--- a/ostelco-core/Models/EKYCAddress.swift
+++ b/ostelco-core/Models/EKYCAddress.swift
@@ -1,0 +1,24 @@
+//
+//  EKYCAddress.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct EKYCAddress: Codable {
+    public let address: String
+    public let phoneNumber: String
+    
+    public init(street: String,
+                unit: String,
+                city: String,
+                postcode: String,
+                country: String,
+                phone: String = "12345678") {
+        self.phoneNumber = phone
+        self.address = "\(street);;;\(unit);;;\(city);;;\(postcode);;;\(country)"
+    }
+}

--- a/ostelco-core/Models/JSONRequestError.swift
+++ b/ostelco-core/Models/JSONRequestError.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-struct JSONRequestError: Codable {
-    let errorCode: String
-    let httpStatusCode: Int
-    let message: String
+public struct JSONRequestError: Codable {
+    public let errorCode: String
+    public let httpStatusCode: Int
+    public let message: String
     
     enum CodingKeys: String, CodingKey {
         case errorCode

--- a/ostelco-core/Models/Region.swift
+++ b/ostelco-core/Models/Region.swift
@@ -71,4 +71,8 @@ public struct RegionResponse: Codable {
             return regionResponses.last
         }
     }
+    
+    public func getSimProfile() -> SimProfile? {
+        return self.simProfiles?.first
+    }
 }

--- a/ostelco-core/Models/Region.swift
+++ b/ostelco-core/Models/Region.swift
@@ -1,0 +1,32 @@
+//
+//  Region.swift
+//  ostelco-ios-client
+//
+//  Created by mac on 3/28/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+public enum KycStatus: String, Codable {
+    case APPROVED
+    case REJECTED
+    case PENDING
+}
+
+public struct KYCStatusMap: Codable {
+    public let JUMIO: KycStatus?
+    public let MY_INFO: KycStatus?
+    public let NRIC_FIN: KycStatus?
+    public let ADDRESS_AND_PHONE_NUMBER: KycStatus?
+}
+
+public struct Region: Codable {
+    public let id: String
+    public let name: String
+}
+
+public struct RegionResponse: Codable {
+    public let region: Region
+    public let status: KycStatus
+    public let simProfiles: [SimProfile]?
+    public let kycStatusMap: KYCStatusMap
+}

--- a/ostelco-core/Models/Region.swift
+++ b/ostelco-core/Models/Region.swift
@@ -17,11 +17,29 @@ public struct KYCStatusMap: Codable {
     public let MY_INFO: KycStatus?
     public let NRIC_FIN: KycStatus?
     public let ADDRESS_AND_PHONE_NUMBER: KycStatus?
+    
+    /// Testing initializer
+    init(jumio: KycStatus? = nil,
+         myInfo: KycStatus? = nil,
+         nricFin: KycStatus? = nil,
+         addressPhone: KycStatus? = nil) {
+        self.JUMIO = jumio
+        self.MY_INFO = myInfo
+        self.NRIC_FIN = nricFin
+        self.ADDRESS_AND_PHONE_NUMBER = addressPhone
+    }
 }
 
 public struct Region: Codable {
     public let id: String
     public let name: String
+    
+    /// Testing initializer
+    init(id: String,
+         name: String) {
+        self.id = id
+        self.name = name
+    }
 }
 
 public struct RegionResponse: Codable {
@@ -30,33 +48,27 @@ public struct RegionResponse: Codable {
     public let simProfiles: [SimProfile]?
     public let kycStatusMap: KYCStatusMap
     
+    /// Testing initializer
+    init(region: Region,
+         status: KycStatus,
+         simProfiles: [SimProfile]?,
+         kycStatusMap: KYCStatusMap) {
+        self.region = region
+        self.status = status
+        self.simProfiles = simProfiles
+        self.kycStatusMap = kycStatusMap
+    }
+    
     public static func getRegionFromRegionResponseArray(_ regionResponses: [RegionResponse]) -> RegionResponse? {
-        var ret: RegionResponse?
-        
-        var hasRejectedStatus = false
-        var hasApprovedStatus = false
-        
-        for region in regionResponses {
-            switch region.status {
-            case .PENDING:
-                if !hasRejectedStatus && !hasApprovedStatus {
-                    ret = region
-                }
-            case .REJECTED:
-                if !hasApprovedStatus {
-                    ret = region
-                }
-                hasRejectedStatus = true
-            case .APPROVED:
-                ret = region
-                hasApprovedStatus = true
-            }
-            
-            if hasApprovedStatus {
-                break
-            }
+        if let approvedRegion = regionResponses.first(where: { $0.status == .APPROVED }) {
+            // Hooray, at least one region has been approved!
+            return approvedRegion
+        } else if let rejectedRegion = regionResponses.last(where: { $0.status == .REJECTED }) {
+            // Boo, at least one region has been rejected.
+            return rejectedRegion
+        } else {
+            // Return the last response, which is either nil or .PENDING
+            return regionResponses.last
         }
-        
-        return ret
     }
 }

--- a/ostelco-core/Models/Region.swift
+++ b/ostelco-core/Models/Region.swift
@@ -29,4 +29,34 @@ public struct RegionResponse: Codable {
     public let status: KycStatus
     public let simProfiles: [SimProfile]?
     public let kycStatusMap: KYCStatusMap
+    
+    public static func getRegionFromRegionResponseArray(_ regionResponses: [RegionResponse]) -> RegionResponse? {
+        var ret: RegionResponse?
+        
+        var hasRejectedStatus = false
+        var hasApprovedStatus = false
+        
+        for region in regionResponses {
+            switch region.status {
+            case .PENDING:
+                if !hasRejectedStatus && !hasApprovedStatus {
+                    ret = region
+                }
+            case .REJECTED:
+                if !hasApprovedStatus {
+                    ret = region
+                }
+                hasRejectedStatus = true
+            case .APPROVED:
+                ret = region
+                hasApprovedStatus = true
+            }
+            
+            if hasApprovedStatus {
+                break
+            }
+        }
+        
+        return ret
+    }
 }

--- a/ostelco-core/Models/ServerError.swift
+++ b/ostelco-core/Models/ServerError.swift
@@ -1,11 +1,11 @@
 //
-//  PutProfileError.swift
+//  ServerError.swift
 //  ostelco-ios-client
 //
 //  Created by mac on 4/2/19.
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-struct PutProfileError: Codable {
-    let errors: [String]
+public struct ServerError: Codable {
+    public let errors: [String]
 }

--- a/ostelco-core/Models/SimProfile.swift
+++ b/ostelco-core/Models/SimProfile.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-enum SimProfileStatus: String, Codable {
+public enum SimProfileStatus: String, Codable {
     case AVAILABLE_FOR_DOWNLOAD
     case DOWNLOADED
     case INSTALLED
@@ -14,9 +14,9 @@ enum SimProfileStatus: String, Codable {
     case NOT_READY
 }
 
-struct SimProfile: Codable {
-    let eSimActivationCode: String
-    let alias: String
-    let iccId: String
-    let status: SimProfileStatus
+public struct SimProfile: Codable {
+    public let eSimActivationCode: String
+    public let alias: String
+    public let iccId: String
+    public let status: SimProfileStatus
 }

--- a/ostelco-core/Network/APIEndpoint.swift
+++ b/ostelco-core/Network/APIEndpoint.swift
@@ -1,0 +1,64 @@
+//
+//  APIEndpoint.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/1/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+protocol APIEndpoint {
+    var value: String { get }
+}
+
+extension APIEndpoint {
+    
+    func pathByAddingEndpoints(_ endpoints: [APIEndpoint]) -> String {
+        let restOfPath = endpoints
+            .map { $0.value }
+            .joined(separator: "/")
+        
+        return self.value + "/" + restOfPath
+    }
+}
+
+public enum RootEndpoint: String, APIEndpoint {
+    case bundles
+    case context
+    case customer
+    case purchases
+    case products
+    case profile
+    case regions
+    
+    var value: String {
+        return self.rawValue
+    }
+}
+
+public enum RegionEndpoint: APIEndpoint {
+    case jumio
+    case kyc
+    case region(code: String)
+    case profile
+    case simProfiles
+    case scans
+    
+    var value: String {
+        switch self {
+        case .jumio:
+            return "jumio"
+        case .kyc:
+            return "kyc"
+        case .region(let code):
+            return code
+        case .profile:
+            return "profile"
+        case .simProfiles:
+            return "simProfiles"
+        case .scans:
+            return "scans"
+        }
+    }
+}

--- a/ostelco-core/Network/APIEndpoint.swift
+++ b/ostelco-core/Network/APIEndpoint.swift
@@ -38,8 +38,10 @@ public enum RootEndpoint: String, APIEndpoint {
 }
 
 public enum RegionEndpoint: APIEndpoint {
+    case dave
     case jumio
     case kyc
+    case nric(number: String)
     case region(code: String)
     case profile
     case simProfiles
@@ -47,8 +49,13 @@ public enum RegionEndpoint: APIEndpoint {
     
     var value: String {
         switch self {
+        case .dave:
+            // I can't let you do that,
+            return "dave"
         case .jumio:
             return "jumio"
+        case .nric(let number):
+            return number
         case .kyc:
             return "kyc"
         case .region(let code):

--- a/ostelco-core/Network/APIHelper.swift
+++ b/ostelco-core/Network/APIHelper.swift
@@ -10,17 +10,19 @@ import Foundation
 import PromiseKit
 
 /// Reusable helper to handle validation across APIs
-struct APIHelper {
+public struct APIHelper {
     
     /// Errors thrown by the API helper
     ///
     /// - invalidResponseType: The response received was not an HTTP Response. Includes the data returned as a parameter.
     /// - invalidResponseCode: The response received did not have a code between 200-300. Includes the data returned as a parameter.
     /// - dataWasEmpty: The data in the response was empty.
-    enum Error: Swift.Error {
+    /// - errorCameWithoutData: An expected error came without data to back it up
+    public enum Error: Swift.Error {
         case invalidResponseType(data: Data)
         case invalidResponseCode(_ code: Int, data: Data)
         case dataWasEmpty
+        case errorCameWithoutData
     }
     
     /// Validates the data and URLResponse received from NSURLSession

--- a/ostelco-core/Network/APIHelper.swift
+++ b/ostelco-core/Network/APIHelper.swift
@@ -55,4 +55,13 @@ public struct APIHelper {
         
         return data
     }
+    
+    public static func encode<T: Codable>(_ object: T, with encoder: JSONEncoder) -> Promise<Data> {
+        do {
+            let data = try encoder.encode(object)
+            return .value(data)
+        } catch {
+            return Promise(error: error)
+        }
+    }
 }

--- a/ostelco-core/Network/APIHelper.swift
+++ b/ostelco-core/Network/APIHelper.swift
@@ -122,7 +122,7 @@ public struct APIHelper {
                                                      decoder: JSONDecoder,
                                                      dataCanBeEmpty: Bool = true) throws {
         do {
-            _ = try APIHelper.validateResponse(data: data, response: response, dataCanBeEmpty: true)
+            _ = try APIHelper.validateResponse(data: data, response: response, dataCanBeEmpty: dataCanBeEmpty)
         } catch {
             switch error {
             case APIHelper.Error.invalidResponseCode(_, let data):

--- a/ostelco-core/Network/BasicNetwork.swift
+++ b/ostelco-core/Network/BasicNetwork.swift
@@ -1,0 +1,27 @@
+//
+//  BasicNetwork.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+
+open class BasicNetwork {
+    
+    open func performRequest(_ request: Request) -> Promise<(data: Data, response: URLResponse)> {
+        return request.generateRequest()
+            .then {
+                URLSession.shared.dataTask(.promise, with: $0)
+            }
+    }
+    
+    open func performValidatedRequest(_ request: Request) -> Promise<Data> {
+        return self.performRequest(request)
+            .map { data, response in
+                try APIHelper.validateResponse(data: data, response: response)
+            }
+    }
+}

--- a/ostelco-core/Network/BasicNetwork.swift
+++ b/ostelco-core/Network/BasicNetwork.swift
@@ -14,6 +14,8 @@ open class BasicNetwork {
     /// Performs a request and hands back the data and response it gets. Only if a system-level error
     /// occurs will this be piped into an Error.
     ///
+    /// Note: Override this method in a subclass to provide mock data to the other methods.
+    ///
     /// - Parameter request: The request to execute
     /// - Returns: The promise, which when fulfilled, will return the data and the URLResponse received.
     open func performRequest(_ request: Request) -> Promise<(data: Data, response: URLResponse)> {

--- a/ostelco-core/Network/BasicNetwork.swift
+++ b/ostelco-core/Network/BasicNetwork.swift
@@ -11,17 +11,35 @@ import PromiseKit
 
 open class BasicNetwork {
     
+    /// Performs a request and hands back the data and response it gets. Only if a system-level error
+    /// occurs will this be piped into an Error.
+    ///
+    /// - Parameter request: The request to execute
+    /// - Returns: The promise, which when fulfilled, will return the data and the URLResponse received.
     open func performRequest(_ request: Request) -> Promise<(data: Data, response: URLResponse)> {
-        return request.generateRequest()
-            .then {
-                URLSession.shared.dataTask(.promise, with: $0)
-            }
+        let urlRequest: URLRequest
+        do {
+            urlRequest = try request.toURLRequest()
+        } catch {
+            return Promise(error: error)
+        }
+        
+        return URLSession.shared.dataTask(.promise, with: urlRequest)
     }
     
-    open func performValidatedRequest(_ request: Request) -> Promise<Data> {
+    /// Performs a request, then validates that the response is in the expected status code range.
+    /// If the response is not a valid status code or the data is unexpectedly empty an error will be thrown
+    ///
+    /// - Parameters:
+    ///   - request: The request to execute
+    ///   - dataCanBeEmpty: If returned data can be empty. Defaults to false.
+    /// - Returns: The promise, which when fulfilled will return the data received.
+    open func performValidatedRequest(_ request: Request, dataCanBeEmpty: Bool = false) -> Promise<Data> {
         return self.performRequest(request)
             .map { data, response in
-                try APIHelper.validateResponse(data: data, response: response)
+                try APIHelper.validateResponse(data: data,
+                                               response: response,
+                                               dataCanBeEmpty: dataCanBeEmpty)
             }
     }
 }

--- a/ostelco-core/Network/HTTPMethod.swift
+++ b/ostelco-core/Network/HTTPMethod.swift
@@ -1,0 +1,17 @@
+//
+//  HTTPMethod.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public enum HTTPMethod: String {
+    case GET
+    case PATCH
+    case POST
+    case PUT
+    case DELETE
+}

--- a/ostelco-core/Network/Headers.swift
+++ b/ostelco-core/Network/Headers.swift
@@ -12,6 +12,7 @@ import Foundation
 public enum HeaderKey: String {
     case authorization = "Authorization"
     case contentType = "Content-Type"
+    case testing = "Testing"
 }
 
 /// Values to include in headers.
@@ -19,6 +20,7 @@ public enum HeaderKey: String {
 public enum HeaderValue {
     case applicationJSON
     case token(String)
+    case testing(String)
     
     public var toString: String {
         switch self {
@@ -26,6 +28,8 @@ public enum HeaderValue {
             return "application/json"
         case .token(let token):
             return "Bearer \(token)"
+        case .testing(let testString):
+            return testString
         }
     }
 }

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -107,7 +107,7 @@ open class LoggedInAPI: BasicNetwork {
         
         return self.sendObject(address, to: path, method: .PUT)
             .done { data, response in
-
+                try APIHelper.validateAndLookForServerError(data: data, response: response, decoder: self.decoder, dataCanBeEmpty: true)
             }
     }
     

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -47,31 +47,31 @@ open class LoggedInAPI: BasicNetwork {
     
     /// - Returns: A Promise which which when fulfilled will contain the user's bundle models
     public func loadBundles() -> Promise<[BundleModel]> {
-        return self.loadData(from: "bundles")
+        return self.loadData(from: RootEndpoint.bundles.rawValue)
             .map { try self.decoder.decode([BundleModel].self, from: $0) }
     }
     
     /// - Returns: A Promise which when fulfilled will contain the user's purchase models
     public func loadPurchases() -> Promise<[PurchaseModel]> {
-        return self.loadData(from: "purchases")
+        return self.loadData(from: RootEndpoint.purchases.rawValue)
             .map { try self.decoder.decode([PurchaseModel].self, from: $0) }
     }
     
     /// - Returns: A Promise which when fulfilled will contain the user's proile model
     public func loadProfile() -> Promise<ProfileModel> {
-        return self.loadData(from: "profile")
+        return self.loadData(from: RootEndpoint.profile.rawValue)
             .map { try self.decoder.decode(ProfileModel.self, from: $0) }
     }
     
     /// - Returns: A Promise which when fulfilled will contain the user's product models
     public func loadProducts() -> Promise<[ProductModel]> {
-        return self.loadData(from: "products")
+        return self.loadData(from: RootEndpoint.products.rawValue)
             .map { try self.decoder.decode([ProductModel].self, from: $0) }
     }
 
     /// - Returns: A promise which when fulfilled will contain all region responses for this user
     public func loadRegions() -> Promise<[RegionResponse]> {
-        return self.loadData(from: "regions")
+        return self.loadData(from: RootEndpoint.regions.rawValue)
             .map { try self.decoder.decode([RegionResponse].self, from: $0) }
     }
 
@@ -94,20 +94,20 @@ open class LoggedInAPI: BasicNetwork {
     ///
     /// - Parameter endpoint: The endpoint to load data from
     /// - Returns: A promise, which when fulfilled, will contain the loaded data.
-    open func loadData(from endpoint: String) -> Promise<Data> {
+    open func loadData(from path: String) -> Promise<Data> {
         let request = Request(baseURL: self.baseURL,
-                              endpoint: endpoint,
+                              path: path,
                               loggedIn: true,
                               secureStorage: self.secureStorage)
         
         return self.performValidatedRequest(request)
     }
     
-    open func sendObject<T: Codable>(_ object: T, to endpoint: String, method: HTTPMethod) -> Promise<(data: Data, response: URLResponse)> {
+    open func sendObject<T: Codable>(_ object: T, to path: String, method: HTTPMethod) -> Promise<(data: Data, response: URLResponse)> {
         return APIHelper.encode(object, with: self.encoder)
             .map { data -> Request in
                 var request = Request(baseURL: self.baseURL,
-                                      endpoint: endpoint,
+                                      path: path,
                                       method: method,
                                       loggedIn: true,
                                       secureStorage: self.secureStorage)

--- a/ostelco-core/Network/Request.swift
+++ b/ostelco-core/Network/Request.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import PromiseKit
 
 public struct Request {
     
@@ -32,26 +31,22 @@ public struct Request {
     public var additionalHeaders: [HeaderKey: HeaderValue]?
     public var bodyData: Data?
     
-    public func generateRequest() -> Promise<URLRequest> {
+    public func toURLRequest() throws -> URLRequest {
         let url = self.baseURL.appendingPathComponent(self.path)
         var request = URLRequest(url: url)
         request.httpMethod = self.method.rawValue
         
-        do {
-            var headers = try Headers(loggedIn: self.loggedIn, secureStorage: self.secureStorage)
-            
-            if let additional = self.additionalHeaders {
-                additional.forEach { key, value in headers.addValue(value, for: key) }
-            }
-            
-            request.allHTTPHeaderFields = headers.toStringDict
-            if let body = self.bodyData {
-                request.httpBody = body
-            }
-            
-            return .value(request)
-        } catch {
-            return Promise(error: error)
+        var headers = try Headers(loggedIn: self.loggedIn, secureStorage: self.secureStorage)
+        
+        if let additional = self.additionalHeaders {
+            additional.forEach { key, value in headers.addValue(value, for: key) }
         }
+        
+        request.allHTTPHeaderFields = headers.toStringDict
+        if let body = self.bodyData {
+            request.httpBody = body
+        }
+        
+        return request
     }
 }

--- a/ostelco-core/Network/Request.swift
+++ b/ostelco-core/Network/Request.swift
@@ -12,18 +12,18 @@ import PromiseKit
 public struct Request {
     
     public let baseURL: URL
-    public let endpoint: String
+    public let path: String
     public let loggedIn: Bool
     public let secureStorage: SecureStorage
     public let method: HTTPMethod
     
     public init(baseURL: URL,
-                endpoint: String,
+                path: String,
                 method: HTTPMethod = .GET,
                 loggedIn: Bool,
                 secureStorage: SecureStorage) {
         self.baseURL = baseURL
-        self.endpoint = endpoint
+        self.path = path
         self.method = method
         self.loggedIn = loggedIn
         self.secureStorage = secureStorage
@@ -33,7 +33,7 @@ public struct Request {
     public var bodyData: Data?
     
     public func generateRequest() -> Promise<URLRequest> {
-        let url = self.baseURL.appendingPathComponent(endpoint)
+        let url = self.baseURL.appendingPathComponent(self.path)
         var request = URLRequest(url: url)
         request.httpMethod = self.method.rawValue
         

--- a/ostelco-core/Network/Request.swift
+++ b/ostelco-core/Network/Request.swift
@@ -1,0 +1,57 @@
+//
+//  RequestBuilder.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+
+public struct Request {
+    
+    public let baseURL: URL
+    public let endpoint: String
+    public let loggedIn: Bool
+    public let secureStorage: SecureStorage
+    public let method: HTTPMethod
+    
+    public init(baseURL: URL,
+                endpoint: String,
+                method: HTTPMethod = .GET,
+                loggedIn: Bool,
+                secureStorage: SecureStorage) {
+        self.baseURL = baseURL
+        self.endpoint = endpoint
+        self.method = method
+        self.loggedIn = loggedIn
+        self.secureStorage = secureStorage
+    }
+    
+    public var additionalHeaders: [HeaderKey: HeaderValue]?
+    public var bodyData: Data?
+    
+    public func generateRequest() -> Promise<URLRequest> {
+        let url = self.baseURL.appendingPathComponent(endpoint)
+        var request = URLRequest(url: url)
+        request.httpMethod = self.method.rawValue
+        
+        do {
+            var headers = try Headers(loggedIn: self.loggedIn, secureStorage: self.secureStorage)
+            
+            if let additional = self.additionalHeaders {
+                additional.forEach { key, value in headers.addValue(value, for: key) }
+            }
+            
+            request.allHTTPHeaderFields = headers.toStringDict
+            if let body = self.bodyData {
+                request.httpBody = body
+            }
+            
+            return .value(request)
+        } catch {
+            return Promise(error: error)
+        }
+    }
+}

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		9B8215832279DF8700DC6B64 /* SimProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF85224D1E020022A2B8 /* SimProfile.swift */; };
 		9B8215852279F5E000DC6B64 /* RegionResponse+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */; };
 		9B8215872279F7FA00DC6B64 /* RegionResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */; };
+		9B8215892279FDB000DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
+		9B82158A2279FDCC00DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -459,6 +461,7 @@
 		9B82157C2279B98000DC6B64 /* MockSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureStorage.swift; sourceTree = "<group>"; };
 		9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RegionResponse+Testing.swift"; sourceTree = "<group>"; };
 		9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionResponseTests.swift; sourceTree = "<group>"; };
+		9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialSecureStorage.swift; sourceTree = "<group>"; };
 		9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ostelco_core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B851ABD225E29BE0076ABF3 /* ostelco_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ostelco_core.h; sourceTree = "<group>"; };
 		9B851ABE225E29BE0076ABF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -724,6 +727,7 @@
 				04834D7D2237D53700A01500 /* UserManager.swift */,
 				04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */,
 				C2D2EAE822785C0C00010586 /* AppErrors.swift */,
+				9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1771,6 +1775,7 @@
 				9BE2D44A225B5E9600B51999 /* TabBarController.swift in Sources */,
 				048533A0223C1882007C89F4 /* Product.swift in Sources */,
 				04834D3C222EC7DC00A01500 /* UIViewController+DismissKeyboard.swift in Sources */,
+				9B8215892279FDB000DC6B64 /* CredentialSecureStorage.swift in Sources */,
 				C2C3EAD42270B43200585FA4 /* PurchaseRecord.swift in Sources */,
 				04834D7E2237D53700A01500 /* UserManager.swift in Sources */,
 				042928EF223D083A00806438 /* SelectIdentityVerificationMethodViewController.swift in Sources */,
@@ -1921,6 +1926,7 @@
 				9BE2D44B225B5E9600B51999 /* TabBarController.swift in Sources */,
 				04EC5AE9218873C0000C2EC3 /* Environment.swift in Sources */,
 				041216AA222817EC00455278 /* ChooseCountryOnBoardingViewController.swift in Sources */,
+				9B82158A2279FDCC00DC6B64 /* CredentialSecureStorage.swift in Sources */,
 				C2C3EAD52270B43200585FA4 /* PurchaseRecord.swift in Sources */,
 				04834D7C2237D2CB00A01500 /* JWT+EmailClaim.swift in Sources */,
 				9BC465462271DC98001951BF /* OhNoViewController.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		9B82157D2279B98000DC6B64 /* MockSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82157C2279B98000DC6B64 /* MockSecureStorage.swift */; };
 		9B8215822279DF6900DC6B64 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF82224D1DAE0022A2B8 /* Region.swift */; };
 		9B8215832279DF8700DC6B64 /* SimProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF85224D1E020022A2B8 /* SimProfile.swift */; };
+		9B8215852279F5E000DC6B64 /* RegionResponse+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */; };
+		9B8215872279F7FA00DC6B64 /* RegionResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -455,6 +457,8 @@
 		9B8215752279B0F800DC6B64 /* Headers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Headers.swift; sourceTree = "<group>"; };
 		9B8215792279B92F00DC6B64 /* HeaderGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderGeneratorTests.swift; sourceTree = "<group>"; };
 		9B82157C2279B98000DC6B64 /* MockSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureStorage.swift; sourceTree = "<group>"; };
+		9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RegionResponse+Testing.swift"; sourceTree = "<group>"; };
+		9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionResponseTests.swift; sourceTree = "<group>"; };
 		9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ostelco_core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B851ABD225E29BE0076ABF3 /* ostelco_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ostelco_core.h; sourceTree = "<group>"; };
 		9B851ABE225E29BE0076ABF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -768,6 +772,7 @@
 			isa = PBXGroup;
 			children = (
 				9B82157C2279B98000DC6B64 /* MockSecureStorage.swift */,
+				9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -980,6 +985,7 @@
 				9BBF70462265D45700E4B9B4 /* MyInfoTests.swift */,
 				9B3FA95422649BD70001641A /* KeychainTests.swift */,
 				9B8215792279B92F00DC6B64 /* HeaderGeneratorTests.swift */,
+				9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */,
 			);
 			path = "dev-ostelco-ios-clientTests";
 			sourceTree = "<group>";
@@ -1828,6 +1834,8 @@
 			files = (
 				9B82157A2279B92F00DC6B64 /* HeaderGeneratorTests.swift in Sources */,
 				9BE2D45A225B625500B51999 /* EnumHelperTests.swift in Sources */,
+				9B8215872279F7FA00DC6B64 /* RegionResponseTests.swift in Sources */,
+				9B8215852279F5E000DC6B64 /* RegionResponse+Testing.swift in Sources */,
 				C2C3EAD62270B43200585FA4 /* PurchaseRecord.swift in Sources */,
 				9BBF704B2265DAC300E4B9B4 /* MyInfoTests.swift in Sources */,
 				9B3FA95522649BD70001641A /* KeychainTests.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		9B821592227AD9EA00DC6B64 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */; };
 		9B821594227ADA1000DC6B64 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821593227ADA1000DC6B64 /* Request.swift */; };
 		9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821595227ADCE000DC6B64 /* BasicNetwork.swift */; };
+		9B821598227AEE1400DC6B64 /* RequestGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821597227AEE1400DC6B64 /* RequestGeneratorTests.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -472,6 +473,7 @@
 		9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		9B821593227ADA1000DC6B64 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		9B821595227ADCE000DC6B64 /* BasicNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicNetwork.swift; sourceTree = "<group>"; };
+		9B821597227AEE1400DC6B64 /* RequestGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestGeneratorTests.swift; sourceTree = "<group>"; };
 		9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ostelco_core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B851ABD225E29BE0076ABF3 /* ostelco_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ostelco_core.h; sourceTree = "<group>"; };
 		9B851ABE225E29BE0076ABF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1005,6 +1007,7 @@
 				9B3FA95422649BD70001641A /* KeychainTests.swift */,
 				9B8215792279B92F00DC6B64 /* HeaderGeneratorTests.swift */,
 				9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */,
+				9B821597227AEE1400DC6B64 /* RequestGeneratorTests.swift */,
 			);
 			path = "dev-ostelco-ios-clientTests";
 			sourceTree = "<group>";
@@ -1857,6 +1860,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B821598227AEE1400DC6B64 /* RequestGeneratorTests.swift in Sources */,
 				9B82157A2279B92F00DC6B64 /* HeaderGeneratorTests.swift in Sources */,
 				9BE2D45A225B625500B51999 /* EnumHelperTests.swift in Sources */,
 				9B8215872279F7FA00DC6B64 /* RegionResponseTests.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		9B8215872279F7FA00DC6B64 /* RegionResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */; };
 		9B8215892279FDB000DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
 		9B82158A2279FDCC00DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
+		9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -462,6 +463,7 @@
 		9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RegionResponse+Testing.swift"; sourceTree = "<group>"; };
 		9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionResponseTests.swift; sourceTree = "<group>"; };
 		9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialSecureStorage.swift; sourceTree = "<group>"; };
+		9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCAddress.swift; sourceTree = "<group>"; };
 		9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ostelco_core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B851ABD225E29BE0076ABF3 /* ostelco_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ostelco_core.h; sourceTree = "<group>"; };
 		9B851ABE225E29BE0076ABF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -854,6 +856,7 @@
 			children = (
 				0448819D217B4E4E00F59758 /* BundleModel.swift */,
 				043E711D223AF61600E01993 /* Country.swift */,
+				9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
 				044881A7217BA32B00F59758 /* PurchaseModel.swift */,
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
@@ -1810,6 +1813,7 @@
 				9B851AE1225E33350076ABF3 /* RemainingDataViewController.swift in Sources */,
 				9B9B324A225E3D3900227EA3 /* ProductModel.swift in Sources */,
 				9BBF70582265EE4F00E4B9B4 /* LocatableCell.swift in Sources */,
+				9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */,
 				9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */,
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
 				9B9B324B225E3D3E00227EA3 /* ProfileModel.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		9B8215872279F7FA00DC6B64 /* RegionResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */; };
 		9B8215892279FDB000DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
 		9B82158A2279FDCC00DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
+		9B82158C227A2F4100DC6B64 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82158B227A2F4100DC6B64 /* APIEndpoint.swift */; };
 		9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */; };
 		9B821592227AD9EA00DC6B64 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */; };
 		9B821594227ADA1000DC6B64 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821593227ADA1000DC6B64 /* Request.swift */; };
@@ -466,6 +467,7 @@
 		9B8215842279F5E000DC6B64 /* RegionResponse+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RegionResponse+Testing.swift"; sourceTree = "<group>"; };
 		9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionResponseTests.swift; sourceTree = "<group>"; };
 		9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialSecureStorage.swift; sourceTree = "<group>"; };
+		9B82158B227A2F4100DC6B64 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
 		9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCAddress.swift; sourceTree = "<group>"; };
 		9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		9B821593227ADA1000DC6B64 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 		9B851ADE225E33010076ABF3 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				9B82158B227A2F4100DC6B64 /* APIEndpoint.swift */,
 				9B9B324D225E411700227EA3 /* APIHelper.swift */,
 				9B8215752279B0F800DC6B64 /* Headers.swift */,
 				9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */,
@@ -1808,6 +1811,7 @@
 				9BBF707A22675C3900E4B9B4 /* Array+FancyAppend.swift in Sources */,
 				9B8215822279DF6900DC6B64 /* Region.swift in Sources */,
 				9B851AE4225E33620076ABF3 /* NibLoadable.swift in Sources */,
+				9B82158C227A2F4100DC6B64 /* APIEndpoint.swift in Sources */,
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
 				9B9B3243225E3B7B00227EA3 /* LoggedInAPI.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -156,6 +156,9 @@
 		9B8215892279FDB000DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
 		9B82158A2279FDCC00DC6B64 /* CredentialSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */; };
 		9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */; };
+		9B821592227AD9EA00DC6B64 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */; };
+		9B821594227ADA1000DC6B64 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821593227ADA1000DC6B64 /* Request.swift */; };
+		9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821595227ADCE000DC6B64 /* BasicNetwork.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -464,6 +467,9 @@
 		9B8215862279F7FA00DC6B64 /* RegionResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionResponseTests.swift; sourceTree = "<group>"; };
 		9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialSecureStorage.swift; sourceTree = "<group>"; };
 		9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCAddress.swift; sourceTree = "<group>"; };
+		9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		9B821593227ADA1000DC6B64 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		9B821595227ADCE000DC6B64 /* BasicNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicNetwork.swift; sourceTree = "<group>"; };
 		9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ostelco_core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B851ABD225E29BE0076ABF3 /* ostelco_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ostelco_core.h; sourceTree = "<group>"; };
 		9B851ABE225E29BE0076ABF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -812,7 +818,10 @@
 			children = (
 				9B9B324D225E411700227EA3 /* APIHelper.swift */,
 				9B8215752279B0F800DC6B64 /* Headers.swift */,
+				9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */,
 				9B9B3242225E3B7B00227EA3 /* LoggedInAPI.swift */,
+				9B821593227ADA1000DC6B64 /* Request.swift */,
+				9B821595227ADCE000DC6B64 /* BasicNetwork.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1802,6 +1811,7 @@
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
 				9B9B3243225E3B7B00227EA3 /* LoggedInAPI.swift in Sources */,
+				9B821594227ADA1000DC6B64 /* Request.swift in Sources */,
 				9B560A9C2273289D004473E1 /* PageControllerDataSource.swift in Sources */,
 				9BBF7069226613C400E4B9B4 /* GenericDataSource.swift in Sources */,
 				9BC4653A2271AD5A001951BF /* LocationProblem.swift in Sources */,
@@ -1809,6 +1819,7 @@
 				9B851ADC225E2A240076ABF3 /* KeychainWrapper.swift in Sources */,
 				9BBF70572265EE4F00E4B9B4 /* Identifiable.swift in Sources */,
 				9B9B3250225E423A00227EA3 /* Collection+Empty.swift in Sources */,
+				9B821592227AD9EA00DC6B64 /* HTTPMethod.swift in Sources */,
 				9B9B324E225E411700227EA3 /* APIHelper.swift in Sources */,
 				9B851AE1225E33350076ABF3 /* RemainingDataViewController.swift in Sources */,
 				9B9B324A225E3D3900227EA3 /* ProductModel.swift in Sources */,
@@ -1816,6 +1827,7 @@
 				9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */,
 				9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */,
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
+				9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */,
 				9B9B324B225E3D3E00227EA3 /* ProfileModel.swift in Sources */,
 				9B8215762279B0F800DC6B64 /* Headers.swift in Sources */,
 				9B8215832279DF8700DC6B64 /* SimProfile.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		9B821594227ADA1000DC6B64 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821593227ADA1000DC6B64 /* Request.swift */; };
 		9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821595227ADCE000DC6B64 /* BasicNetwork.swift */; };
 		9B821598227AEE1400DC6B64 /* RequestGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821597227AEE1400DC6B64 /* RequestGeneratorTests.swift */; };
+		9B82159B227B225400DC6B64 /* String+Static.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82159A227B225400DC6B64 /* String+Static.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -474,6 +475,7 @@
 		9B821593227ADA1000DC6B64 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		9B821595227ADCE000DC6B64 /* BasicNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicNetwork.swift; sourceTree = "<group>"; };
 		9B821597227AEE1400DC6B64 /* RequestGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestGeneratorTests.swift; sourceTree = "<group>"; };
+		9B82159A227B225400DC6B64 /* String+Static.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Static.swift"; sourceTree = "<group>"; };
 		9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ostelco_core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B851ABD225E29BE0076ABF3 /* ostelco_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ostelco_core.h; sourceTree = "<group>"; };
 		9B851ABE225E29BE0076ABF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -851,6 +853,7 @@
 				9B851AE3225E33620076ABF3 /* NibLoadable.swift */,
 				9B9B324F225E423A00227EA3 /* Collection+Empty.swift */,
 				9BBF706A2266162F00E4B9B4 /* UITableView+Generics.swift */,
+				9B82159A227B225400DC6B64 /* String+Static.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1832,6 +1835,7 @@
 				9B9B324A225E3D3900227EA3 /* ProductModel.swift in Sources */,
 				9BBF70582265EE4F00E4B9B4 /* LocatableCell.swift in Sources */,
 				9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */,
+				9B82159B227B225400DC6B64 /* String+Static.swift in Sources */,
 				9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */,
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
 				9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -98,10 +98,6 @@
 		048C78822191ED430041F135 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04488172217924B800F59758 /* Assets.xcassets */; };
 		048C78D92191F46D0041F135 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 048C78D82191F46D0041F135 /* LaunchScreen.storyboard */; };
 		048C78DA2191F46D0041F135 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 048C78D82191F46D0041F135 /* LaunchScreen.storyboard */; };
-		0493B80C2252BE0900989F40 /* JSONRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0493B80B2252BE0900989F40 /* JSONRequestError.swift */; };
-		0493B80D2252BE0900989F40 /* JSONRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0493B80B2252BE0900989F40 /* JSONRequestError.swift */; };
-		0493B80F2253943900989F40 /* PutProfileError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0493B80E2253943900989F40 /* PutProfileError.swift */; };
-		0493B8102253943900989F40 /* PutProfileError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0493B80E2253943900989F40 /* PutProfileError.swift */; };
 		04BA349A222587DD000359C4 /* Splash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 04BA3499222587DD000359C4 /* Splash.storyboard */; };
 		04BA349C222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
 		04BA349D222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
@@ -161,7 +157,9 @@
 		9B821594227ADA1000DC6B64 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821593227ADA1000DC6B64 /* Request.swift */; };
 		9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821595227ADCE000DC6B64 /* BasicNetwork.swift */; };
 		9B821598227AEE1400DC6B64 /* RequestGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B821597227AEE1400DC6B64 /* RequestGeneratorTests.swift */; };
+		9B821599227AFC4700DC6B64 /* ServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0493B80E2253943900989F40 /* ServerError.swift */; };
 		9B82159B227B225400DC6B64 /* String+Static.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82159A227B225400DC6B64 /* String+Static.swift */; };
+		9B82159C227B254B00DC6B64 /* JSONRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0493B80B2252BE0900989F40 /* JSONRequestError.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -410,7 +408,7 @@
 		048C787B2191C9660041F135 /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		048C78D82191F46D0041F135 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0493B80B2252BE0900989F40 /* JSONRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRequestError.swift; sourceTree = "<group>"; };
-		0493B80E2253943900989F40 /* PutProfileError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutProfileError.swift; sourceTree = "<group>"; };
+		0493B80E2253943900989F40 /* ServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerError.swift; sourceTree = "<group>"; };
 		04BA3499222587DD000359C4 /* Splash.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Splash.storyboard; sourceTree = "<group>"; };
 		04BA349B222587F6000359C4 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		04BA349F2226B8D9000359C4 /* EnableNotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableNotificationsViewController.swift; sourceTree = "<group>"; };
@@ -736,12 +734,12 @@
 			children = (
 				04834D6E2237ACFF00A01500 /* APIManager.swift */,
 				04488191217938A300F59758 /* Auth.swift */,
+				C2D2EAE822785C0C00010586 /* AppErrors.swift */,
+				9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */,
 				043E711A223AF3CF00E01993 /* OnBoardingManager.swift */,
 				04488198217B42C200F59758 /* OstelcoAPI.swift */,
 				04834D7D2237D53700A01500 /* UserManager.swift */,
 				04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */,
-				C2D2EAE822785C0C00010586 /* AppErrors.swift */,
-				9B8215882279FDB000DC6B64 /* CredentialSecureStorage.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -751,13 +749,11 @@
 			children = (
 				0437CF88224D3B380022A2B8 /* Context.swift */,
 				04834D712237B11800A01500 /* CustomerModel.swift */,
-				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
 				9BC4653B2271ADA9001951BF /* LocationProblem+UserFacingCopy.swift */,
 				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
 				9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */,
 				0485339F223C1882007C89F4 /* Product.swift */,
 				C2C3EAD32270B43200585FA4 /* PurchaseRecord.swift */,
-				0493B80E2253943900989F40 /* PutProfileError.swift */,
 				0437CF7F224D08660022A2B8 /* Scan.swift */,
 				9B17457F227722C200CF321B /* ValidationState.swift */,
 			);
@@ -824,11 +820,11 @@
 			children = (
 				9B82158B227A2F4100DC6B64 /* APIEndpoint.swift */,
 				9B9B324D225E411700227EA3 /* APIHelper.swift */,
+				9B821595227ADCE000DC6B64 /* BasicNetwork.swift */,
 				9B8215752279B0F800DC6B64 /* Headers.swift */,
 				9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */,
 				9B9B3242225E3B7B00227EA3 /* LoggedInAPI.swift */,
 				9B821593227ADA1000DC6B64 /* Request.swift */,
-				9B821595227ADCE000DC6B64 /* BasicNetwork.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -874,11 +870,13 @@
 				0448819D217B4E4E00F59758 /* BundleModel.swift */,
 				043E711D223AF61600E01993 /* Country.swift */,
 				9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */,
+				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
 				044881A7217BA32B00F59758 /* PurchaseModel.swift */,
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
 				044881A1217B896800F59758 /* ProfileModel.swift */,
 				0437CF82224D1DAE0022A2B8 /* Region.swift */,
+				0493B80E2253943900989F40 /* ServerError.swift */,
 				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
 			);
 			path = Models;
@@ -1729,7 +1727,6 @@
 				0437CF89224D3B380022A2B8 /* Context.swift in Sources */,
 				043E711B223AF3CF00E01993 /* OnBoardingManager.swift in Sources */,
 				9BBF7075226751A200E4B9B4 /* Netverify+Ostelco.swift in Sources */,
-				0493B80C2252BE0900989F40 /* JSONRequestError.swift in Sources */,
 				04834D3F222EC92C00A01500 /* UIViewController+UIActivityIndicator.swift in Sources */,
 				9B17457A2276F6E900CF321B /* AddressEditDataSource.swift in Sources */,
 				04488199217B42C200F59758 /* OstelcoAPI.swift in Sources */,
@@ -1744,7 +1741,6 @@
 				047F29032224460B00FC6A8F /* LoginViewController.swift in Sources */,
 				9BBF70712267423A00E4B9B4 /* UIApplication+TypedDelegate.swift in Sources */,
 				0437CF80224D08660022A2B8 /* Scan.swift in Sources */,
-				0493B80F2253943900989F40 /* PutProfileError.swift in Sources */,
 				043E7124223B00F400E01993 /* UITableViewController+CountryListActionSheet.swift in Sources */,
 				042928F2223D0BE700806438 /* NRCIVerifyViewController.swift in Sources */,
 				041216AF22281CE000455278 /* AllowLocationAccessViewController.swift in Sources */,
@@ -1818,6 +1814,7 @@
 				9B8215822279DF6900DC6B64 /* Region.swift in Sources */,
 				9B851AE4225E33620076ABF3 /* NibLoadable.swift in Sources */,
 				9B82158C227A2F4100DC6B64 /* APIEndpoint.swift in Sources */,
+				9B821599227AFC4700DC6B64 /* ServerError.swift in Sources */,
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
 				9B9B3243225E3B7B00227EA3 /* LoggedInAPI.swift in Sources */,
@@ -1835,6 +1832,7 @@
 				9B9B324A225E3D3900227EA3 /* ProductModel.swift in Sources */,
 				9BBF70582265EE4F00E4B9B4 /* LocatableCell.swift in Sources */,
 				9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */,
+				9B82159C227B254B00DC6B64 /* JSONRequestError.swift in Sources */,
 				9B82159B227B225400DC6B64 /* String+Static.swift in Sources */,
 				9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */,
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
@@ -1883,7 +1881,6 @@
 				043E7122223AFFA800E01993 /* CountriesTableViewController.swift in Sources */,
 				0437CF8A224D3B380022A2B8 /* Context.swift in Sources */,
 				042928F0223D083A00806438 /* SelectIdentityVerificationMethodViewController.swift in Sources */,
-				0493B80D2252BE0900989F40 /* JSONRequestError.swift in Sources */,
 				9BE2D452225B609100B51999 /* TopUpButton.swift in Sources */,
 				04BA349D222587F6000359C4 /* SplashViewController.swift in Sources */,
 				04834D49222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift in Sources */,
@@ -1902,7 +1899,6 @@
 				043E711C223AF3CF00E01993 /* OnBoardingManager.swift in Sources */,
 				0437CF81224D08660022A2B8 /* Scan.swift in Sources */,
 				04834D66223020DA00A01500 /* UIButton+Border.swift in Sources */,
-				0493B8102253943900989F40 /* PutProfileError.swift in Sources */,
 				0412168D2226BBBA00455278 /* GetStartedViewController.swift in Sources */,
 				9BE2D45F225B651600B51999 /* UIApplicaiton+Testing.swift in Sources */,
 				041216902226BEB100455278 /* TheLegalStuffViewController.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -29,10 +29,6 @@
 		042928F9223D4D8800806438 /* SignUpCompletedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042928F7223D4D8800806438 /* SignUpCompletedViewController.swift */; };
 		0437CF80224D08660022A2B8 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
 		0437CF81224D08660022A2B8 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
-		0437CF83224D1DAE0022A2B8 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF82224D1DAE0022A2B8 /* Region.swift */; };
-		0437CF84224D1DAE0022A2B8 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF82224D1DAE0022A2B8 /* Region.swift */; };
-		0437CF86224D1E020022A2B8 /* SimProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF85224D1E020022A2B8 /* SimProfile.swift */; };
-		0437CF87224D1E020022A2B8 /* SimProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF85224D1E020022A2B8 /* SimProfile.swift */; };
 		0437CF89224D3B380022A2B8 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF88224D3B380022A2B8 /* Context.swift */; };
 		0437CF8A224D3B380022A2B8 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF88224D3B380022A2B8 /* Context.swift */; };
 		043E710E2239F17200E01993 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E710D2239F17200E01993 /* main.swift */; };
@@ -153,6 +149,8 @@
 		9B8215762279B0F800DC6B64 /* Headers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215752279B0F800DC6B64 /* Headers.swift */; };
 		9B82157A2279B92F00DC6B64 /* HeaderGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8215792279B92F00DC6B64 /* HeaderGeneratorTests.swift */; };
 		9B82157D2279B98000DC6B64 /* MockSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82157C2279B98000DC6B64 /* MockSecureStorage.swift */; };
+		9B8215822279DF6900DC6B64 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF82224D1DAE0022A2B8 /* Region.swift */; };
+		9B8215832279DF8700DC6B64 /* SimProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF85224D1E020022A2B8 /* SimProfile.swift */; };
 		9B851ACD225E29BE0076ABF3 /* ostelco_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B851ABD225E29BE0076ABF3 /* ostelco_core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B851AD0225E29BE0076ABF3 /* ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; };
 		9B851AD1225E29BE0076ABF3 /* ostelco_core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B851ABB225E29BE0076ABF3 /* ostelco_core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -738,9 +736,7 @@
 				0485339F223C1882007C89F4 /* Product.swift */,
 				C2C3EAD32270B43200585FA4 /* PurchaseRecord.swift */,
 				0493B80E2253943900989F40 /* PutProfileError.swift */,
-				0437CF82224D1DAE0022A2B8 /* Region.swift */,
 				0437CF7F224D08660022A2B8 /* Scan.swift */,
-				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
 				9B17457F227722C200CF321B /* ValidationState.swift */,
 			);
 			path = Models;
@@ -853,6 +849,8 @@
 				044881A7217BA32B00F59758 /* PurchaseModel.swift */,
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
 				044881A1217B896800F59758 /* ProfileModel.swift */,
+				0437CF82224D1DAE0022A2B8 /* Region.swift */,
+				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1757,13 +1755,11 @@
 				047B2798223BC38D00EE134B /* UIViewController+ActionSheet.swift in Sources */,
 				9B920F5F225B8AF0001EF9CD /* VerifyIdentityOnBoardingViewController.swift in Sources */,
 				9B9B324C225E3D4400227EA3 /* CustomerModel.swift in Sources */,
-				0437CF83224D1DAE0022A2B8 /* Region.swift in Sources */,
 				C2A89CF02261554000100E44 /* UIViewController+Notification.swift in Sources */,
 				9B174580227722C200CF321B /* ValidationState.swift in Sources */,
 				9BE2D463225B696400B51999 /* StoryboardLoadable.swift in Sources */,
 				9B6E3A20227080CE0063EBAA /* LocationProblemViewController.swift in Sources */,
 				9BE2D454225B60BE00B51999 /* UIImage+Coloring.swift in Sources */,
-				0437CF86224D1E020022A2B8 /* SimProfile.swift in Sources */,
 				04834D4D222FB9EE00A01500 /* ESIMOnBoardingViewController.swift in Sources */,
 				C2BC662122733C75008BBC4E /* ApplePayViewController.swift in Sources */,
 				9BE2D44A225B5E9600B51999 /* TabBarController.swift in Sources */,
@@ -1787,6 +1783,7 @@
 				9B3FA95822649DD30001641A /* SecureStorage.swift in Sources */,
 				9BBF706B2266162F00E4B9B4 /* UITableView+Generics.swift in Sources */,
 				9BBF707A22675C3900E4B9B4 /* Array+FancyAppend.swift in Sources */,
+				9B8215822279DF6900DC6B64 /* Region.swift in Sources */,
 				9B851AE4225E33620076ABF3 /* NibLoadable.swift in Sources */,
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
@@ -1806,6 +1803,7 @@
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
 				9B9B324B225E3D3E00227EA3 /* ProfileModel.swift in Sources */,
 				9B8215762279B0F800DC6B64 /* Headers.swift in Sources */,
+				9B8215832279DF8700DC6B64 /* SimProfile.swift in Sources */,
 				9BC465382270BAE9001951BF /* CLGeocoder+PromiseKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1905,13 +1903,11 @@
 				043E71122239F1D300E01993 /* FLApplication.swift in Sources */,
 				C23CFC8C227610E5000117A8 /* ApplePayDelegate.swift in Sources */,
 				C2A89CF12261554000100E44 /* UIViewController+Notification.swift in Sources */,
-				0437CF84224D1DAE0022A2B8 /* Region.swift in Sources */,
 				9BBF70612265F2FD00E4B9B4 /* CountryDataSource.swift in Sources */,
 				041216B022281CE000455278 /* AllowLocationAccessViewController.swift in Sources */,
 				9BBF704A2265D51600E4B9B4 /* MyInfoDetails+Testing.swift in Sources */,
 				9B174581227722C200CF321B /* ValidationState.swift in Sources */,
 				C25A95972226FF7F005958EC /* MyInfoSummaryViewController.swift in Sources */,
-				0437CF87224D1E020022A2B8 /* SimProfile.swift in Sources */,
 				C224D921225FADFC00AE10FD /* MyInfoDetails.swift in Sources */,
 				C2BC662222733C75008BBC4E /* ApplePayViewController.swift in Sources */,
 				9BE2D44B225B5E9600B51999 /* TabBarController.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/xcshareddata/xcschemes/dev-ostelco-ios-client.xcscheme
+++ b/ostelco-ios-client.xcodeproj/xcshareddata/xcschemes/dev-ostelco-ios-client.xcscheme
@@ -68,7 +68,32 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9BB6A792226F6513000D5E13"
+            BuildableName = "OstelcoStyles.framework"
+            BlueprintName = "OstelcoStyles"
+            ReferencedContainer = "container:ostelco-ios-client.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C29802A82181EDA800FBC5C3"
+            BuildableName = "Oya-Development.app"
+            BlueprintName = "dev-ostelco-ios-client"
+            ReferencedContainer = "container:ostelco-ios-client.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9B851ABA225E29BE0076ABF3"
+            BuildableName = "ostelco_core.framework"
+            BlueprintName = "ostelco-core"
+            ReferencedContainer = "container:ostelco-ios-client.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ostelco-ios-client/Extensions/UIViewController+Alerts.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+Alerts.swift
@@ -34,7 +34,7 @@ extension UIViewController {
     
     func showGenericError(error: Error) {
         let title = "Error"
-        let message = "Client crashed: \(error)"
+        let message = "An error has occurred:\n\n\(error)"
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         present(alert, animated: true, completion: nil)
     }

--- a/ostelco-ios-client/Models/Context.swift
+++ b/ostelco-ios-client/Models/Context.swift
@@ -6,42 +6,13 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-// TODO: Use Region struct from Region.swift when feature/ekyc-api-integration branch is merged into develop
-
-func getRegionFromRegionResponseArray(_ regionResponses: [RegionResponse]) -> RegionResponse? {
-    var ret: RegionResponse?
-    
-    var hasRejectedStatus = false
-    var hasApprovedStatus = false
-    
-    for region in regionResponses {
-        switch region.status {
-        case .PENDING:
-            if !hasRejectedStatus && !hasApprovedStatus {
-                ret = region
-            }
-        case .REJECTED:
-            if !hasApprovedStatus {
-                ret = region
-            }
-            hasRejectedStatus = true
-        case .APPROVED:
-            ret = region
-            hasApprovedStatus = true
-        }
-        if hasApprovedStatus {
-            break
-        }
-    }
-    
-    return ret
-}
+import ostelco_core
 
 struct Context: Codable {
     let customer: CustomerModel?
     let regions: [RegionResponse]
     
     func getRegion() -> RegionResponse? {
-        return getRegionFromRegionResponseArray(regions)
+        return RegionResponse.getRegionFromRegionResponseArray(regions)
     }
 }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -98,7 +98,6 @@ extension APIManager {
     enum APIError: Swift.Error, LocalizedError {
         case failedToGetRegion
         case failedToParse
-        case errorCameWithoutData
         
         var localizedDescription: String {
             switch self {
@@ -106,8 +105,6 @@ extension APIManager {
                 return "Could not find suitable region from region response"
             case .failedToParse:
                 return "Something went wrong while parsing the API response"
-            case .errorCameWithoutData:
-                return "An error response was received from the server, but no further information is available"
             }
         }
     }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -117,7 +117,7 @@ extension APIManager {
         regions.load()
             .onSuccess { response in
                 if let regionResponseArray: [RegionResponse] = response.typedContent(ifNone: []) {
-                    if let region = getRegionFromRegionResponseArray(regionResponseArray) {
+                    if let region = RegionResponse.getRegionFromRegionResponseArray(regionResponseArray) {
                         DispatchQueue.main.async {
                             completion(region, nil)
                         }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
+import PromiseKit
 import Siesta
 import ostelco_core
 
@@ -13,6 +14,14 @@ class APIManager: Service {
     
     static let sharedInstance = APIManager()
     let jsonDecoder = JSONDecoder()
+    
+    lazy var loggedInAPI: LoggedInAPI = {
+        let baseURLString = Environment().configuration(PlistKey.ServerURL)
+        let auth0Storage = sharedAuth.credentialsSecureStorage
+        return LoggedInAPI(baseURL: baseURLString,
+                           secureStorage: auth0Storage)
+    }()
+    
     var authHeader: String? {
         didSet {
             invalidateConfiguration()
@@ -87,53 +96,6 @@ class APIManager: Service {
 
         configureTransformer("/purchases") {
             try self.jsonDecoder.decode([PurchaseModel].self, from: $0.content)
-        }
-
-    }
-}
-
-extension APIManager {
-    
-    // TODO: Move to APIHelper together with the below todo
-    enum APIError: Swift.Error, LocalizedError {
-        case failedToGetRegion
-        case failedToParse
-        
-        var localizedDescription: String {
-            switch self {
-            case .failedToGetRegion: // TODO: This error is specific to the APIManager, not APIHelper, thus should stay here
-                return "Could not find suitable region from region response"
-            case .failedToParse:
-                return "Something went wrong while parsing the API response"
-            }
-        }
-    }
-    
-    // TODO: Abstract the parsing logic into APIHelper using RegionResponse as a generic type. And handle the specific logic of returning one region out of a list inside this function. Also Refactor to use PromiseKit
-    func getRegionFromRegions(completion: @escaping (RegionResponse?, Error?) -> Void) {
-        regions.load()
-            .onSuccess { response in
-                if let regionResponseArray: [RegionResponse] = response.typedContent(ifNone: []) {
-                    if let region = RegionResponse.getRegionFromRegionResponseArray(regionResponseArray) {
-                        DispatchQueue.main.async {
-                            completion(region, nil)
-                        }
-                        
-                    } else {
-                        DispatchQueue.main.async {
-                            completion(nil, APIError.failedToGetRegion)
-                        }
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        completion(nil, APIError.failedToParse)
-                    }
-                }
-            }
-            .onFailure { requestError in
-                DispatchQueue.main.async {
-                    completion(nil, requestError)
-                }
         }
     }
 }

--- a/ostelco-ios-client/Network/AppErrors.swift
+++ b/ostelco-ios-client/Network/AppErrors.swift
@@ -30,11 +30,15 @@ struct ApplicationErrors {
     ///   - error: The error to log
     ///   - userInfo: A dictionary with any additional user info to pass along. Defaults to nil.
     static func log(_ error: Error,
-                    withAdditionalUserInfo userInfo: [String : Any]? = nil,
+                    withAdditionalUserInfo userInfo: [String: Any]? = nil,
                     file: StaticString = #file,
                     line: UInt = #line) {
         let fileName = (String(staticString: file) as NSString).lastPathComponent
-        debugPrint("\(fileName) line \(line)\n- Error: \(error)\n- UserInfo: \(String(describing: userInfo))\n\n")
+        debugPrint("""
+            \(fileName) line \(line)
+            - Error: \(error)
+            - UserInfo: \(String(describing: userInfo))
+            """)
         Crashlytics.sharedInstance().recordError(error, withAdditionalUserInfo: userInfo)
     }
 }

--- a/ostelco-ios-client/Network/AppErrors.swift
+++ b/ostelco-ios-client/Network/AppErrors.swift
@@ -6,10 +6,12 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-import Foundation
 import Crashlytics
+import Foundation
+import ostelco_core
 
-class ApplicationErrors {
+/// Wrapper for logging errors throughout the application
+struct ApplicationErrors {
     enum General: LocalizedError {
         case noValidPlansFound
 
@@ -20,7 +22,19 @@ class ApplicationErrors {
             }
         }
     }
-    static func log(_ error: Error) {
-        Crashlytics.sharedInstance().recordError(error)
+    
+    /// Logs the passed-in error to our error logging software of choice and `debugPrint`s it
+    /// (Currently: Crashlytics)
+    ///
+    /// - Parameters:
+    ///   - error: The error to log
+    ///   - userInfo: A dictionary with any additional user info to pass along. Defaults to nil.
+    static func log(_ error: Error,
+                    withAdditionalUserInfo userInfo: [String : Any]? = nil,
+                    file: StaticString = #file,
+                    line: UInt = #line) {
+        let fileName = (String(staticString: file) as NSString).lastPathComponent
+        debugPrint("\(fileName) line \(line)\n- Error: \(error)\n- UserInfo: \(String(describing: userInfo))\n\n")
+        Crashlytics.sharedInstance().recordError(error, withAdditionalUserInfo: userInfo)
     }
 }

--- a/ostelco-ios-client/Network/Auth.swift
+++ b/ostelco-ios-client/Network/Auth.swift
@@ -15,6 +15,7 @@ let sharedAuth = Auth()
 
 class Auth {
     let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
+    private(set) lazy var credentialsSecureStorage = CredentialSecureStorage(credentialManger: self.credentialsManager)
     
     // force show the login screen after user logs out without using the auth0 logout url
     var forceLoginPrompt = false
@@ -25,6 +26,7 @@ class Auth {
             .clearSession(federated: true) {
                 print("Clear Session: ", $0)
                 _ = self.credentialsManager.clear()
+                self.credentialsSecureStorage.clearSecureStorage()
                 if let callback = callback {
                     callback()
                 }
@@ -76,6 +78,7 @@ class Auth {
                     case .success(let credentials):
                         os_log("Store credentials with auth0 credentials manager.")
                         _ = self.credentialsManager.store(credentials: credentials)
+                        self.credentialsSecureStorage.update(with: credentials)
                         os_log("Successfully logged in with auth0, credential. refreshToken: %{private}@ accessToken: %{private}@ idToken: %{private}@", credentials.refreshToken ?? "none", credentials.accessToken ?? "none", credentials.idToken ?? "none")
                         if let accessToken = credentials.accessToken {
                             DispatchQueue.main.async {
@@ -93,7 +96,5 @@ class Auth {
             }
             return Disposables.create()
         }
-        
     }
-    
 }

--- a/ostelco-ios-client/Network/CredentialSecureStorage.swift
+++ b/ostelco-ios-client/Network/CredentialSecureStorage.swift
@@ -1,0 +1,57 @@
+//
+//  CredentialSecureStorage.swift
+//  ostelco-ios-client
+//
+//  Created by Ellen Shapiro on 5/1/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import ostelco_core
+import Foundation
+import Auth0
+
+class CredentialSecureStorage: SecureStorage {
+    
+    private var creds = [KeychainKey: String]()
+    
+    init(credentialManger: CredentialsManager) {
+        credentialManger.credentials { error, credentials in
+            if let error = error {
+                debugPrint("- Credentials couldn't be loaded: \(error)")
+            }
+            
+            guard let creds = credentials else {
+                return
+            }
+            
+            self.update(with: creds)
+        }
+    }
+    
+    func update(with credentials: Credentials) {
+        if let accessToken = credentials.accessToken {
+            self.creds[.Auth0Token] = accessToken
+        }
+        
+        if let refreshToken = credentials.refreshToken {
+            self.creds[.Auth0RefreshToken] = refreshToken
+        }
+    }
+    
+    func setString(_ string: String, for key: KeychainKey) {
+        self.creds[key] = string
+    }
+    
+    func getString(for key: KeychainKey) -> String? {
+        return self.creds[key]
+    }
+    
+    func clearValue(for key: KeychainKey) {
+        self.creds.removeValue(forKey: key)
+    }
+    
+    func clearSecureStorage() {
+        self.creds.removeAll()
+    }
+    
+}

--- a/ostelco-ios-client/Network/OstelcoAPI.swift
+++ b/ostelco-ios-client/Network/OstelcoAPI.swift
@@ -51,8 +51,12 @@ func refreshTokenHandler(refreshToken: String?) -> Siesta.Request {
     return auth0API.token.request(.post, json: ["grant_type": "refresh_token", "client_id": Environment().configuration(.Auth0ClientID), "refresh_token": refreshToken])
         .onSuccess {
             let credentials = $0.typedContent()! as Credentials
-            let accessToken = credentials.accessToken
-            APIManager.sharedInstance.authHeader = "Bearer \(accessToken!)"
+            guard let accessToken = credentials.accessToken else {
+                assertionFailure("No access token?!")
+                return
+            }
+            APIManager.sharedInstance.authHeader = "Bearer \(accessToken)"
+            sharedAuth.credentialsSecureStorage.setString(accessToken, for: .Auth0Token)
             // Credentials only contains accessToken at this point, if saved, we overwrite all other informatmion required
             // by auth0 to validate the credentials, thus the user is presented with the login screen. Downside of not updating
             // the accessToken with auth0 is that auth0 will again refresh the access token next time you open the app or the

--- a/ostelco-ios-client/Network/OstelcoAPI.swift
+++ b/ostelco-ios-client/Network/OstelcoAPI.swift
@@ -12,7 +12,6 @@ import os
 import Auth0
 import ostelco_core
 
-let ostelcoAPI = OstelcoAPI()
 let auth0API = Auth0API()
 
 // var authRequest: Siesta.Request? = nil;
@@ -53,7 +52,7 @@ func refreshTokenHandler(refreshToken: String?) -> Siesta.Request {
         .onSuccess {
             let credentials = $0.typedContent()! as Credentials
             let accessToken = credentials.accessToken
-            ostelcoAPI.authToken = "Bearer \(accessToken!)"
+            APIManager.sharedInstance.authHeader = "Bearer \(accessToken!)"
             // Credentials only contains accessToken at this point, if saved, we overwrite all other informatmion required
             // by auth0 to validate the credentials, thus the user is presented with the login screen. Downside of not updating
             // the accessToken with auth0 is that auth0 will again refresh the access token next time you open the app or the
@@ -80,62 +79,4 @@ class Auth0API: Service {
     }
     
     var token: Resource { return resource("oauth/token") }
-}
-
-class OstelcoAPI: Service {
-    
-    fileprivate init() {
-        super.init(
-            baseURL: Environment().configuration(PlistKey.ServerURL),
-            standardTransformers: [.text, .image]
-        )
-        
-        configure {
-            $0.headers["Content-Type"] = "application/json"
-            $0.headers["Authorization"] = self.authToken
-            
-            $0.decorateRequests { _, req in
-                return refreshTokenOnAuthFailure(request: req, refreshToken: self.refreshToken)
-            }
-        }
-        
-        let jsonDecoder = JSONDecoder()
-        self.configureTransformer("/bundles") {
-            try jsonDecoder.decode([BundleModel].self, from: $0.content)
-        }
-        
-        self.configure("/bundles") {
-            $0.expirationTime = 5
-        }
-        
-        self.configureTransformer("/profile") {
-            try jsonDecoder.decode(ProfileModel.self, from: $0.content)
-        }
-        
-        self.configureTransformer("/purchases*") {
-            try jsonDecoder.decode([PurchaseModel].self, from: $0.content)
-        }
-        
-        self.configureTransformer("/products") {
-            try jsonDecoder.decode([ProductModel].self, from: $0.content)
-        }
-    }
-    
-    var bundles: Resource { return resource("/bundles") }
-    var profile: Resource { return resource("/profile") }
-    var purchases: Resource { return resource("/purchases") }
-    var products: Resource { return resource("/products") }
-    
-    var authToken: String? {
-        didSet {
-            // Rerun existing configuration closure using new value
-            invalidateConfiguration()
-            
-            // Wipe any cached state if auth token changes
-            // Note: If we wipe resources, the purchase history list becomes blank after we repeate a request after a 401 from ostelcoAPI
-            // wipeResources()
-        }
-    }
-    
-    var refreshToken: String?
 }

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -29,7 +29,7 @@ class OstelcoAnalytics {
             var meta = event.metadata
             meta["name"] = event.name
             meta["className"] = String(describing: event)
-            Crashlytics.sharedInstance().recordError(AnalyticsError.eventNameIsEmpty, withAdditionalUserInfo: meta)
+            ApplicationErrors.log(AnalyticsError.eventNameIsEmpty, withAdditionalUserInfo: meta)
         } else {
             Analytics.logEvent(event.name, parameters: event.metadata)
         }

--- a/ostelco-ios-client/Protocols/LocationCheckingViewController.swift
+++ b/ostelco-ios-client/Protocols/LocationCheckingViewController.swift
@@ -63,12 +63,8 @@ extension LocationChecking {
             }
             .ensure { [weak self] in
                 // Whether we get an error or success, we always want to kill the spinner.
-                guard let self = self else {
-                    return
-                }
-                
-                self.removeSpinner(self.spinnerView)
-                self.spinnerView = nil
+                self?.removeSpinner(self?.spinnerView)
+                self?.spinnerView = nil
             }
             .catch { [weak self] error in
                 if let locationError = error as? LocationController.Error {

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -123,10 +123,8 @@ class AddressEditViewController: UITableViewController {
         APIManager.sharedInstance.loggedInAPI
             .addAddress(address, forRegion: countryCode)
             .ensure { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                self.removeSpinner(self.spinnerView)
+                self?.removeSpinner(self?.spinnerView)
+                self?.spinnerView = nil
             }
             .done { [weak self] in
                 let pendingVC = PendingVerificationViewController.fromStoryboard()

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Crashlytics
+import ostelco_core
 import RxSwift
 import UIKit
 
@@ -128,7 +129,7 @@ class AddressEditViewController: UITableViewController {
             .onFailure { requestError in
                 do {
                     guard let errorData = requestError.entity?.content as? Data else {
-                        throw APIManager.APIError.errorCameWithoutData
+                        throw APIHelper.Error.errorCameWithoutData
                     }
                     
                     let putProfileError = try JSONDecoder().decode(PutProfileError.self, from: errorData)

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -8,6 +8,7 @@
 
 import Crashlytics
 import ostelco_core
+import PromiseKit
 import RxSwift
 import UIKit
 
@@ -114,49 +115,50 @@ class AddressEditViewController: UITableViewController {
     }
     
     private func sendAddressToServer() {
-        self.spinnerView = showSpinner(onView: self.view)
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
-        APIManager.sharedInstance.regions.child(countryCode).child("kyc/profile")
-            .withParam("address", self.buildAddressString())
-            .withParam("phoneNumber", "12345678")
-            .request(.put)
-            .onSuccess { _ in
-                DispatchQueue.main.async {
-                    let pendingVC = PendingVerificationViewController.fromStoryboard()
-                    self.present(pendingVC, animated: true)
+        let address = self.buildAddress()
+        
+        self.spinnerView = showSpinner(onView: self.view)
+
+        APIManager.sharedInstance.loggedInAPI
+            .addAddress(address, forRegion: countryCode)
+            .ensure { [weak self] in
+                guard let self = self else {
+                    return
                 }
-            }
-            .onFailure { requestError in
-                do {
-                    guard let errorData = requestError.entity?.content as? Data else {
-                        throw APIHelper.Error.errorCameWithoutData
-                    }
-                    
-                    let putProfileError = try JSONDecoder().decode(PutProfileError.self, from: errorData)
-                    self.showAlert(title: "Error", msg: "\(putProfileError.errors)")
-                } catch let error {
-                    print(error)
-                    Crashlytics.sharedInstance().recordError(requestError)
-                    self.showAPIError(error: requestError)
-                }
-                
-            }
-            .onCompletion { _ in
                 self.removeSpinner(self.spinnerView)
+            }
+            .done { [weak self] in
+                let pendingVC = PendingVerificationViewController.fromStoryboard()
+                self?.present(pendingVC, animated: true)
+            }
+            .catch { [weak self] error in
+                switch error {
+                case APIHelper.Error.serverError(let serverError):
+                    self?.showAlert(title: "Error", msg: "\(serverError.errors)")
+                default:
+                    debugPrint("Error adding address: \(error)")
+                    ApplicationErrors.log(error)
+                    self?.showGenericError(error: error)
+                }
             }
     }
         
-    private func buildAddressString() -> String {
+    private func buildAddress() -> EKYCAddress {
         guard
             let street = self.dataSource.value(for: .street),
-            let house = self.dataSource.value(for: .unit),
+            let unit = self.dataSource.value(for: .unit),
             let city = self.dataSource.value(for: .city),
             let postcode = self.dataSource.value(for: .postcode),
             let country = self.dataSource.value(for: .country) else {
                 fatalError("Somehow validation passed but one of these was null")
         }
             
-        return "\(street);;;\(house);;;\(city);;;\(postcode);;;\(country)"
+        return EKYCAddress(street: street,
+                           unit: unit,
+                           city: city,
+                           postcode: postcode,
+                           country: country)
     }
     
     private func updateMyInfo() {

--- a/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
@@ -40,25 +40,20 @@ class NRCIVerifyViewController: UIViewController {
         self.nricErrorLabel.isHidden = true
         self.spinnerView = self.showSpinner(onView: self.view)
         APIManager.sharedInstance.loggedInAPI
-            .callNRICEndpoint(with: nric, forRegion: countryCode)
+            .validateNRIC(nric, forRegion: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
             }
-            .done { [weak self] in
-                self?.startNetverify()
+            .done { [weak self] isValid in
+                if isValid {
+                    self?.startNetverify()
+                } else {
+                    self?.nricErrorLabel.isHidden = false
+                }
             }
             .catch { [weak self] error in
                 ApplicationErrors.log(error)
-                switch error {
-                case APIHelper.Error.jsonError(let jsonError):
-                    if jsonError.errorCode == "INVALID_NRIC_FIN_ID" {
-                        self?.nricErrorLabel.isHidden = false
-                    } else {
-                        self?.showGenericError(error: error)
-                    }
-                default:
-                    self?.showAlert(title: "Error", msg: "Please try again later.")
-                }
+                self?.showGenericError(error: error)
             }
     }
 }

--- a/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-import UIKit
-import Netverify
 import Crashlytics
+import Netverify
+import ostelco_core
+import UIKit
 
 class NRCIVerifyViewController: UIViewController {
     
@@ -40,7 +41,7 @@ class NRCIVerifyViewController: UIViewController {
                 .onFailure { requestError in
                     do {
                         guard let errorData = requestError.entity?.content as? Data else {
-                            throw APIManager.APIError.errorCameWithoutData
+                            throw APIHelper.Error.errorCameWithoutData
                         }
                         
                         let jsonRequestError = try JSONDecoder().decode(JSONRequestError.self, from: errorData)

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import ostelco_core
 
 class PendingVerificationViewController: UIViewController {
     

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -118,11 +118,7 @@ class PendingVerificationViewController: UIViewController {
         let ohNo = OhNoViewController.fromStoryboard(type: .generic(code: nil))
         ohNo.primaryButtonAction = {
             ohNo.dismiss(animated: true, completion: { [weak self] in
-                guard let self = self else {
-                    return
-                }
-              
-                self.checkVerificationStatus()
+                self?.checkVerificationStatus()
             })
         }
         self.present(ohNo, animated: true)

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -83,7 +83,7 @@ class ESIMPendingDownloadViewController: UIViewController {
                 }
             }
             .onFailure { requestError in
-                Crashlytics.sharedInstance().recordError(requestError)
+                ApplicationErrors.log(requestError)
                 self.showAPIError(error: requestError)
             }
             .onCompletion { _ in

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -31,15 +31,17 @@ class ESIMPendingDownloadViewController: UIViewController {
         if let region = OnBoardingManager.sharedInstance.region {
             getSimProfileForRegion(region: region)
         } else {
-            APIManager.sharedInstance.getRegionFromRegions { (regionResponse, _) in
-                if let regionResponse = regionResponse {
-                    OnBoardingManager.sharedInstance.region = regionResponse
-                    self.getSimProfileForRegion(region: regionResponse)
-                } else {
-                    self.performSegue(withIdentifier: "showGenericOhNo", sender: self)
-                }
+           APIManager.sharedInstance
+            .loggedInAPI
+            .getRegionFromRegions()
+            .done { [weak self] regionResponse in
+                OnBoardingManager.sharedInstance.region = regionResponse
+                self?.getSimProfileForRegion(region: regionResponse)
             }
-            
+            .catch { [weak self] error in
+                debugPrint("Error getting region: \(error)")
+                self?.performSegue(withIdentifier: "showGenericOhNo", sender: self)
+            }
         }
     }
     

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Crashlytics
+import ostelco_core
 
 class ESIMPendingDownloadViewController: UIViewController {
     var spinnerView: UIView?

--- a/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
@@ -114,9 +114,7 @@ class LoginViewController: UIViewController {
                                                 }
                                             } else {
                                                 self.perform(#selector(self.showESim), with: nil, afterDelay: 0.5)
-                                            }
-                                            
-                                            
+                                            }         
                                         case .REJECTED:
                                             self.perform(#selector(self.showEKYCOhNo), with: nil, afterDelay: 0.5)
                                         }

--- a/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
@@ -114,7 +114,7 @@ class LoginViewController: UIViewController {
                                                 }
                                             } else {
                                                 self.perform(#selector(self.showESim), with: nil, afterDelay: 0.5)
-                                            }         
+                                            }
                                         case .REJECTED:
                                             self.perform(#selector(self.showEKYCOhNo), with: nil, afterDelay: 0.5)
                                         }

--- a/ostelco-ios-client/ViewControllers/SplashViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SplashViewController.swift
@@ -39,6 +39,7 @@ class SplashViewController: UIViewController, StoryboardLoadable {
                         if userManager.authToken != accessToken {
                             apiManager.authHeader = "Bearer \(accessToken)"
                             UserManager.sharedInstance.authToken = accessToken
+                            sharedAuth.credentialsSecureStorage.setString(accessToken, for: .Auth0Token)
                         }
                         
                         // TODO: New API does not handle refreshToken yet


### PR DESCRIPTION
Apologies, this one slightly got away from me in terms of size. 

In this PR: 
- Add and test Request generator 
- Pull some stuff into a `BasicNetwork` superclass so we can pass arbitrary requests to it
- Pull a bunch of region response stuff into core
- Test picking a region out of a number of regions
- Consolidate error handling
- Add a temporary wrapper to let the `LoggedInAPI` use creds from Auth0
- Set up some stuff around API path generation to try to keep it type-safe
- Centralize looking for server errors in returned data
- Actually move a couple calls in the code over to new API!
- Nuke unused `OstelcoAPI`