### PR TITLE
Firebase pt. 2: Refactor all APIs to use PrimeAPI

### DIFF
--- a/ostelco-core/Models/EKYCProfileUpdate.swift
+++ b/ostelco-core/Models/EKYCProfileUpdate.swift
@@ -1,0 +1,20 @@
+//
+//  EKYCProfileUpdate.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/9/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct EKYCProfileUpdate: Codable {
+    public let address: String
+    public let phoneNumber: String
+    
+    public init(address: String,
+                phoneNumber: String) {
+        self.address = address
+        self.phoneNumber = phoneNumber
+    }
+}

--- a/ostelco-core/Models/PaymentInfo.swift
+++ b/ostelco-core/Models/PaymentInfo.swift
@@ -1,0 +1,17 @@
+//
+//  SourceInfo.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/8/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct PaymentInfo: Codable {
+    public let sourceId: String
+    
+    public init(sourceID: String) {
+        self.sourceId = sourceID
+    }
+}

--- a/ostelco-core/Models/PushToken.swift
+++ b/ostelco-core/Models/PushToken.swift
@@ -1,0 +1,23 @@
+//
+//  PushToken.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/9/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct PushToken: Codable {
+    public let token: String
+    public let tokenType: String
+    public let applicationID: String
+    
+    public init(token: String,
+                tokenType: String = "FCM",
+                applicationID: String) {
+        self.token = token
+        self.tokenType = tokenType
+        self.applicationID = applicationID
+    }
+}

--- a/ostelco-core/Models/Scan.swift
+++ b/ostelco-core/Models/Scan.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-struct Scan: Codable {
-    let countryCode: String
-    let scanId: String
-    let status: String
+public struct Scan: Codable {
+    public let countryCode: String
+    public let scanId: String
+    public let status: String
 }

--- a/ostelco-core/Models/SimProfileRequest.swift
+++ b/ostelco-core/Models/SimProfileRequest.swift
@@ -1,0 +1,17 @@
+//
+//  SimProfileRequest.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/9/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct SimProfileRequest: Codable {
+    public let profileType: String
+    
+    public init() {
+        self.profileType = "iphone"
+    }
+}

--- a/ostelco-core/Network/APIEndpoint.swift
+++ b/ostelco-core/Network/APIEndpoint.swift
@@ -75,3 +75,17 @@ public enum RegionEndpoint: APIEndpoint {
         }
     }
 }
+
+public enum ProductEndpoint: APIEndpoint {
+    case sku(_ sku: String)
+    case purchase
+    
+    var value: String {
+        switch self {
+        case .sku(let sku):
+            return sku
+        case .purchase:
+            return "purchase"
+        }
+    }
+}

--- a/ostelco-core/Network/APIEndpoint.swift
+++ b/ostelco-core/Network/APIEndpoint.swift
@@ -24,6 +24,7 @@ extension APIEndpoint {
 }
 
 public enum RootEndpoint: String, APIEndpoint {
+    case applicationToken
     case bundles
     case context
     case customer

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -239,6 +239,29 @@ open class LoggedInAPI: BasicNetwork {
             }
     }
     
+    /// Updates the user's EKYC profile with the given information in the given region.
+    ///
+    /// - Parameters:
+    ///   - update: The info to be updated.
+    ///   - code: The region to update the user profile in
+    /// - Returns: A promise which when fulfilled, indicates successful completion of the operation.
+    public func updateEKYCProfile(with update: EKYCProfileUpdate, forRegion code: String) -> Promise<Void> {
+        let endpoints: [RegionEndpoint] = [
+            .region(code: code),
+            .kyc,
+            .profile
+        ]
+        
+        let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
+
+        return self.sendObject(update, to: path, method: .PUT)
+            .map { data, response in
+                try APIHelper.validateAndLookForServerError(data: data,
+                                                            response: response,
+                                                            decoder: self.decoder)
+            }
+    }
+    
     /// Validates the given NRIC.
     ///
     /// - Parameters:

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -45,6 +45,17 @@ open class LoggedInAPI: BasicNetwork {
         self.tokenProvider = tokenProvider
     }
     
+    /// Uploads the device's push token to the server.
+    ///
+    /// - Parameter pushToken: The push token to send
+    /// - Returns: A promise which, when fulfilled, indicates the token was sent successfully.
+    public func sendPushToken(_ pushToken: PushToken) -> Promise<Void> {
+        return self.sendObject(pushToken, to: RootEndpoint.applicationToken.value, method: .POST)
+            .map { data, response in
+                try APIHelper.validateAndLookForServerError(data: data, response: response, decoder: self.decoder)
+            }
+    }
+    
     /// - Returns: A Promise which which when fulfilled will contain the user's bundle models
     public func loadBundles() -> Promise<[BundleModel]> {
         return self.loadData(from: RootEndpoint.bundles.value)

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -168,6 +168,25 @@ open class LoggedInAPI: BasicNetwork {
             .map { try self.decoder.decode([SimProfile].self, from: $0) }
     }
     
+    /// Creates a SIM profile for the given region
+    ///
+    /// - Parameter code: The region code to use
+    /// - Returns: A promise which, when fulfilled, will contain the created SIM profile.
+    public func createSimProfileForRegion(code: String) -> Promise<SimProfile> {
+        let endpoints: [RegionEndpoint] = [
+            .region(code: code),
+            .simProfiles
+        ]
+    
+        let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
+        
+        return self.sendObject(SimProfileRequest(), to: path, method: .POST)
+            .map { data, response in
+                try APIHelper.validateResponse(data: data, response: response)
+            }
+            .map { try self.decoder.decode(SimProfile.self, from: $0) }
+    }
+    
     /// Creates a Jumio scan request for the given region
     ///
     /// - Parameter code: The region to request a Jumio scan request for

--- a/ostelco-core/Network/LoggedInAPI.swift
+++ b/ostelco-core/Network/LoggedInAPI.swift
@@ -167,6 +167,24 @@ open class LoggedInAPI: BasicNetwork {
         return self.loadData(from: path)
             .map { try self.decoder.decode([SimProfile].self, from: $0) }
     }
+    
+    /// Creates a Jumio scan request for the given region
+    ///
+    /// - Parameter code: The region to request a Jumio scan request for
+    /// - Returns: A promise which when fulfilled contains the requested data
+    public func createJumioScanForRegion(code: String) -> Promise<Scan> {
+        let endpoints: [RegionEndpoint] = [
+            .region(code: code),
+            .kyc,
+            .jumio,
+            .scans,
+        ]
+        
+        let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
+        
+        return self.loadData(from: path)
+            .map { try self.decoder.decode(Scan.self, from: $0) }
+    }
 
     /// - Returns: A promise which when fulfilled will contain the relevant region response for this user.
     public func getRegionFromRegions() -> Promise<RegionResponse> {

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -1,5 +1,5 @@
 //
-//  LoggedInAPI.swift
+//  PrimeAPI.swift
 //  ostelco-core
 //
 //  Created by Ellen Shapiro on 4/10/19.
@@ -9,8 +9,8 @@
 import PromiseKit
 import Foundation
 
-/// A class to wrap APIs called once the user is logged in.
-open class LoggedInAPI: BasicNetwork {
+/// A class to wrap APIs controlled by the Prime backend.
+open class PrimeAPI: BasicNetwork {
     
     enum Error: Swift.Error, LocalizedError {
         case failedToGetRegion

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -183,7 +183,7 @@
 		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B920F65225B8EC6001EF9CD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F64225B8EC6001EF9CD /* Theme.swift */; };
 		9B920F66225B8EE1001EF9CD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F64225B8EC6001EF9CD /* Theme.swift */; };
-		9B9B3243225E3B7B00227EA3 /* LoggedInAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9B3242225E3B7B00227EA3 /* LoggedInAPI.swift */; };
+		9B9B3243225E3B7B00227EA3 /* PrimeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */; };
 		9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044881A7217BA32B00F59758 /* PurchaseModel.swift */; };
 		9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0448819D217B4E4E00F59758 /* BundleModel.swift */; };
 		9B9B324A225E3D3900227EA3 /* ProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044881A9217BA35C00F59758 /* ProductModel.swift */; };
