### PR TITLE
Migrate more calls to LoggedInAPI

### DIFF
--- a/dev-ostelco-ios-clientTests/MyInfoTests.swift
+++ b/dev-ostelco-ios-clientTests/MyInfoTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import Oya_Development_app
+import ostelco_core
 import XCTest
 
 class MyInfoTests: XCTestCase {

--- a/ostelco-core/Models/MyInfoDetails.swift
+++ b/ostelco-core/Models/MyInfoDetails.swift
@@ -8,16 +8,32 @@
 
 import Foundation
 
-struct MyInfoAddress: Codable {
-    let country: String?
-    let unit: String?
-    let street: String?
-    let block: String?
-    let postal: String?
-    let floor: String?
-    let building: String?
+public struct MyInfoAddress: Codable {
+    public let country: String?
+    public let unit: String?
+    public let street: String?
+    public let block: String?
+    public let postal: String?
+    public let floor: String?
+    public let building: String?
     
-    func getAddressLine1() -> String {
+    public init(country: String?,
+                unit: String?,
+                street: String?,
+                block: String?,
+                postal: String?,
+                floor: String?,
+                building: String?) {
+        self.country = country
+        self.unit = unit
+        self.street = street
+        self.block = block
+        self.postal = postal
+        self.floor = floor
+        self.building = building
+    }
+    
+    public func getAddressLine1() -> String {
         var addressLine1: String = ""
         if let block = self.block {
             addressLine1 = "\(block) "
@@ -28,7 +44,7 @@ struct MyInfoAddress: Codable {
         return addressLine1
     }
     
-    func getAddressLine2() -> String {
+    public func getAddressLine2() -> String {
         var addressLine2: String = ""
         if let postal = self.postal {
             addressLine2 = "\(postal) "
@@ -40,38 +56,38 @@ struct MyInfoAddress: Codable {
     }
 }
 
-struct MyInfoDetails: Codable {
+public struct MyInfoDetails: Codable {
     private let _name: MyInfoRequiredValue
-    var name: String {
+    public var name: String {
         return _name.value
     }
     
     private let _dob: MyInfoRequiredValue
-    var dob: String {
+    public var dob: String {
         return _dob.value
     }
     private let _email: MyInfoRequiredValue
-    var email: String {
+    public var email: String {
         return _email.value
     }
     
     private let _sex: MyInfoOptionalValue?
-    var sex: String? {
+    public var sex: String? {
         return _sex?.value
     }
     
     private let _residentialStatus: MyInfoOptionalValue?
-    var residentialStatus: String? {
+    public var residentialStatus: String? {
         return _residentialStatus?.value
     }
     
     private let _nationality: MyInfoOptionalValue?
-    var nationality: String? {
+    public var nationality: String? {
         return _nationality?.value
     }
     
-    var address: MyInfoAddress
-    let mobileNumber: MyInfoMobileNumber?
+    public var address: MyInfoAddress
+    public let mobileNumber: MyInfoMobileNumber?
     
     enum CodingKeys: String, CodingKey {
         case _name = "name"
@@ -93,10 +109,10 @@ struct MyInfoOptionalValue: Codable {
     let value: String?
 }
 
-struct MyInfoMobileNumber: Codable {
-    let number: String?
-    let code: String?
-    let prefix: String?
+public struct MyInfoMobileNumber: Codable {
+    public let number: String?
+    public let code: String?
+    public let prefix: String?
     
     enum CodingKeys: String, CodingKey {
         case number = "nbr"
@@ -104,7 +120,7 @@ struct MyInfoMobileNumber: Codable {
         case prefix
     }
     
-    var formattedNumber: String? {
+    public var formattedNumber: String? {
         guard
             let number = self.number,
             let code = self.code,

--- a/ostelco-core/Network/APIEndpoint.swift
+++ b/ostelco-core/Network/APIEndpoint.swift
@@ -41,6 +41,8 @@ public enum RegionEndpoint: APIEndpoint {
     case dave
     case jumio
     case kyc
+    case myInfo
+    case myInfoCode(code: String)
     case nric(number: String)
     case region(code: String)
     case profile
@@ -54,10 +56,14 @@ public enum RegionEndpoint: APIEndpoint {
             return "dave"
         case .jumio:
             return "jumio"
-        case .nric(let number):
-            return number
         case .kyc:
             return "kyc"
+        case .myInfo:
+            return "myInfo"
+        case .myInfoCode(let code):
+            return code
+        case .nric(let number):
+            return number
         case .region(let code):
             return code
         case .profile:

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -176,6 +176,26 @@ open class LoggedInAPI: BasicNetwork {
             }
     }
     
+    /// Loads details based on a SingPass sign in (singapore only!)
+    ///
+    /// - Parameter code: The code associated with the user in SingPass
+    /// - Returns: A promise which, when fulfilled, will contain the user's `MyInfoDetails`.
+    public func loadSingpassInfo(code: String) -> Promise<MyInfoDetails> {
+        let myInfoEndpoints: [RegionEndpoint] = [
+            .region(code: "sg"),
+            .kyc,
+            .myInfo,
+            .myInfoCode(code: code)
+        ]
+        
+        let path = RootEndpoint.regions.pathByAddingEndpoints(myInfoEndpoints)
+        
+        return self.loadData(from: path)
+            .map { try self.decoder.decode(MyInfoDetails.self, from: $0) }
+    }
+    
+    // MARK: - General
+    
     /// Loads arbitrary data from a path based on the base URL, then validates
     /// that the response is valid.
     ///

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -87,6 +87,22 @@ open class LoggedInAPI: BasicNetwork {
         return self.loadData(from: path)
             .map { try self.decoder.decode(RegionResponse.self, from: $0) }
     }
+    
+    /// Loads the SIM profiles for the specified region
+    ///
+    /// - Parameter code: The region to request SIM profiles for
+    /// - Returns: A promise which when fullfilled contains the requested profiles
+    public func loadSimProfilesForRegion(code: String) -> Promise<[SimProfile]> {
+        let endpoints: [RegionEndpoint] = [
+            .region(code: code),
+            .simProfiles
+        ]
+        
+        let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
+        
+        return self.loadData(from: path)
+            .map { try self.decoder.decode([SimProfile].self, from: $0) }
+    }
 
     /// - Returns: A promise which when fulfilled will contain the relevant region response for this user.
     public func getRegionFromRegions() -> Promise<RegionResponse> {

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -76,6 +76,17 @@ open class LoggedInAPI: BasicNetwork {
         return self.loadData(from: RootEndpoint.regions.rawValue)
             .map { try self.decoder.decode([RegionResponse].self, from: $0) }
     }
+    
+    /// Loads the region response for the specified region
+    ///
+    /// - Parameter code: The region to request
+    /// - Returns: A promise which when fulfilled contains the requested region.
+    public func loadRegion(code: String) -> Promise<RegionResponse> {
+        let path = RootEndpoint.regions.pathByAddingEndpoints([RegionEndpoint.region(code: code)])
+        
+        return self.loadData(from: path)
+            .map { try self.decoder.decode(RegionResponse.self, from: $0) }
+    }
 
     /// - Returns: A promise which when fulfilled will contain the relevant region response for this user.
     public func getRegionFromRegions() -> Promise<RegionResponse> {

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		9B560A9922731E57004473E1 /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B560A9822731E57004473E1 /* OnboardingPageViewController.swift */; };
 		9B560A9A22731E97004473E1 /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B560A9822731E57004473E1 /* OnboardingPageViewController.swift */; };
 		9B560A9C2273289D004473E1 /* PageControllerDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B560A9B2273289D004473E1 /* PageControllerDataSource.swift */; };
+		9B611A47227C8EA700194364 /* MyInfoDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */; };
 		9B6E3A11226F6FDE0063EBAA /* SFProText-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */; };
 		9B6E3A12226F6FE30063EBAA /* SFProText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */; };
 		9B6E3A13226F6FE90063EBAA /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */; };
@@ -207,7 +208,6 @@
 		9BBF706B2266162F00E4B9B4 /* UITableView+Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF706A2266162F00E4B9B4 /* UITableView+Generics.swift */; };
 		9BBF70712267423A00E4B9B4 /* UIApplication+TypedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70702267423A00E4B9B4 /* UIApplication+TypedDelegate.swift */; };
 		9BBF70722267427200E4B9B4 /* UIApplication+TypedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF70702267423A00E4B9B4 /* UIApplication+TypedDelegate.swift */; };
-		9BBF7073226746E500E4B9B4 /* MyInfoDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */; };
 		9BBF7075226751A200E4B9B4 /* Netverify+Ostelco.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF7074226751A200E4B9B4 /* Netverify+Ostelco.swift */; };
 		9BBF7076226751E500E4B9B4 /* Netverify+Ostelco.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF7074226751A200E4B9B4 /* Netverify+Ostelco.swift */; };
 		9BBF707A22675C3900E4B9B4 /* Array+FancyAppend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBF7077226753F700E4B9B4 /* Array+FancyAppend.swift */; };
@@ -257,7 +257,6 @@
 		9BF27784225D15FE006428D5 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9BF2777F225D15FE006428D5 /* Auth0.plist */; };
 		9BF27785225D15FE006428D5 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9BF2777F225D15FE006428D5 /* Auth0.plist */; };
 		B372691FA8FCE81A40A161DB /* Pods_ostelco_ios_ostelco_ios_client.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0FA23121B4593BEA7856FF9 /* Pods_ostelco_ios_ostelco_ios_client.framework */; };
-		C224D921225FADFC00AE10FD /* MyInfoDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */; };
 		C23CFC8B227610E5000117A8 /* ApplePayDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23CFC8A227610E5000117A8 /* ApplePayDelegate.swift */; };
 		C23CFC8C227610E5000117A8 /* ApplePayDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23CFC8A227610E5000117A8 /* ApplePayDelegate.swift */; };
 		C24EE405222838950053937E /* PendingVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24EE404222838950053937E /* PendingVerificationViewController.swift */; };
@@ -750,7 +749,6 @@
 				0437CF88224D3B380022A2B8 /* Context.swift */,
 				04834D712237B11800A01500 /* CustomerModel.swift */,
 				9BC4653B2271ADA9001951BF /* LocationProblem+UserFacingCopy.swift */,
-				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
 				9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */,
 				0485339F223C1882007C89F4 /* Product.swift */,
 				C2C3EAD32270B43200585FA4 /* PurchaseRecord.swift */,
@@ -872,6 +870,7 @@
 				9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */,
 				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
+				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
 				044881A7217BA32B00F59758 /* PurchaseModel.swift */,
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
 				044881A1217B896800F59758 /* ProfileModel.swift */,
@@ -1770,7 +1769,6 @@
 				041216A9222817EC00455278 /* ChooseCountryOnBoardingViewController.swift in Sources */,
 				04D6C9882276F7CB00AE13DD /* String+SnakeCase.swift in Sources */,
 				9B560A9922731E57004473E1 /* OnboardingPageViewController.swift in Sources */,
-				9BBF7073226746E500E4B9B4 /* MyInfoDetails.swift in Sources */,
 				9BE2D451225B609100B51999 /* TopUpButton.swift in Sources */,
 				048C787C2191C9660041F135 /* ThemeManager.swift in Sources */,
 				9BBF70492265D4D200E4B9B4 /* MyInfoDetails+Testing.swift in Sources */,
@@ -1834,6 +1832,7 @@
 				9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */,
 				9B82159C227B254B00DC6B64 /* JSONRequestError.swift in Sources */,
 				9B82159B227B225400DC6B64 /* String+Static.swift in Sources */,
+				9B611A47227C8EA700194364 /* MyInfoDetails.swift in Sources */,
 				9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */,
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
 				9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */,
@@ -1945,7 +1944,6 @@
 				9BBF704A2265D51600E4B9B4 /* MyInfoDetails+Testing.swift in Sources */,
 				9B174581227722C200CF321B /* ValidationState.swift in Sources */,
 				C25A95972226FF7F005958EC /* MyInfoSummaryViewController.swift in Sources */,
-				C224D921225FADFC00AE10FD /* MyInfoDetails.swift in Sources */,
 				C2BC662222733C75008BBC4E /* ApplePayViewController.swift in Sources */,
 				9BE2D44B225B5E9600B51999 /* TabBarController.swift in Sources */,
 				04EC5AE9218873C0000C2EC3 /* Environment.swift in Sources */,

--- a/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
+++ b/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import ostelco_core
 
 // TODO: Move this to test package once stabilized
 extension MyInfoDetails {

--- a/ostelco-ios-client/Models/Product.swift
+++ b/ostelco-ios-client/Models/Product.swift
@@ -16,24 +16,26 @@ public class Product {
     let sku: String
     let type: String
 
-    @available(*, deprecated, message: "Construct a Product object from ProdctModel")
-    init(name: String, label: String, amount: Decimal, country: String, currency: String, sku: String, type: String) {
-        self.name = name
-        self.label = label
-        self.amount = amount
-        self.country = country
-        self.currency = currency
-        self.sku = sku
-        self.type = type
-    }
-
     init(from: ProductModel, countryCode: String) {
-        name = "\(from.presentation.label) of Data"
-        label = "Buy \(from.presentation.label) for \(from.presentation.price)"
-        amount = Decimal(from.price.amount)
-        country = countryCode
-        currency = from.price.currency
-        sku = from.sku
-        type = from.type
+        self.name = "\(from.presentation.label) of Data"
+        self.label = "Buy \(from.presentation.label) for \(from.presentation.price)"
+        self.amount = Decimal(from.price.amount)
+        self.country = countryCode
+        self.currency = from.price.currency
+        self.sku = from.sku
+        self.type = from.type
+    }
+}
+
+extension Product: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return """
+        - Name: \(self.name)
+        - Amount: \(self.amount)
+        - Currency: \(self.currency)
+        - Country: \(self.country)
+        - SKU: \(self.sku)
+        """
     }
 }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -59,25 +59,9 @@ class APIManager: Service {
         configureTransformer("/regions/sg/kyc/myInfo/*") {
             try self.jsonDecoder.decode(MyInfoDetails.self, from: $0.content)
         }
-        
-        configureTransformer("/regions/*/simProfiles", requestMethods: [.get]) {
-            try self.jsonDecoder.decode([SimProfile].self, from: $0.content)
-        }
-        
+
         configureTransformer("/regions/*/simProfiles", requestMethods: [.post]) {
             try self.jsonDecoder.decode(SimProfile.self, from: $0.content)
-        }
-        
-        self.configure("/reginos/*/simProfiles") {
-            $0.expirationTime = 5
-        }
-        
-        configureTransformer("/regions/*") {
-            try self.jsonDecoder.decode(RegionResponse.self, from: $0.content)
-        }
-        
-        configureTransformer("/regions") {
-            try self.jsonDecoder.decode([RegionResponse].self, from: $0.content)
         }
         
         configureTransformer("/context") {

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -33,7 +33,6 @@ class APIManager: Service {
     var products: Resource { return resource("/products") }
     var context: Resource { return resource("/context") }
     var regions: Resource { return resource("/regions") }
-    var bundles: Resource { return resource("/bundles") }
     var purchases: Resource { return resource("/purchases") }
 
     fileprivate init() {
@@ -84,10 +83,6 @@ class APIManager: Service {
         
         configureTransformer("/context") {
             try self.jsonDecoder.decode(Context.self, from: $0.content)
-        }
-
-        configureTransformer("/bundles") {
-            try self.jsonDecoder.decode([BundleModel].self, from: $0.content)
         }
 
         configureTransformer("/purchases") {

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -33,7 +33,6 @@ class APIManager: Service {
     var products: Resource { return resource("/products") }
     var context: Resource { return resource("/context") }
     var regions: Resource { return resource("/regions") }
-    var purchases: Resource { return resource("/purchases") }
 
     fileprivate init() {
         let networking = URLSessionConfiguration.ephemeral
@@ -83,10 +82,6 @@ class APIManager: Service {
         
         configureTransformer("/context") {
             try self.jsonDecoder.decode(Context.self, from: $0.content)
-        }
-
-        configureTransformer("/purchases") {
-            try self.jsonDecoder.decode([PurchaseModel].self, from: $0.content)
         }
     }
 }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -55,11 +55,6 @@ class APIManager: Service {
         configureTransformer("/regions/*/kyc/jumio/scans") {
             try self.jsonDecoder.decode(Scan.self, from: $0.content)
         }
-        
-        configureTransformer("/regions/sg/kyc/myInfo/*") {
-            try self.jsonDecoder.decode(MyInfoDetails.self, from: $0.content)
-        }
-
         configureTransformer("/regions/*/simProfiles", requestMethods: [.post]) {
             try self.jsonDecoder.decode(SimProfile.self, from: $0.content)
         }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -86,10 +86,6 @@ class APIManager: Service {
             try self.jsonDecoder.decode(Context.self, from: $0.content)
         }
 
-        configureTransformer("/products") {
-            try self.jsonDecoder.decode([ProductModel].self, from: $0.content)
-        }
-
         configureTransformer("/bundles") {
             try self.jsonDecoder.decode([BundleModel].self, from: $0.content)
         }

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
+import ostelco_core
 import UIKit
 
 class MyInfoSummaryViewController: UIViewController {

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -25,29 +25,28 @@ class MyInfoSummaryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         debugPrint("Query Items: \(String(describing: myInfoQueryItems))")
-        spinnerView = self.showSpinner(onView: self.view)
-        if let code = getMyInfoCode() {
-            print("Code = \(code)")
-            APIManager.sharedInstance.regions.child("/sg/kyc/myInfo").child(code).load()
-                .onSuccess { entity in
-                    DispatchQueue.main.async {
-                        if let myInfoDetails: MyInfoDetails = entity.typedContent(ifNone: nil) {
-                            self.myInfoDetails = myInfoDetails
-                            self.updateUI(myInfoDetails)
-                        }
-                        self.removeSpinner(self.spinnerView)
-                    }
-                }
-                .onFailure { error in
-                    DispatchQueue.main.async {
-                        self.removeSpinner(self.spinnerView)
-                        self.showAPIError(error: error)
-                    }
-            }
+        self.spinnerView = self.showSpinner(onView: self.view)
+        
+        guard let code = getMyInfoCode() else {
+            return
         }
+        
         //TODO: Pass the code we retrieved to PRIME
-        //TODO: Get the address & phone number form PRIME
-        // updateUI(MyInfoDetails.testInfo) // TODO: Remove this when API is stable.
+        debugPrint("Code = \(code)")
+        APIManager.sharedInstance.loggedInAPI
+            .loadSingpassInfo(code: code)
+            .ensure { [weak self] in
+                self?.removeSpinner(self?.spinnerView)
+                self?.spinnerView = nil
+            }
+            .done { [weak self] myInfoDetails in
+                self?.myInfoDetails = myInfoDetails
+                self?.updateUI(myInfoDetails)
+            }
+            .catch { [weak self] error in
+                ApplicationErrors.log(error)
+                self?.showGenericError(error: error)
+            }
     }
     
     private func getMyInfoCode() -> String? {

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import PassKit
+import PromiseKit
 import ostelco_core
 
 // This is the base class for both HomeViewController and BecomeAMemberViewController
@@ -40,24 +41,12 @@ class ApplePayViewController: UIViewController, ApplePayDelegate {
         self.showAlert(title: "Yay!", msg: "Imaginary confetti, and lots of it! \(String(describing: product?.name))")
     }
 
-    func getProducts(completionHandler: @escaping ([Product], Error?) -> Void) {
-        APIManager.sharedInstance.products.load()
-            .onSuccess { entity in
-                DispatchQueue.main.async {
-                    if let products: [ProductModel] = entity.typedContent(ifNone: nil) {
-                        products.forEach {debugPrint($0.sku, $0.properties)}
-                        let availableProducts: [Product] = products.map { Product(from: $0, countryCode: "SG") }
-                        completionHandler(availableProducts, nil)
-                    } else {
-                        completionHandler([], nil)
-                    }
-                }
+    func getProducts() -> Promise<[Product]> {
+        return APIManager.sharedInstance.loggedInAPI
+            .loadProducts()
+            .map { productModels in
+                productModels.map { Product(from: $0, countryCode: "SG") }
             }
-            .onFailure { error in
-                DispatchQueue.main.async {
-                    completionHandler([], error)
-                }
-        }
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -77,19 +77,22 @@ class HomeViewController: ApplePayViewController {
     }
 
     private func fetchProducts() {
-        getProducts { products, error in
-            self.availableProducts = products
-            if let error = error {
-                debugPrint("error fetching products \(error)")
-            } else if products.isEmpty {
-                debugPrint("No products available")
+        getProducts()
+            .done { [weak self] products in
+                products.forEach { debugPrint($0) }
+                guard let self = self else {
+                    return
+                }
+                
+                self.availableProducts = products
+                // Check if the customer is a member already.
+                self.hasSubscription = self.checkForSubscription(products)
+                // TODO: Remove this after the subscription purchase is implemented
+                self.hasSubscription = false
             }
-            self.availableProducts.forEach {debugPrint($0.name, $0.amount, $0.currency, $0.country, $0.sku)}
-            // Check if the customer is a member already.
-            self.hasSubscription = self.checkForSubscription(products)
-            // TODO: Remove this after the subscription purchase is implemented
-            self.hasSubscription = false
-        }
+            .catch { error in
+                debugPrint("error fetching products \(error)")
+            }
     }
 
     override func paymentSuccessful(_ product: Product?) {


### PR DESCRIPTION
In this PR: 
- Migrated most things using `load()` for `GET` API calls from Siesta to `LoggedInAPI`, which is using promise wrappers and handling data parsing under the hood.
- Removed no-longer-needed transformers from `APIManager`
- Moved `MyInfoDetails` to core. 
- Removed deprecated `Product` initializer and gave it a debugDescription

Future PRs (ie, things NOT done in this PR): 
- Update base pipeline based on final auth decision. **NOTE: This means auto-refreshing of tokens won't work on the migrated calls until that's done.** 
- Migrate the `context` calls using `load()` - right now that whole thing is a rat's nest in two different places, and I wanted to try and focus on some more low-hanging fruit first.
- Migrate stuff using `request` (most of which requires a bit more work). 