### PR TITLE
Improve error messaging

### DIFF
--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		9B1745832277428A00CF321B /* OstelcoTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1745822277428A00CF321B /* OstelcoTextField.swift */; };
 		9B1E07462282F4A900EBFCDC /* Email.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B4DAD952281A7BB003810BE /* Email.storyboard */; };
 		9B1E07472282F5E500EBFCDC /* EmailEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4DAD982281A7E9003810BE /* EmailEntryViewController.swift */; };
+		9B3FA68F22896510001E4D60 /* UIAlertAction+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3FA68E22896510001E4D60 /* UIAlertAction+Convenience.swift */; };
+		9B3FA69022896640001E4D60 /* UIAlertAction+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3FA68E22896510001E4D60 /* UIAlertAction+Convenience.swift */; };
 		9B4DAD90228198F4003810BE /* EmailLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4DAD8F228198F4003810BE /* EmailLinkManager.swift */; };
 		9B4DAD922281A2CE003810BE /* RootCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4DAD912281A2CE003810BE /* RootCoordinator.swift */; };
 		9B4DAD932281A538003810BE /* RootCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4DAD912281A2CE003810BE /* RootCoordinator.swift */; };
@@ -443,6 +445,7 @@
 		9B17457C2277033300CF321B /* AddressEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressEditViewController.swift; sourceTree = "<group>"; };
 		9B17457F227722C200CF321B /* ValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationState.swift; sourceTree = "<group>"; };
 		9B1745822277428A00CF321B /* OstelcoTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstelcoTextField.swift; sourceTree = "<group>"; };
+		9B3FA68E22896510001E4D60 /* UIAlertAction+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Convenience.swift"; sourceTree = "<group>"; };
 		9B46D64A226F00210030A8EB /* OstelcoColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstelcoColor.swift; sourceTree = "<group>"; };
 		9B46D64C226F01D60030A8EB /* OstelcoLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstelcoLabel.swift; sourceTree = "<group>"; };
 		9B46D64E226F02C30030A8EB /* OstelcoFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstelcoFont.swift; sourceTree = "<group>"; };
@@ -1052,6 +1055,7 @@
 				9BBF7074226751A200E4B9B4 /* Netverify+Ostelco.swift */,
 				04D6C9872276F7CB00AE13DD /* String+SnakeCase.swift */,
 				9B6A928022833242007F5EC9 /* STPAPIClient+PromiseKit.swift */,
+				9B3FA68E22896510001E4D60 /* UIAlertAction+Convenience.swift */,
 				9BE2D45D225B642500B51999 /* UIApplicaiton+Testing.swift */,
 				9BBF70702267423A00E4B9B4 /* UIApplication+TypedDelegate.swift */,
 				04834D64223020DA00A01500 /* UIButton+Border.swift */,
@@ -1769,6 +1773,7 @@
 				041216AF22281CE000455278 /* AllowLocationAccessViewController.swift in Sources */,
 				C2D2EAE922785C0C00010586 /* AppErrors.swift in Sources */,
 				C2C3EAD022705D9F00585FA4 /* PurchaseHistoryTableViewController.swift in Sources */,
+				9B3FA68F22896510001E4D60 /* UIAlertAction+Convenience.swift in Sources */,
 				041FAB1B225F19AC00877E72 /* UIViewController+Presentation.swift in Sources */,
 				9B920F65225B8EC6001EF9CD /* Theme.swift in Sources */,
 				9BE2D447225B5E3100B51999 /* UIColor+Hex.swift in Sources */,
@@ -1933,6 +1938,7 @@
 				041216902226BEB100455278 /* TheLegalStuffViewController.swift in Sources */,
 				041FAB1C225F19AC00877E72 /* UIViewController+Presentation.swift in Sources */,
 				C2C3EAD122705D9F00585FA4 /* PurchaseHistoryTableViewController.swift in Sources */,