@@ -494,7 +494,7 @@
 		9B851AE7225E36F90076ABF3 /* RemainingDataViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RemainingDataViewController.xib; sourceTree = "<group>"; };
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B920F64225B8EC6001EF9CD /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
-		9B9B3242225E3B7B00227EA3 /* LoggedInAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedInAPI.swift; sourceTree = "<group>"; };
+		9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeAPI.swift; sourceTree = "<group>"; };
 		9B9B324D225E411700227EA3 /* APIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
 		9B9B324F225E423A00227EA3 /* Collection+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Empty.swift"; sourceTree = "<group>"; };
 		9B9B3251225E7CCD00227EA3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -845,7 +845,7 @@
 				9B821595227ADCE000DC6B64 /* BasicNetwork.swift */,
 				9B8215752279B0F800DC6B64 /* Headers.swift */,
 				9B821591227AD9EA00DC6B64 /* HTTPMethod.swift */,
-				9B9B3242225E3B7B00227EA3 /* LoggedInAPI.swift */,
+				9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */,
 				9B821593227ADA1000DC6B64 /* Request.swift */,
 			);
 			path = Network;
@@ -1888,7 +1888,7 @@
 				9B821599227AFC4700DC6B64 /* ServerError.swift in Sources */,
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
-				9B9B3243225E3B7B00227EA3 /* LoggedInAPI.swift in Sources */,
+				9B9B3243225E3B7B00227EA3 /* PrimeAPI.swift in Sources */,
 				9B6A92892284209A007F5EC9 /* PushToken.swift in Sources */,
 				9B821594227ADA1000DC6B64 /* Request.swift in Sources */,
 				9B560A9C2273289D004473E1 /* PageControllerDataSource.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -27,8 +27,6 @@
 		042928F3223D0BE700806438 /* NRCIVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042928F1223D0BE700806438 /* NRCIVerifyViewController.swift */; };
 		042928F8223D4D8800806438 /* SignUpCompletedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042928F7223D4D8800806438 /* SignUpCompletedViewController.swift */; };
 		042928F9223D4D8800806438 /* SignUpCompletedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042928F7223D4D8800806438 /* SignUpCompletedViewController.swift */; };
-		0437CF80224D08660022A2B8 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
-		0437CF81224D08660022A2B8 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
 		043E710E2239F17200E01993 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E710D2239F17200E01993 /* main.swift */; };
 		043E710F2239F17200E01993 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E710D2239F17200E01993 /* main.swift */; };
 		043E711B223AF3CF00E01993 /* OnBoardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E711A223AF3CF00E01993 /* OnBoardingManager.swift */; };
@@ -146,6 +144,7 @@
 		9B6A927F22832F5B007F5EC9 /* PaymentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */; };
 		9B6A928122833242007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
 		9B6A92822283330A007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
+		9B6A928322833586007F5EC9 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
 		9B6E3A11226F6FDE0063EBAA /* SFProText-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */; };
 		9B6E3A12226F6FE30063EBAA /* SFProText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */; };
 		9B6E3A13226F6FE90063EBAA /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */; };
@@ -754,7 +753,6 @@
 				9BBF70482265D4D200E4B9B4 /* MyInfoDetails+Testing.swift */,
 				0485339F223C1882007C89F4 /* Product.swift */,
 				C2C3EAD32270B43200585FA4 /* PurchaseRecord.swift */,
-				0437CF7F224D08660022A2B8 /* Scan.swift */,
 				9B17457F227722C200CF321B /* ValidationState.swift */,
 				044725AE2281B7E6006184E5 /* ExternalLink.swift */,
 			);
@@ -898,6 +896,7 @@
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
 				044881A1217B896800F59758 /* ProfileModel.swift */,
 				0437CF82224D1DAE0022A2B8 /* Region.swift */,
+				0437CF7F224D08660022A2B8 /* Scan.swift */,
 				0493B80E2253943900989F40 /* ServerError.swift */,
 				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
 				9B5CBF3A22803A9A00D83D7B /* UserSetup.swift */,
@@ -1801,7 +1800,6 @@
 				047B2795223BB8D900EE134B /* SettingsTableViewController.swift in Sources */,
 				047F29032224460B00FC6A8F /* LoginViewController.swift in Sources */,
 				9BBF70712267423A00E4B9B4 /* UIApplication+TypedDelegate.swift in Sources */,
-				0437CF80224D08660022A2B8 /* Scan.swift in Sources */,
 				9B4DAD922281A2CE003810BE /* RootCoordinator.swift in Sources */,
 				042928F2223D0BE700806438 /* NRCIVerifyViewController.swift in Sources */,
 				041216AF22281CE000455278 /* AllowLocationAccessViewController.swift in Sources */,
@@ -1871,6 +1869,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B6A928322833586007F5EC9 /* Scan.swift in Sources */,
 				9BBF706B2266162F00E4B9B4 /* UITableView+Generics.swift in Sources */,
 				9BBF707A22675C3900E4B9B4 /* Array+FancyAppend.swift in Sources */,
 				9B8215822279DF6900DC6B64 /* Region.swift in Sources */,
@@ -1961,7 +1960,6 @@
 				9B17457E2277033300CF321B /* AddressEditViewController.swift in Sources */,
 				9B17456A2276D75700CF321B /* ScanICStepsViewController.swift in Sources */,
 				043E711C223AF3CF00E01993 /* OnBoardingManager.swift in Sources */,
-				0437CF81224D08660022A2B8 /* Scan.swift in Sources */,
 				04834D66223020DA00A01500 /* UIButton+Border.swift in Sources */,
 				0412168D2226BBBA00455278 /* GetStartedViewController.swift in Sources */,
 				9BE2D45F225B651600B51999 /* UIApplicaiton+Testing.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		9B6A928122833242007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
 		9B6A92822283330A007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
 		9B6A928322833586007F5EC9 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
+		9B6A9285228418A4007F5EC9 /* SimProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */; };
 		9B6E3A11226F6FDE0063EBAA /* SFProText-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */; };
 		9B6E3A12226F6FE30063EBAA /* SFProText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */; };
 		9B6E3A13226F6FE90063EBAA /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */; };
@@ -460,6 +461,7 @@
 		9B5CBF5522818A0F00D83D7B /* MockTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenProvider.swift; sourceTree = "<group>"; };
 		9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentInfo.swift; sourceTree = "<group>"; };
 		9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAPIClient+PromiseKit.swift"; sourceTree = "<group>"; };
+		9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimProfileRequest.swift; sourceTree = "<group>"; };
 		9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Heavy.otf"; sourceTree = "<group>"; };
 		9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Bold.otf"; sourceTree = "<group>"; };
 		9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Regular.otf"; sourceTree = "<group>"; };
@@ -899,6 +901,7 @@
 				0437CF7F224D08660022A2B8 /* Scan.swift */,
 				0493B80E2253943900989F40 /* ServerError.swift */,
 				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
+				9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */,
 				9B5CBF3A22803A9A00D83D7B /* UserSetup.swift */,
 			);
 			path = Models;
@@ -1888,6 +1891,7 @@
 				9BBF70572265EE4F00E4B9B4 /* Identifiable.swift in Sources */,
 				9B9B3250225E423A00227EA3 /* Collection+Empty.swift in Sources */,
 				9B5CBF3922803A7E00D83D7B /* CustomerModel.swift in Sources */,
+				9B6A9285228418A4007F5EC9 /* SimProfileRequest.swift in Sources */,
 				9B821592227AD9EA00DC6B64 /* HTTPMethod.swift in Sources */,
 				9B9B324E225E411700227EA3 /* APIHelper.swift in Sources */,
 				9B851AE1225E33350076ABF3 /* RemainingDataViewController.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		9B6A928322833586007F5EC9 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
 		9B6A9285228418A4007F5EC9 /* SimProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */; };
 		9B6A928722841C38007F5EC9 /* EKYCProfileUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */; };
+		9B6A92892284209A007F5EC9 /* PushToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A92882284209A007F5EC9 /* PushToken.swift */; };
 		9B6E3A11226F6FDE0063EBAA /* SFProText-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */; };
 		9B6E3A12226F6FE30063EBAA /* SFProText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */; };
 		9B6E3A13226F6FE90063EBAA /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */; };
