### PR TITLE
Add ability to have query parameters on a `Request`

### DIFF
--- a/dev-ostelco-ios-clientTests/RequestGeneratorTests.swift
+++ b/dev-ostelco-ios-clientTests/RequestGeneratorTests.swift
@@ -96,4 +96,30 @@ class RequestGeneratorTests: XCTestCase {
         XCTAssertEqual(headers[HeaderKey.contentType.rawValue], "TEST")
         XCTAssertEqual(headers[HeaderKey.authorization.rawValue], "Bearer Testing!")
     }
+    
+    func testCreatingRequestWithQueryItems() throws {
+        let queryParams = [
+            URLQueryItem(name: "test_key", value: "Test Value"),
+            URLQueryItem(name: "date", value: "2019-05-08")
+        ]
+        
+        let request = Request(baseURL: self.baseURL,
+                              path: "query/params",
+                              queryItems: queryParams,
+                              loggedIn: false,
+                              secureStorage: self.storage)
+        
+        let urlRequest = try request.toURLRequest()
+        XCTAssertEqual(urlRequest.httpMethod, HTTPMethod.GET.rawValue)
+        XCTAssertNil(urlRequest.httpBody)
+        
+        XCTAssertEqual(urlRequest.url?.absoluteString, "https://www.test.nl/api/query/params?test_key=Test%20Value&date=2019-05-08")
+        guard let headers = urlRequest.allHTTPHeaderFields else {
+            XCTFail("Could not access headers!")
+            return
+        }
+        
+        XCTAssertEqual(headers.count, 1)
+        XCTAssertEqual(headers[HeaderKey.contentType.rawValue], HeaderValue.applicationJSON.toString)
+    }
 }

--- a/ostelco-core/Network/Request.swift
+++ b/ostelco-core/Network/Request.swift
@@ -10,20 +10,27 @@ import Foundation
 
 public struct Request {
     
+    enum Error: Swift.Error {
+        case couldntConstructURLFromComponents
+    }
+    
     public let baseURL: URL
     public let path: String
     public let loggedIn: Bool
     public let secureStorage: SecureStorage
     public let method: HTTPMethod
+    public let queryItems: [URLQueryItem]?
     
     public init(baseURL: URL,
                 path: String,
                 method: HTTPMethod = .GET,
+                queryItems: [URLQueryItem]? = nil,
                 loggedIn: Bool,
                 secureStorage: SecureStorage) {
         self.baseURL = baseURL
         self.path = path
         self.method = method
+        self.queryItems = queryItems
         self.loggedIn = loggedIn
         self.secureStorage = secureStorage
     }
@@ -32,7 +39,12 @@ public struct Request {
     public var bodyData: Data?
     
     public func toURLRequest() throws -> URLRequest {
-        let url = self.baseURL.appendingPathComponent(self.path)
+        var urlComponents = URLComponents(string: self.baseURL.appendingPathComponent(self.path).absoluteString)
+        urlComponents?.queryItems = self.queryItems
+        guard let url = urlComponents?.url else {
+            throw Error.couldntConstructURLFromComponents
+        }
+        
         var request = URLRequest(url: url)
         request.httpMethod = self.method.rawValue
         

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -11,7 +11,6 @@ import OstelcoStyles
 import PromiseKit
 import UIKit
 
-
 class HomeViewController: ApplePayViewController {
 
     static var newSubscriber = false


### PR DESCRIPTION
In this PR: 
- Added and tested ability to have `URLQueryItem`s on a `Request`.
- Resolved whitespace warning from SwiftLint.