+				9B3FA69022896640001E4D60 /* UIAlertAction+Convenience.swift in Sources */,
 				C2D2EAEA22785C0C00010586 /* AppErrors.swift in Sources */,
 				9B920F66225B8EE1001EF9CD /* Theme.swift in Sources */,
 				043E710F2239F17200E01993 /* main.swift in Sources */,

--- a/ostelco-ios-client/Extensions/UIAlertAction+Convenience.swift
+++ b/ostelco-ios-client/Extensions/UIAlertAction+Convenience.swift
@@ -1,0 +1,50 @@
+//
+//  UIAlertAction+Convenience.swift
+//  ostelco-ios-client
+//
+//  Created by Ellen Shapiro on 5/13/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import UIKit
+
+extension UIAlertAction {
+    
+    /// Basic "OK" action.
+    ///
+    /// - Parameter completion: [optional] The completion block to execute as the alert is dismissed. Defaults to nil.
+    /// - Returns: The created action
+    static func okAction(completion: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+        return UIAlertAction(title: "OK",
+                             style: .default,
+                             handler: completion)
+    }
+    
+    
+    /// Basic "Cancel" style action
+    ///
+    /// - Parameters:
+    ///   - title: The title of the action. Defaults to "Cancel"
+    ///   - completion: [optional] The completion block to execute as the alert is dismissed. Defaults to nil.
+    /// - Returns: The created action
+    static func cancelAction(title: String = "Cancel", completion: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+        return UIAlertAction(title: title,
+                             style: .cancel,
+                             handler: completion)
+    }
+    
+    /// Basic "Destructive" style action
+    ///
+    /// - Parameters:
+    ///   - title: The title of the action
+    ///   - completion: [optional] The completion block to execute as the alert is dismissed.
+    ///                 Note that no default value is provided here, since if the action is destructive you probably
+    ///                 want to do *something*.
+    /// - Returns: The created action.
+    static func destructiveAction(title: String,
+                                  completion: ((UIAlertAction) -> Void)?) -> UIAlertAction {
+        return UIAlertAction(title: title,
+                             style: .destructive,
+                             handler: completion)
+    }
+}