@@ -464,6 +465,7 @@
 		9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAPIClient+PromiseKit.swift"; sourceTree = "<group>"; };
 		9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimProfileRequest.swift; sourceTree = "<group>"; };
 		9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCProfileUpdate.swift; sourceTree = "<group>"; };
+		9B6A92882284209A007F5EC9 /* PushToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushToken.swift; sourceTree = "<group>"; };
 		9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Heavy.otf"; sourceTree = "<group>"; };
 		9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Bold.otf"; sourceTree = "<group>"; };
 		9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Regular.otf"; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				044881A7217BA32B00F59758 /* PurchaseModel.swift */,
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
 				044881A1217B896800F59758 /* ProfileModel.swift */,
+				9B6A92882284209A007F5EC9 /* PushToken.swift */,
 				0437CF82224D1DAE0022A2B8 /* Region.swift */,
 				0437CF7F224D08660022A2B8 /* Scan.swift */,
 				0493B80E2253943900989F40 /* ServerError.swift */,
@@ -1886,6 +1889,7 @@
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
 				9B9B3243225E3B7B00227EA3 /* LoggedInAPI.swift in Sources */,
+				9B6A92892284209A007F5EC9 /* PushToken.swift in Sources */,
 				9B821594227ADA1000DC6B64 /* Request.swift in Sources */,
 				9B560A9C2273289D004473E1 /* PageControllerDataSource.swift in Sources */,
 				9BBF7069226613C400E4B9B4 /* GenericDataSource.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		9B6A92822283330A007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
 		9B6A928322833586007F5EC9 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0437CF7F224D08660022A2B8 /* Scan.swift */; };
 		9B6A9285228418A4007F5EC9 /* SimProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */; };
+		9B6A928722841C38007F5EC9 /* EKYCProfileUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */; };
 		9B6E3A11226F6FDE0063EBAA /* SFProText-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */; };
 		9B6E3A12226F6FE30063EBAA /* SFProText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */; };
 		9B6E3A13226F6FE90063EBAA /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */; };
@@ -462,6 +463,7 @@
 		9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentInfo.swift; sourceTree = "<group>"; };
 		9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAPIClient+PromiseKit.swift"; sourceTree = "<group>"; };
 		9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimProfileRequest.swift; sourceTree = "<group>"; };
+		9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCProfileUpdate.swift; sourceTree = "<group>"; };
 		9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Heavy.otf"; sourceTree = "<group>"; };
 		9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Bold.otf"; sourceTree = "<group>"; };
 		9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Regular.otf"; sourceTree = "<group>"; };
@@ -890,6 +892,7 @@
 				043E711D223AF61600E01993 /* Country.swift */,
 				04834D712237B11800A01500 /* CustomerModel.swift */,
 				9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */,
+				9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */,
 				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
 				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
@@ -1890,6 +1893,7 @@
 				9BC465392271ACC3001951BF /* Country.swift in Sources */,
 				9BBF70572265EE4F00E4B9B4 /* Identifiable.swift in Sources */,
 				9B9B3250225E423A00227EA3 /* Collection+Empty.swift in Sources */,
+				9B6A928722841C38007F5EC9 /* EKYCProfileUpdate.swift in Sources */,
 				9B5CBF3922803A7E00D83D7B /* CustomerModel.swift in Sources */,
 				9B6A9285228418A4007F5EC9 /* SimProfileRequest.swift in Sources */,
 				9B821592227AD9EA00DC6B64 /* HTTPMethod.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -2485,7 +2485,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDevelopment;
 				CODE_SIGN_ENTITLEMENTS = "ostelco-ios-client/SupportingFiles/dev-ostelco-ios-client.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_TEAM = 2R8HFAXUXD;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2498,7 +2498,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = sg.redotter.dev.selfcare;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)_app";
 				PRODUCT_NAME = "Oya-Development";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development sg.redotter.dev.selfcare";
 				SWIFT_OBJC_BRIDGING_HEADER = "ostelco-ios-client/SupportingFiles/ostelco-ios-client-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2514,8 +2514,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDevelopment;
 				CODE_SIGN_ENTITLEMENTS = "ostelco-ios-client/SupportingFiles/dev-ostelco-ios-client.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_TEAM = 2R8HFAXUXD;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2528,7 +2528,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = sg.redotter.dev.selfcare;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)_app";
 				PRODUCT_NAME = "Oya-Development";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore sg.redotter.dev.selfcare";
 				SWIFT_OBJC_BRIDGING_HEADER = "ostelco-ios-client/SupportingFiles/ostelco-ios-client-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 		9B5CBF542281888A00D83D7B /* FirebaseAuthUser+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5CBF52228184F100D83D7B /* FirebaseAuthUser+PromiseKit.swift */; };
 		9B5CBF5622818A0F00D83D7B /* MockTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5CBF5522818A0F00D83D7B /* MockTokenProvider.swift */; };
 		9B611A47227C8EA700194364 /* MyInfoDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */; };
+		9B6A927F22832F5B007F5EC9 /* PaymentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */; };
+		9B6A928122833242007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
+		9B6A92822283330A007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */; };
 		9B6E3A11226F6FDE0063EBAA /* SFProText-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */; };
 		9B6E3A12226F6FE30063EBAA /* SFProText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */; };
 		9B6E3A13226F6FE90063EBAA /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */; };
@@ -456,6 +459,8 @@
 		9B5CBF502281808B00D83D7B /* TokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProvider.swift; sourceTree = "<group>"; };
 		9B5CBF52228184F100D83D7B /* FirebaseAuthUser+PromiseKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuthUser+PromiseKit.swift"; sourceTree = "<group>"; };
 		9B5CBF5522818A0F00D83D7B /* MockTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenProvider.swift; sourceTree = "<group>"; };
+		9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentInfo.swift; sourceTree = "<group>"; };
+		9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAPIClient+PromiseKit.swift"; sourceTree = "<group>"; };
 		9B6E3A0C226F6FC20063EBAA /* SFProText-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Heavy.otf"; sourceTree = "<group>"; };
 		9B6E3A0D226F6FC20063EBAA /* SFProText-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Bold.otf"; sourceTree = "<group>"; };
 		9B6E3A0E226F6FC30063EBAA /* SFProText-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Regular.otf"; sourceTree = "<group>"; };
@@ -888,6 +893,7 @@
 				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
 				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
+				9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */,
 				044881A7217BA32B00F59758 /* PurchaseModel.swift */,
 				044881A9217BA35C00F59758 /* ProductModel.swift */,
 				044881A1217B896800F59758 /* ProfileModel.swift */,
@@ -1037,6 +1043,7 @@
 				9B5CBF52228184F100D83D7B /* FirebaseAuthUser+PromiseKit.swift */,
 				9BBF7074226751A200E4B9B4 /* Netverify+Ostelco.swift */,
 				04D6C9872276F7CB00AE13DD /* String+SnakeCase.swift */,
+				9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */,
 				9BE2D45D225B642500B51999 /* UIApplicaiton+Testing.swift */,
 				9BBF70702267423A00E4B9B4 /* UIApplication+TypedDelegate.swift */,
 				04834D64223020DA00A01500 /* UIButton+Border.swift */,
@@ -1819,6 +1826,7 @@
 				9BBF705D2265F04200E4B9B4 /* CountryCell.swift in Sources */,
 				04BA34A02226B8D9000359C4 /* EnableNotificationsViewController.swift in Sources */,
 				9BE2D442225B5D5100B51999 /* UIView+Shadow.swift in Sources */,
+				9B6A928122833242007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */,
 				9B4DAD992281A7E9003810BE /* EmailEntryViewController.swift in Sources */,
 				041216A9222817EC00455278 /* VerifyCountryOnBoardingViewController.swift in Sources */,
 				04D6C9882276F7CB00AE13DD /* String+SnakeCase.swift in Sources */,
@@ -1893,6 +1901,7 @@
 				9B611A47227C8EA700194364 /* MyInfoDetails.swift in Sources */,
 				9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */,
 				9BC465372270AD56001951BF /* LocationController.swift in Sources */,
+				9B6A927F22832F5B007F5EC9 /* PaymentInfo.swift in Sources */,
 				9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */,
 				9B9B324B225E3D3E00227EA3 /* ProfileModel.swift in Sources */,
 				9B5CBF512281808B00D83D7B /* TokenProvider.swift in Sources */,