--- a/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+ActionSheet.swift
@@ -56,10 +56,9 @@ extension UIViewController {
         let alertCtrl = UIAlertController(title: nil, message: "Are you sure that you want to delete your account completely?", preferredStyle: .actionSheet)
         
         let deleteAction = createDeleteAccountAlertAction(title: "Cancel Membership", vc: self)
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         
         alertCtrl.addAction(deleteAction)
-        alertCtrl.addAction(cancelAction)
+        alertCtrl.addAction(.cancelAction())
         
         // Action sheet crashes on iPad: https://medium.com/@nickmeehan/actionsheet-popover-on-ipad-in-swift-5768dfa82094
         if UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad {
@@ -81,10 +80,9 @@ extension UIViewController {
             let viewController = UIStoryboard(name: "Login", bundle: nil).instantiateInitialViewController()!
             self.present(viewController, animated: true)
         }
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         
         alertCtrl.addAction(logOutAction)
-        alertCtrl.addAction(cancelAction)
+        alertCtrl.addAction(.cancelAction())
         
         present(alertCtrl, animated: true, completion: nil)
     }

--- a/ostelco-ios-client/Extensions/UIViewController+Alerts.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+Alerts.swift
@@ -6,22 +6,35 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
+import ostelco_core
 import UIKit
 
 extension UIViewController {
     
     func showGenericError(error: Error) {
-        let title = "Error"
-        let message = "An error has occurred:\n\n\(error)"
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Ok", style: .default))
-        present(alert, animated: true, completion: nil)
+        let message: String
+            
+        switch error {
+        case APIHelper.Error.jsonError(let jsonError):
+            message = jsonError.message
+        case APIHelper.Error.serverError(let serverError):
+            message = serverError.errors.joined(separator: "\n\n")
+        default:
+            if let localized = error as? LocalizedError {
+                message = localized.localizedDescription
+            } else {
+                message = "An error has occurred:\n\n\(error)"
+            }
+        }
+        
+        self.showAlert(title: "Error", msg: message)
     }
     
     func showAlert(title: String, msg: String) {
-        let alert = UIAlertController(title: title, message: msg, preferredStyle: .alert)
-        let action = UIAlertAction(title: "OK", style: .default, handler: nil)
-        alert.addAction(action)
+        let alert = UIAlertController(title: title,
+                                      message: msg,
+                                      preferredStyle: .alert)
+        alert.addAction(.okAction())
         self.present(alert, animated: true, completion: nil)
     }
 }

--- a/ostelco-ios-client/Protocols/LocationCheckingViewController.swift
+++ b/ostelco-ios-client/Protocols/LocationCheckingViewController.swift
@@ -39,9 +39,7 @@ protocol LocationChecking: UIViewController {
 extension LocationChecking {
     
     func showFailedToGetLocationAlert() {
-        let alert = UIAlertController(title: "We're sorry but...", message: "We were unable to get your current location.", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        self.present(alert, animated: true, completion: nil)
+        self.showAlert(title: "We're sorry but...", msg: "We were unable to get your current location.")
     }
     
     func checkLocation(isIn country: Country = OnBoardingManager.sharedInstance.selectedCountry) {

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -130,14 +130,8 @@ class AddressEditViewController: UITableViewController {
                 self?.present(pendingVC, animated: true)
             }
             .catch { [weak self] error in
-                switch error {
-                case APIHelper.Error.serverError(let serverError):
-                    self?.showAlert(title: "Error", msg: "\(serverError.errors)")
-                default:
-                    debugPrint("Error adding address: \(error)")
-                    ApplicationErrors.log(error)
-                    self?.showGenericError(error: error)
-                }
+                ApplicationErrors.log(error)
+                self?.showGenericError(error: error)
             }
     }
         

--- a/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
@@ -157,9 +157,7 @@ extension NRCIVerifyViewController: NetverifyViewControllerDelegate {
         self.dismiss(animated: true) {
             self.netverifyViewController?.destroy()
             self.netverifyViewController = nil
-            let alert = UIAlertController(title: "Info", message: "\(error?.message ?? "An unknown error occurred.")", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            self.present(alert, animated: true)
+            self.showAlert(title: "Info", msg: "\(error?.message ?? "An unknown error occurred.")")
         }
     }
 }

--- a/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRCIVerifyViewController.swift
@@ -135,14 +135,7 @@ extension NRCIVerifyViewController: NetverifyViewControllerDelegate {
                     return
                 }
                 
-                switch error {
-                case APIHelper.Error.jsonError(let jsonError):
-                    self.showAlert(title: "Error", msg: jsonError.message)
-                case APIHelper.Error.serverError(let serverError):
-                    self.showAlert(title: "Error", msg: serverError.errors.joined(separator: "\n"))
-                default:
-                    self.showGenericError(error: error)
-                }
+                self.showGenericError(error: error)
             }
     }
     

--- a/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
@@ -112,8 +112,7 @@ class BecomeAMemberViewController: ApplePayViewController {
             self.showPaymentOptions()
         }
         alertCtrl.addAction(addCardsAction)
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        alertCtrl.addAction(cancelAction)
+        alertCtrl.addAction(.cancelAction())
         present(alertCtrl, animated: true, completion: nil)
     }
     #endif

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -164,8 +164,8 @@ class HomeViewController: ApplePayViewController {
             }
             alertCtrl.addAction(addCardsAction)
         #endif
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        alertCtrl.addAction(cancelAction)
+        
+        alertCtrl.addAction(.cancelAction())
         present(alertCtrl, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
In this PR: 

- Add some handling so if we get information from the server or a `LocalizedError` about what's gone wrong, we show that instead of a really goofy error alert
- Add some convenience helpers for generating common button types
- Use convenience APIs where appropriate. 