@@ -1978,6 +1987,7 @@
 				9BE2D460225B651A00B51999 /* TestAppDelegate.swift in Sources */,
 				047B2799223BC38D00EE134B /* UIViewController+ActionSheet.swift in Sources */,
 				9B6E3A26227093DA0063EBAA /* LocationProblemViewController.swift in Sources */,
+				9B6A92822283330A007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */,
 				9BBF70722267427200E4B9B4 /* UIApplication+TypedDelegate.swift in Sources */,
 				047F29042224460B00FC6A8F /* LoginViewController.swift in Sources */,
 				04834D3D222EC7DC00A01500 /* UIViewController+DismissKeyboard.swift in Sources */,
@@ -2465,7 +2475,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDevelopment;
 				CODE_SIGN_ENTITLEMENTS = "ostelco-ios-client/SupportingFiles/dev-ostelco-ios-client.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_TEAM = 2R8HFAXUXD;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2478,7 +2488,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = sg.redotter.dev.selfcare;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)_app";
 				PRODUCT_NAME = "Oya-Development";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development sg.redotter.dev.selfcare";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ostelco-ios-client/SupportingFiles/ostelco-ios-client-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2494,8 +2504,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDevelopment;
 				CODE_SIGN_ENTITLEMENTS = "ostelco-ios-client/SupportingFiles/dev-ostelco-ios-client.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_TEAM = 2R8HFAXUXD;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2508,7 +2518,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = sg.redotter.dev.selfcare;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)_app";
 				PRODUCT_NAME = "Oya-Development";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore sg.redotter.dev.selfcare";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "ostelco-ios-client/SupportingFiles/ostelco-ios-client-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -6,12 +6,13 @@
 //  Copyright © 2018 mac. All rights reserved.
 //
 
-import UIKit
-import Stripe
 import Firebase
+import FirebaseDynamicLinks
+import FirebaseMessaging
 import ostelco_core
 import PromiseKit
-import Siesta
+import Stripe
+import UIKit
 import UserNotifications
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -36,13 +37,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let bundleIndentifier = Bundle.main.bundleIdentifier {
             if bundleIndentifier.contains("dev") {
                 ThemeManager.applyTheme(theme: .TurquoiseTheme)
-                SiestaLog.Category.enabled = .all
             } else {
                 ThemeManager.applyTheme(theme: .BlueTheme)
             }
         } else {
             ThemeManager.applyTheme(theme: .TurquoiseTheme)
-            SiestaLog.Category.enabled = .all
         }
         
         let freschatConfig: FreshchatConfig = FreshchatConfig(appID: Environment().configuration(.FreshchatAppID), andAppKey: Environment().configuration(.FreshchatAppKey))

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -130,7 +130,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if EmailLinkManager.isSignInLink(incomingURL) {
             EmailLinkManager.signInWithLink(incomingURL)
                 .then {
-                    UserManager.sharedInstance.getDestinationFromContext()
+                    UserManager.shared.getDestinationFromContext()
                 }
                 .done { [weak self] destination in
                     self?.rootCoordinator.navigate(to: destination, from: nil)
@@ -283,7 +283,7 @@ extension AppDelegate: MessagingDelegate {
     
     func sendFCMToken() {
         guard
-            UserManager.sharedInstance.firebaseUser != nil,
+            UserManager.shared.firebaseUser != nil,
             let token = fcmToken else {
                 // Wait to be authenticated, or the token to be ready.
                 return

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -293,7 +293,7 @@ extension AppDelegate: MessagingDelegate {
         let appId = "\(Bundle.main.bundleIdentifier!).\(UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString)"
         
         let pushToken = PushToken(token: token, applicationID: appId)
-        APIManager.sharedInstance.loggedInAPI.sendPushToken(pushToken)
+        APIManager.shared.loggedInAPI.sendPushToken(pushToken)
             .done {
                 debugPrint("Set new FCM token: \(token)")
             }

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -293,7 +293,7 @@ extension AppDelegate: MessagingDelegate {
         let appId = "\(Bundle.main.bundleIdentifier!).\(UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString)"
         
         let pushToken = PushToken(token: token, applicationID: appId)
-        APIManager.shared.loggedInAPI.sendPushToken(pushToken)
+        APIManager.shared.primeAPI.sendPushToken(pushToken)
             .done {
                 debugPrint("Set new FCM token: \(token)")
             }

--- a/ostelco-ios-client/Extensions/STPAPIClient+PromiseKit.swift
+++ b/ostelco-ios-client/Extensions/STPAPIClient+PromiseKit.swift
@@ -1,0 +1,36 @@
+//
+//  STPAPIClient+PromiseKit.swift
+//  ostelco-ios-client
+//
+//  Created by Ellen Shapiro on 5/8/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+import Stripe
+
+extension STPAPIClient {
+    
+    enum Error: Swift.Error {
+        case noSourceAndNoError
+    }
+    
+    func promiseCreateSource(with payment: PKPayment) -> Promise<STPSource> {
+        return Promise { seal in
+            self.createSource(with: payment) { source, error in
+                if let stripeError = error {
+                    seal.reject(stripeError)
+                    return
+                }
+                
+                guard let source = source else {
+                    seal.reject(Error.noSourceAndNoError)
+                    return
+                }
+                
+                seal.fulfill(source)
+            }
+        }
+    }
+}

--- a/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
@@ -33,7 +33,7 @@ func createDeleteAccountAlertAction(title: String, vc: UIViewController) -> UIAl
                 vc?.removeSpinner(spinnerView)
             }
             .done { [weak vc] in
-                UserManager.sharedInstance.logOut()
+                UserManager.shared.logOut()
                 vc?.showSplashScreen()
             }
             .catch { [weak vc] error in
@@ -77,7 +77,7 @@ extension UIViewController {
         let alertCtrl = UIAlertController(title: nil, message: "Are you sure that you want to log out from your account?", preferredStyle: .actionSheet)
         
         let logOutAction = UIAlertAction(title: "Log Out", style: .destructive) {_ in
-            UserManager.sharedInstance.logOut()
+            UserManager.shared.logOut()
             let viewController = UIStoryboard(name: "Login", bundle: nil).instantiateInitialViewController()!
             self.present(viewController, animated: true)
         }
@@ -97,7 +97,7 @@ extension UIViewController {
         }
         let startOverAction = createDeleteAccountAlertAction(title: "Start Again", vc: self)
         let logOutAction = UIAlertAction(title: "Log Out", style: .default) {_ in
-            UserManager.sharedInstance.logOut()
+            UserManager.shared.logOut()
             let viewController = UIStoryboard(name: "Login", bundle: nil).instantiateInitialViewController()!
             self.present(viewController, animated: true)
         }

--- a/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
@@ -28,7 +28,7 @@ class NeedHelpAlertController: UIAlertController {
 func createDeleteAccountAlertAction(title: String, vc: UIViewController) -> UIAlertAction {
     let alertAction = UIAlertAction(title: title, style: .destructive) {_ in
         let spinnerView = vc.showSpinner(onView: vc.view)
-        APIManager.shared.loggedInAPI.deleteCustomer()
+        APIManager.shared.primeAPI.deleteCustomer()
             .ensure { [weak vc] in
                 vc?.removeSpinner(spinnerView)
             }

--- a/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
@@ -28,7 +28,7 @@ class NeedHelpAlertController: UIAlertController {
 func createDeleteAccountAlertAction(title: String, vc: UIViewController) -> UIAlertAction {
     let alertAction = UIAlertAction(title: title, style: .destructive) {_ in
         let spinnerView = vc.showSpinner(onView: vc.view)
-        APIManager.sharedInstance.loggedInAPI.deleteCustomer()
+        APIManager.shared.loggedInAPI.deleteCustomer()
             .ensure { [weak vc] in
                 vc?.removeSpinner(spinnerView)
             }

--- a/ostelco-ios-client/Extensions/UIViewController+Alerts.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+Alerts.swift
@@ -7,30 +7,8 @@
 //
 
 import UIKit
-import Siesta
 
 extension UIViewController {
-    
-    func showAPIError(error: RequestError, completion: ((_:UIAlertAction) -> Void)? = nil) {
-        var message = ""
-        if let statusCode = error.httpStatusCode {
-            message += "\(statusCode): "
-        }
-        message += error.userMessage
-        
-        var title = ""
-        if error.cause != nil {
-            title += "Internal client error"
-        }
-        if error.entity != nil {
-            title += "Domain specific error"
-        }
-        
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: completion))
-        
-        present(alert, animated: true, completion: nil)
-    }
     
     func showGenericError(error: Error) {
         let title = "Error"

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -45,9 +45,5 @@ class APIManager: Service {
             $0.headers["Content-Type"] = "application/json"
             $0.headers["Authorization"] = self.authHeader
         }
-        
-        configureTransformer("/regions/*/simProfiles", requestMethods: [.post]) {
-            try self.jsonDecoder.decode(SimProfile.self, from: $0.content)
-        }
     }
 }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -46,9 +46,6 @@ class APIManager: Service {
             $0.headers["Authorization"] = self.authHeader
         }
         
-        configureTransformer("/regions/*/kyc/jumio/scans") {
-            try self.jsonDecoder.decode(Scan.self, from: $0.content)
-        }
         configureTransformer("/regions/*/simProfiles", requestMethods: [.post]) {
             try self.jsonDecoder.decode(SimProfile.self, from: $0.content)
         }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-import PromiseKit
-import Siesta
 import ostelco_core
+import PromiseKit
 
-class APIManager: Service {
+class APIManager {
     
     static let sharedInstance = APIManager()
     

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -13,9 +13,9 @@ class APIManager {
     
     static let shared = APIManager()
     
-    lazy var loggedInAPI: LoggedInAPI = {
+    lazy var primeAPI: PrimeAPI = {
         let baseURLString = Environment().configuration(PlistKey.ServerURL)
-        return LoggedInAPI(baseURL: baseURLString,
+        return PrimeAPI(baseURL: baseURLString,
                            tokenProvider: self.tokenProvider)
     }()
     

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -28,7 +28,6 @@ class APIManager: Service {
         }
     }
     
-    var products: Resource { return resource("/products") }
     var regions: Resource { return resource("/regions") }
     
     var tokenProvider: TokenProvider = UserManager.sharedInstance

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -19,7 +19,7 @@ class APIManager {
                            tokenProvider: self.tokenProvider)
     }()
     
-    var tokenProvider: TokenProvider = UserManager.sharedInstance
+    var tokenProvider: TokenProvider = UserManager.shared
 
     fileprivate init() {
         URLSession.shared.configuration.timeoutIntervalForRequest = 300

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -11,7 +11,7 @@ import PromiseKit
 
 class APIManager {
     
-    static let sharedInstance = APIManager()
+    static let shared = APIManager()
     
     lazy var loggedInAPI: LoggedInAPI = {
         let baseURLString = Environment().configuration(PlistKey.ServerURL)

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -13,7 +13,6 @@ import ostelco_core
 class APIManager: Service {
     
     static let sharedInstance = APIManager()
-    let jsonDecoder = JSONDecoder()
     
     lazy var loggedInAPI: LoggedInAPI = {
         let baseURLString = Environment().configuration(PlistKey.ServerURL)
@@ -21,29 +20,9 @@ class APIManager: Service {
                            tokenProvider: self.tokenProvider)
     }()
     
-    var authHeader: String? {
-        didSet {
-            invalidateConfiguration()
-            wipeResources()
-        }
-    }
-    
-    var regions: Resource { return resource("/regions") }
-    
     var tokenProvider: TokenProvider = UserManager.sharedInstance
 
     fileprivate init() {
-        let networking = URLSessionConfiguration.ephemeral
-        networking.timeoutIntervalForRequest = 300
-        super.init(
-            baseURL: Environment().configuration(PlistKey.ServerURL),
-            standardTransformers: [.text],
-            networking: networking
-        )
-        
-        configure {
-            $0.headers["Content-Type"] = "application/json"
-            $0.headers["Authorization"] = self.authHeader
-        }
+        URLSession.shared.configuration.timeoutIntervalForRequest = 300
     }
 }

--- a/ostelco-ios-client/Network/UserManager.swift
+++ b/ostelco-ios-client/Network/UserManager.swift
@@ -16,7 +16,7 @@ class UserManager {
         case noFirebaseUser
     }
     
-    static let sharedInstance = UserManager()
+    static let shared = UserManager()
     
     var customer: CustomerModel? {
         didSet {
@@ -62,7 +62,7 @@ class UserManager {
     func getDestinationFromContext() -> Promise<PostLoginDestination> {
         return APIManager.sharedInstance.loggedInAPI.loadContext()
             .map { context -> PostLoginDestination in
-                UserManager.sharedInstance.customer = context.customer
+                UserManager.shared.customer = context.customer
                 guard let region = context.getRegion() else {
                     return .validateCountry
                 }

--- a/ostelco-ios-client/Network/UserManager.swift
+++ b/ostelco-ios-client/Network/UserManager.swift
@@ -60,7 +60,7 @@ class UserManager {
     }
     
     func getDestinationFromContext() -> Promise<PostLoginDestination> {
-        return APIManager.sharedInstance.loggedInAPI.loadContext()
+        return APIManager.shared.loggedInAPI.loadContext()
             .map { context -> PostLoginDestination in
                 UserManager.shared.customer = context.customer
                 guard let region = context.getRegion() else {

--- a/ostelco-ios-client/Network/UserManager.swift
+++ b/ostelco-ios-client/Network/UserManager.swift
@@ -60,7 +60,7 @@ class UserManager {
     }
     
     func getDestinationFromContext() -> Promise<PostLoginDestination> {
-        return APIManager.shared.loggedInAPI.loadContext()
+        return APIManager.shared.primeAPI.loadContext()
             .map { context -> PostLoginDestination in
                 UserManager.shared.customer = context.customer
                 guard let region = context.getRegion() else {

--- a/ostelco-ios-client/Protocols/ApplePayDelegate.swift
+++ b/ostelco-ios-client/Protocols/ApplePayDelegate.swift
@@ -69,7 +69,7 @@ extension ApplePayDelegate where Self: PKPaymentAuthorizationViewControllerDeleg
             .then { source -> Promise<Void> in
                 // Call Prime API to buy the product.
                 let payment = PaymentInfo(sourceID: source.stripeID)
-                return APIManager.sharedInstance.loggedInAPI.purchaseProduct(with: product.sku, payment: payment)
+                return APIManager.shared.loggedInAPI.purchaseProduct(with: product.sku, payment: payment)
             }
             .done {
                 debugPrint("Successfully bought product \(product.sku)")

--- a/ostelco-ios-client/Protocols/ApplePayDelegate.swift
+++ b/ostelco-ios-client/Protocols/ApplePayDelegate.swift
@@ -69,7 +69,7 @@ extension ApplePayDelegate where Self: PKPaymentAuthorizationViewControllerDeleg
             .then { source -> Promise<Void> in
                 // Call Prime API to buy the product.
                 let payment = PaymentInfo(sourceID: source.stripeID)
-                return APIManager.shared.loggedInAPI.purchaseProduct(with: product.sku, payment: payment)
+                return APIManager.shared.primeAPI.purchaseProduct(with: product.sku, payment: payment)
             }
             .done {
                 debugPrint("Successfully bought product \(product.sku)")

--- a/ostelco-ios-client/Protocols/ApplePayDelegate.swift
+++ b/ostelco-ios-client/Protocols/ApplePayDelegate.swift
@@ -9,7 +9,6 @@
 import Foundation
 import ostelco_core
 import PromiseKit
-import Siesta
 import Stripe
 
 enum ApplePayError: Error {

--- a/ostelco-ios-client/Protocols/ApplePayDelegate.swift
+++ b/ostelco-ios-client/Protocols/ApplePayDelegate.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import ostelco_core
+import PromiseKit
 import Siesta
 import Stripe
 
@@ -17,7 +19,7 @@ enum ApplePayError: Error {
     case otherRestrictions
     // Other errors during payment
     case userCancelled
-    case primeAPIError(RequestError)
+    case primeAPIError(Error)
 }
 
 extension ApplePayError: LocalizedError {
@@ -62,27 +64,24 @@ extension ApplePayDelegate where Self: PKPaymentAuthorizationViewControllerDeleg
                                  handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {
         authorizedApplePay = true
         let product = purchasingProduct!
+        
         // Create Stripe Source.
-        STPAPIClient.shared().createSource(with: payment) { (source: STPSource?, error: Error?) in
-            guard let source = source, error == nil else {
-                debugPrint(error!)
-                completion(PKPaymentAuthorizationResult(status: .failure, errors: [error!]))
-                self.showAlert(title: "Failed to create stripe source", msg: "\(error!.localizedDescription)")
-                return
+        STPAPIClient.shared().promiseCreateSource(with: payment)
+            .then { source -> Promise<Void> in
+                // Call Prime API to buy the product.
+                let payment = PaymentInfo(sourceID: source.stripeID)
+                return APIManager.sharedInstance.loggedInAPI.purchaseProduct(with: product.sku, payment: payment)
             }
-            // Call Prime API to buy the product.
-            APIManager.sharedInstance.products.child(product.sku).child("purchase").withParam("sourceId", source.stripeID).request(.post)
-                .onSuccess({ result in
-                    debugPrint("Successfully bought a product %{public}@", "\(result)")
-                    completion(PKPaymentAuthorizationResult(status: .success, errors: []))
-                })
-                .onFailure({ error in
-                    debugPrint("Failed to buy product with sku %{public}@, got error: %{public}@", "123", "\(error)")
-                    completion(PKPaymentAuthorizationResult(status: .failure, errors: [error]))
-                    self.applePayError = ApplePayError.primeAPIError(error)
-                    // Wait for finish method before we call paymentError()
-                })
-        }
+            .done {
+                debugPrint("Successfully bought product \(product.sku)")
+                completion(PKPaymentAuthorizationResult(status: .success, errors: []))
+            }
+            .catch { error in
+                debugPrint("Failed to buy product with sku %{public}@, got error: %{public}@", "123", "\(error)")
+                self.applePayError = ApplePayError.primeAPIError(error)
+                completion(PKPaymentAuthorizationResult(status: .failure, errors: [error]))
+                // Wait for finish method before we call paymentError()
+            }
     }
 
     func handlePaymentFinished(_ controller: PKPaymentAuthorizationViewController) {

--- a/ostelco-ios-client/Storyboards/Email.storyboard
+++ b/ostelco-ios-client/Storyboards/Email.storyboard
@@ -13,7 +13,7 @@
         <!--Email Entry View Controller-->
         <scene sceneID="6Lf-F7-s8L">
             <objects>
-                <viewController id="8Sr-ot-cFb" customClass="EmailEntryViewController" customModule="Oya_app" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="8Sr-ot-cFb" customClass="EmailEntryViewController" customModule="Oya_Development_app" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ctk-Xq-LA1">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -82,19 +82,13 @@
         <!--Check Email View Controller-->
         <scene sceneID="aZy-RL-n2a">
             <objects>
-                <viewController id="ejA-LR-l53" customClass="CheckEmailViewController" customModule="Oya_app" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="ejA-LR-l53" customClass="CheckEmailViewController" customModule="Oya_Development_app" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="vCx-56-Z2j">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Check your email!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YU5-UY-nx5" customClass="Heading2Label" customModule="OstelcoStyles">
                                 <rect key="frame" x="24" y="88" width="327" height="38.333333333333343"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We need to confirm your email address. Please click the link in the email you received." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0cu-on-0rp" customClass="OnboardingLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="528.33333333333337" width="327" height="64.666666666666629"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -116,6 +110,19 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="illustrationSittingOnCloud" translatesAutoresizingMaskIntoConstraints="NO" id="Eij-OY-xXL">
                                 <rect key="frame" x="24" y="206.33333333333334" width="327" height="16"/>
                             </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BwW-Su-BCB" customClass="LinkTextButton" customModule="OstelcoStyles">
+                                <rect key="frame" x="76" y="560" width="223" height="33"/>
+                                <state key="normal" title="Submit Simulator Pasteboard"/>
+                                <connections>
+                                    <action selector="submitPasteboardTapped" destination="ejA-LR-l53" eventType="touchUpInside" id="dDO-7w-ORq"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We need to confirm your email address. Please click the link in the email you received." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0cu-on-0rp" customClass="OnboardingLabel" customModule="OstelcoStyles">
+                                <rect key="frame" x="24" y="479.33333333333331" width="327" height="64.666666666666686"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
@@ -123,9 +130,11 @@
                             <constraint firstItem="YU5-UY-nx5" firstAttribute="leading" secondItem="CEv-8w-uyC" secondAttribute="leading" constant="24" id="1TM-96-cfB"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="Eij-OY-xXL" secondAttribute="trailing" constant="24" id="20K-9X-JrH"/>
                             <constraint firstItem="0cu-on-0rp" firstAttribute="leading" secondItem="CEv-8w-uyC" secondAttribute="leading" constant="24" id="3oq-7O-aPj"/>
-                            <constraint firstItem="fn5-bY-n3l" firstAttribute="top" secondItem="0cu-on-0rp" secondAttribute="bottom" constant="24" id="Fb7-Gy-UXb"/>
+                            <constraint firstItem="BwW-Su-BCB" firstAttribute="top" secondItem="0cu-on-0rp" secondAttribute="bottom" constant="16" id="9jL-qU-wMR"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="YU5-UY-nx5" secondAttribute="trailing" constant="24" id="I0M-qB-7d4"/>
+                            <constraint firstItem="fn5-bY-n3l" firstAttribute="top" secondItem="BwW-Su-BCB" secondAttribute="bottom" constant="24" id="QdO-at-rJd"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="bottom" secondItem="cen-WM-H3N" secondAttribute="bottom" constant="44" id="Sez-Eo-l7S"/>
+                            <constraint firstItem="BwW-Su-BCB" firstAttribute="centerX" secondItem="vCx-56-Z2j" secondAttribute="centerX" id="UKg-Xf-6Sq"/>
                             <constraint firstItem="fn5-bY-n3l" firstAttribute="centerX" secondItem="vCx-56-Z2j" secondAttribute="centerX" id="UiD-Qv-sUK"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="cen-WM-H3N" secondAttribute="trailing" constant="24" id="UyX-h9-Apg"/>
                             <constraint firstItem="0cu-on-0rp" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Eij-OY-xXL" secondAttribute="bottom" constant="20" id="aHX-D7-eSf"/>
@@ -137,6 +146,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="CEv-8w-uyC"/>
                     </view>
+                    <connections>
+                        <outlet property="submitPasteboardOnSimulatorButton" destination="BwW-Su-BCB" id="5bK-6s-39r"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="s9L-Rx-c69" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/ostelco-ios-client/ViewControllers/Country/VerifyCountryOnBoardingViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/VerifyCountryOnBoardingViewController.swift
@@ -26,7 +26,7 @@ class VerifyCountryOnBoardingViewController: UIViewController {
     }
     
     private func setTitle() {
-        if let user = UserManager.sharedInstance.customer {
+        if let user = UserManager.shared.customer {
             titleLabel.text = "Hi \(user.name)!"
         }
     }

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -119,7 +119,7 @@ class AddressEditViewController: UITableViewController {
         
         self.spinnerView = showSpinner(onView: self.view)
 
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .addAddress(address, forRegion: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -119,7 +119,7 @@ class AddressEditViewController: UITableViewController {
         
         self.spinnerView = showSpinner(onView: self.view)
 
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .addAddress(address, forRegion: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -9,7 +9,6 @@
 import Crashlytics
 import ostelco_core
 import PromiseKit
-import RxSwift
 import UIKit
 
 protocol MyInfoAddressUpdateDelegate: class {

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -33,7 +33,7 @@ class MyInfoSummaryViewController: UIViewController {
         debugPrint("Code = \(code)")
         
         self.spinnerView = self.showSpinner(onView: self.view)
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .loadSingpassInfo(code: code)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
@@ -89,7 +89,7 @@ class MyInfoSummaryViewController: UIViewController {
         
         let profileUpdate = EKYCProfileUpdate(address: address, phoneNumber: phoneNumber)
         self.spinnerView = self.showSpinner(onView: self.view)
-        APIManager.sharedInstance.loggedInAPI.updateEKYCProfile(with: profileUpdate, forRegion: "sg")
+        APIManager.shared.loggedInAPI.updateEKYCProfile(with: profileUpdate, forRegion: "sg")
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
                 self?.spinnerView = nil

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -33,7 +33,7 @@ class MyInfoSummaryViewController: UIViewController {
         debugPrint("Code = \(code)")
         
         self.spinnerView = self.showSpinner(onView: self.view)
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .loadSingpassInfo(code: code)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
@@ -89,7 +89,7 @@ class MyInfoSummaryViewController: UIViewController {
         
         let profileUpdate = EKYCProfileUpdate(address: address, phoneNumber: phoneNumber)
         self.spinnerView = self.showSpinner(onView: self.view)
-        APIManager.shared.loggedInAPI.updateEKYCProfile(with: profileUpdate, forRegion: "sg")
+        APIManager.shared.primeAPI.updateEKYCProfile(with: profileUpdate, forRegion: "sg")
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
                 self?.spinnerView = nil

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -24,15 +24,15 @@ class MyInfoSummaryViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        debugPrint("Query Items: \(String(describing: myInfoQueryItems))")
-        self.spinnerView = self.showSpinner(onView: self.view)
         
+        debugPrint("Query Items: \(String(describing: self.myInfoQueryItems))")
         guard let code = getMyInfoCode() else {
             return
         }
         
-        //TODO: Pass the code we retrieved to PRIME
         debugPrint("Code = \(code)")
+        
+        self.spinnerView = self.showSpinner(onView: self.view)
         APIManager.sharedInstance.loggedInAPI
             .loadSingpassInfo(code: code)
             .ensure { [weak self] in

--- a/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
@@ -40,7 +40,7 @@ class NRCIVerifyViewController: UIViewController {
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
         self.nricErrorLabel.isHidden = true
         self.spinnerView = self.showSpinner(onView: self.view)
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .validateNRIC(nric, forRegion: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
@@ -63,7 +63,7 @@ extension NRCIVerifyViewController: NetverifyViewControllerDelegate {
     
     func getNewScanId() -> Promise<String> {
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
-        return APIManager.sharedInstance.loggedInAPI.createJumioScanForRegion(code: countryCode)
+        return APIManager.shared.loggedInAPI.createJumioScanForRegion(code: countryCode)
             .map { scan in
                 return scan.scanId
             }

--- a/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
@@ -40,7 +40,7 @@ class NRCIVerifyViewController: UIViewController {
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
         self.nricErrorLabel.isHidden = true
         self.spinnerView = self.showSpinner(onView: self.view)
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .validateNRIC(nric, forRegion: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
@@ -63,7 +63,7 @@ extension NRCIVerifyViewController: NetverifyViewControllerDelegate {
     
     func getNewScanId() -> Promise<String> {
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
-        return APIManager.shared.loggedInAPI.createJumioScanForRegion(code: countryCode)
+        return APIManager.shared.primeAPI.createJumioScanForRegion(code: countryCode)
             .map { scan in
                 return scan.scanId
             }

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -42,7 +42,7 @@ class PendingVerificationViewController: UIViewController {
     func checkVerificationStatus(silentCheck: Bool = false) {
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
         let spinnerView = showSpinner(onView: self.view)
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .loadRegion(code: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(spinnerView)

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -42,7 +42,7 @@ class PendingVerificationViewController: UIViewController {
     func checkVerificationStatus(silentCheck: Bool = false) {
         let countryCode = OnBoardingManager.sharedInstance.selectedCountry.countryCode.lowercased()
         let spinnerView = showSpinner(onView: self.view)
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .loadRegion(code: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(spinnerView)

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -31,7 +31,7 @@ class ESIMPendingDownloadViewController: UIViewController {
         if let region = OnBoardingManager.sharedInstance.region {
             getSimProfileForRegion(region: region)
         } else {
-           APIManager.sharedInstance
+           APIManager.shared
             .loggedInAPI
             .getRegionFromRegions()
             .done { [weak self] regionResponse in
@@ -55,7 +55,7 @@ class ESIMPendingDownloadViewController: UIViewController {
         
         self.spinnerView = self.showSpinner(onView: self.view)
         
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .loadSimProfilesForRegion(code: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
@@ -105,7 +105,7 @@ class ESIMPendingDownloadViewController: UIViewController {
             }
         } else {
             self.spinnerView = self.showSpinner(onView: self.view)
-            APIManager.sharedInstance.loggedInAPI.createSimProfileForRegion(code: countryCode)
+            APIManager.shared.loggedInAPI.createSimProfileForRegion(code: countryCode)
                 .ensure { [weak self] in
                     self?.removeSpinner(self?.spinnerView)
                     self?.spinnerView = nil

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -32,7 +32,7 @@ class ESIMPendingDownloadViewController: UIViewController {
             getSimProfileForRegion(region: region)
         } else {
            APIManager.shared
-            .loggedInAPI
+            .primeAPI
             .getRegionFromRegions()
             .done { [weak self] regionResponse in
                 OnBoardingManager.sharedInstance.region = regionResponse
@@ -55,7 +55,7 @@ class ESIMPendingDownloadViewController: UIViewController {
         
         self.spinnerView = self.showSpinner(onView: self.view)
         
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .loadSimProfilesForRegion(code: countryCode)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
@@ -105,7 +105,7 @@ class ESIMPendingDownloadViewController: UIViewController {
             }
         } else {
             self.spinnerView = self.showSpinner(onView: self.view)
-            APIManager.shared.loggedInAPI.createSimProfileForRegion(code: countryCode)
+            APIManager.shared.primeAPI.createSimProfileForRegion(code: countryCode)
                 .ensure { [weak self] in
                     self?.removeSpinner(self?.spinnerView)
                     self?.spinnerView = nil

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -101,37 +101,26 @@ class ESIMPendingDownloadViewController: UIViewController {
                     self.performSegue(withIdentifier: "showHome", sender: self)
                 }
             } else {
-                simProfile = simProfiles.first(where: { [.AVAILABLE_FOR_DOWNLOAD, .DOWNLOADED, .INSTALLED].contains($0.status) })
+                self.simProfile = simProfiles.first(where: { [.AVAILABLE_FOR_DOWNLOAD, .DOWNLOADED, .INSTALLED].contains($0.status) })
             }
         } else {
-            spinnerView = showSpinner(onView: self.view)
-            APIManager.sharedInstance.regions.child(countryCode).child("simProfiles").withParam("profileType", "iphone").request(.post)
-                .onSuccess { data in
-                    if let simProfile: SimProfile = data.typedContent(ifNone: nil) {
-                        self.simProfile = simProfile
-                    } else {
-                        DispatchQueue.main.async {
-                            self.performSegue(withIdentifier: "showGenericOhNo", sender: self)
-                        }
-                    }
+            self.spinnerView = self.showSpinner(onView: self.view)
+            APIManager.sharedInstance.loggedInAPI.createSimProfileForRegion(code: countryCode)
+                .ensure { [weak self] in
+                    self?.removeSpinner(self?.spinnerView)
+                    self?.spinnerView = nil
                 }
-                .onFailure { requestError in
-                    if let statusCode = requestError.httpStatusCode {
-                        switch statusCode {
-                        default:
-                            DispatchQueue.main.async {
-                                self.performSegue(withIdentifier: "showGenericOhNo", sender: self)
-                            }
-                        }
-                    } else {
-                        DispatchQueue.main.async {
-                            self.performSegue(withIdentifier: "showGenericOhNo", sender: self)
-                        }
+                .done { [weak self] profile in
+                    guard let self = self else {
+                        return
                     }
+                    
+                    self.simProfile = profile
                 }
-                .onCompletion { _ in
-                    self.removeSpinner(self.spinnerView)
-            }
+                .catch { [weak self] error in
+                    ApplicationErrors.log(error)
+                    self?.performSegue(withIdentifier: "showGenericOhNo", sender: self)
+                }
         }
     }
     

--- a/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
@@ -10,6 +10,21 @@ import UIKit
 
 class CheckEmailViewController: UIViewController {
     
+    @IBOutlet private var submitPasteboardOnSimulatorButton: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureSubmitPasteboardButton()
+    }
+    
+    private func configureSubmitPasteboardButton() {
+        #if targetEnvironment(simulator)
+            self.submitPasteboardOnSimulatorButton.isHidden = false
+        #else
+            self.submitPasteboardOnSimulatorButton.isHidden = true
+        #endif
+    }
+    
     @IBAction private func needHelpTapped() {
         self.showNeedHelpActionSheet()
     }
@@ -32,5 +47,40 @@ class CheckEmailViewController: UIViewController {
                 ApplicationErrors.log(error)
                 self?.showGenericError(error: error)
             }
+    }
+    
+    @IBAction private func submitPasteboardTapped() {
+        #if targetEnvironment(simulator)
+            guard let pasteboardString = UIPasteboard.general.string else {
+                self.showAlert(title: "Pasteboard was empty!", msg: "Remember to copy the link to the pasteboard first")
+                return
+            }
+            
+            guard let url = URL(string: pasteboardString) else {
+                self.showAlert(title: "Can't Create URL", msg: "Couldn't create a URL from pasteboard contents:\n\n\(pasteboardString)")
+                return
+            }
+            
+            guard EmailLinkManager.isSignInLink(url) else {
+                self.showAlert(title: "Not a sign in link!", msg: "The URL passed in is not a sign-in link!\n\n\(url.absoluteString)")
+                return
+            }
+            
+            let spinner = self.showSpinner(onView: self.view)
+            EmailLinkManager.signInWithLink(url)
+                .ensure { [weak self] in
+                    self?.removeSpinner(spinner)
+                }
+                .then { UserManager.sharedInstance.getDestinationFromContext() }
+                .done { destination in
+                    UIApplication.shared.typedDelegate.rootCoordinator.navigate(to: destination, from: self)
+                }
+                .catch { [weak self] error in
+                    ApplicationErrors.log(error)
+                    self?.showGenericError(error: error)
+                }
+        #else
+            fatalError("Submit pasteboard was somehow used when not on the simulator!")
+        #endif
     }
 }

--- a/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
@@ -71,7 +71,7 @@ class CheckEmailViewController: UIViewController {
                 .ensure { [weak self] in
                     self?.removeSpinner(spinner)
                 }
-                .then { UserManager.sharedInstance.getDestinationFromContext() }
+                .then { UserManager.shared.getDestinationFromContext() }
                 .done { destination in
                     UIApplication.shared.typedDelegate.rootCoordinator.navigate(to: destination, from: self)
                 }

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -42,7 +42,7 @@ class ApplePayViewController: UIViewController, ApplePayDelegate {
     }
 
     func getProducts() -> Promise<[Product]> {
-        return APIManager.sharedInstance.loggedInAPI
+        return APIManager.shared.loggedInAPI
             .loadProducts()
             .map { productModels in
                 productModels.map { Product(from: $0, countryCode: "SG") }

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -32,8 +32,8 @@ class ApplePayViewController: UIViewController, ApplePayDelegate {
             self.showAlert(title: "Payment Error", msg: error.localizedDescription)
         case .userCancelled:
             debugPrint(error.localizedDescription, "Payment was cancelled after showing Apple Pay screen")
-        case .primeAPIError(let requestError):
-            showAPIError(error: requestError)
+        case .primeAPIError(let error):
+            self.showGenericError(error: error)
         }
     }
 

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -42,7 +42,7 @@ class ApplePayViewController: UIViewController, ApplePayDelegate {
     }
 
     func getProducts() -> Promise<[Product]> {
-        return APIManager.shared.loggedInAPI
+        return APIManager.shared.primeAPI
             .loadProducts()
             .map { productModels in
                 productModels.map { Product(from: $0, countryCode: "SG") }

--- a/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import PassKit
 import PromiseKit
 import Stripe
-import Siesta
 
 class BecomeAMemberViewController: ApplePayViewController {
 

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -114,7 +114,7 @@ class HomeViewController: ApplePayViewController {
         messageLabel.isHidden = true
         
         // Call the bundles API
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .loadBundles()
             .ensure { [weak self] in
                 self?.refreshControl.endRefreshing()

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -114,7 +114,7 @@ class HomeViewController: ApplePayViewController {
         messageLabel.isHidden = true
         
         // Call the bundles API
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .loadBundles()
             .ensure { [weak self] in
                 self?.refreshControl.endRefreshing()

--- a/ostelco-ios-client/ViewControllers/Home/PurchaseHistoryTableViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/PurchaseHistoryTableViewController.swift
@@ -33,7 +33,7 @@ class PucrhaseHistoryTableViewController: UITableViewController {
     }
 
     @objc func didPullToRefresh() {
-        APIManager.sharedInstance.loggedInAPI
+        APIManager.shared.loggedInAPI
             .loadPurchases()
             .map { purchaseModels -> [PurchaseRecord] in
                 let sortedPurchases = purchaseModels.sorted { $0.timestamp > $1.timestamp }

--- a/ostelco-ios-client/ViewControllers/Home/PurchaseHistoryTableViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/PurchaseHistoryTableViewController.swift
@@ -33,7 +33,7 @@ class PucrhaseHistoryTableViewController: UITableViewController {
     }
 
     @objc func didPullToRefresh() {
-        APIManager.shared.loggedInAPI
+        APIManager.shared.primeAPI
             .loadPurchases()
             .map { purchaseModels -> [PurchaseRecord] in
                 let sortedPurchases = purchaseModels.sorted { $0.timestamp > $1.timestamp }

--- a/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
@@ -10,12 +10,9 @@ import ostelco_core
 import OstelcoStyles
 import UIKit
 import Firebase
-import RxSwift
 
 class LoginViewController: UIViewController {
     var spinnerView: UIView?
-    
-    let disposeBag = DisposeBag()
     
     @IBOutlet private var primaryButton: UIButton!
     

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -28,7 +28,7 @@ class GetStartedViewController: UIViewController {
     }
     
     @IBAction private func continueTapped(_ sender: Any) {
-        guard let email = UserManager.sharedInstance.currentUserEmail else {
+        guard let email = UserManager.shared.currentUserEmail else {
             self.showAlert(title: "Error", msg: "Email is empty or missing in Firebase")
             return
         }
@@ -48,7 +48,7 @@ class GetStartedViewController: UIViewController {
             }
             .done { [weak self] customer in
                 OstelcoAnalytics.logEvent(.EnteredNickname)
-                UserManager.sharedInstance.customer = customer
+                UserManager.shared.customer = customer
                 self?.performSegue(withIdentifier: "showCountry", sender: self)
             }
             .catch { [weak self] error in

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -41,7 +41,7 @@ class GetStartedViewController: UIViewController {
         self.spinnerView = self.showSpinner(onView: self.view)
         let user = UserSetup(nickname: nickname, email: email)
 
-        APIManager.shared.loggedInAPI.createCustomer(with: user)
+        APIManager.shared.primeAPI.createCustomer(with: user)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
                 self?.spinnerView = nil

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -41,7 +41,7 @@ class GetStartedViewController: UIViewController {
         self.spinnerView = self.showSpinner(onView: self.view)
         let user = UserSetup(nickname: nickname, email: email)
 
-        APIManager.sharedInstance.loggedInAPI.createCustomer(with: user)
+        APIManager.shared.loggedInAPI.createCustomer(with: user)
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)
                 self?.spinnerView = nil

--- a/ostelco-ios-client/ViewControllers/SplashViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SplashViewController.swift
@@ -26,7 +26,7 @@ class SplashViewController: UIViewController, StoryboardLoadable {
     }
     
     func checkIfWeHaveALoggedInUser() {
-        guard UserManager.sharedInstance.firebaseUser != nil else {
+        guard UserManager.shared.firebaseUser != nil else {
             // NOPE! We need to log in.
             UIApplication.shared.typedDelegate.rootCoordinator.showLogin()
             return
@@ -36,7 +36,7 @@ class SplashViewController: UIViewController, StoryboardLoadable {
         UIApplication.shared.typedDelegate.sendFCMToken()
         
         let spinnerView = self.showSpinner(onView: self.view)
-        UserManager.sharedInstance.getDestinationFromContext()
+        UserManager.shared.getDestinationFromContext()
             .ensure { [weak self] in
                 self?.removeSpinner(spinnerView)
             }


### PR DESCRIPTION
In this PR: 
- Rename `LoggedInAPI` to `PrimeAPI` since all calls to prime have to be logged in 
- Migrate all remaining calls to `PrimeAPI`
- Update singleton naming to better match swift conventions
- Add a convenience PromiseKit wrapper for Stripe
- Delete all references to Siesta and RxSwift
- Add ability to login by pasting a link into the simulator (this is mostly for developer convenience - actually pasting the link into Safari was, for some reason, not working at all)