### PR TITLE
Even more API tests!

### DIFF
--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -29,6 +29,7 @@ class LiveAPITests: XCTestCase {
         self.liveRegions()
         self.liveRegionWithData()
         self.liveUnsupportedRegion()
+        self.liveAddressUpdate()
     }
 
     func liveFetchingContext() {
@@ -106,5 +107,21 @@ class LiveAPITests: XCTestCase {
         default:
             XCTFail("Unexpected error fetching unsupportedRegion: \(error)")
         }
+    }
+    
+    func liveAddressUpdate() {
+        let address = MyInfoAddress(country: "SG",
+                                    unit: "128",
+                                    street: "BEDOK NORTH AVENUE 4",
+                                    block: "102",
+                                    postal: "460102",
+                                    floor: "09",
+                                    building: "PEARL GARDEN").formattedAddress
+        let phone = "+6597399245"
+        
+        let update = EKYCProfileUpdate(address: address, phoneNumber: phone)
+        
+        // Failures handled in `awaitResult`
+        self.testAPI.updateEKYCProfile(with: update, forRegion: "sg").awaitResult(in: self)
     }
 }

--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -30,6 +30,7 @@ class LiveAPITests: XCTestCase {
         self.liveRegionWithData()
         self.liveUnsupportedRegion()
         self.liveAddressUpdate()
+        self.liveSimProfilesForRegion()
     }
 
     func liveFetchingContext() {
@@ -123,5 +124,10 @@ class LiveAPITests: XCTestCase {
         
         // Failures handled in `awaitResult`
         self.testAPI.updateEKYCProfile(with: update, forRegion: "sg").awaitResult(in: self)
+    }
+    
+    func liveSimProfilesForRegion() {
+        // Failures handled in `awaitResult`
+        _ = self.testAPI.loadSimProfilesForRegion(code: "sg").awaitResult(in: self)
     }
 }

--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -31,6 +31,7 @@ class LiveAPITests: XCTestCase {
         self.liveUnsupportedRegion()
         self.liveAddressUpdate()
         self.liveSimProfilesForRegion()
+        self.liveStripeEphemeralKey()
     }
 
     func liveFetchingContext() {
@@ -129,5 +130,18 @@ class LiveAPITests: XCTestCase {
     func liveSimProfilesForRegion() {
         // Failures handled in `awaitResult`
         _ = self.testAPI.loadSimProfilesForRegion(code: "sg").awaitResult(in: self)
+    }
+    
+    func liveStripeEphemeralKey() {
+        // API version can be found in Pods/Stripe/STPAPIClient
+        // (near the top) -not public so can't be accessed directly
+        let request = StripeEphemeralKeyRequest(apiVersion: "2015-10-12")
+        
+        guard let dictionary = self.testAPI.stripeEphemeralKey(with: request).awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertTrue(dictionary.isNotEmpty)
     }
 }

--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -32,6 +32,7 @@ class LiveAPITests: XCTestCase {
         self.liveAddressUpdate()
         self.liveSimProfilesForRegion()
         self.liveStripeEphemeralKey()
+        self.liveMyInfoConfig()
     }
 
     func liveFetchingContext() {
@@ -143,5 +144,15 @@ class LiveAPITests: XCTestCase {
         }
         
         XCTAssertTrue(dictionary.isNotEmpty)
+    }
+    
+    func liveMyInfoConfig() {
+        guard let config = self.testAPI.loadMyInfoConfig().awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+
+        // Can we at least create a URL out of what we get back?
+        XCTAssertNotNil(URL(string: config.url))
     }
 }

--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -26,6 +26,9 @@ class LiveAPITests: XCTestCase {
         self.liveBundles()
         self.livePurchases()
         self.liveProducts()
+        self.liveRegions()
+        self.liveRegionWithData()
+        self.liveUnsupportedRegion()
     }
 
     func liveFetchingContext() {
@@ -69,5 +72,39 @@ class LiveAPITests: XCTestCase {
     func liveProducts() {
         // Failures handled in `awaitResult`
         _ = self.testAPI.loadProducts().awaitResult(in: self)
+    }
+    
+    func liveRegions() {
+        guard let regions = self.testAPI.loadRegions().awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertTrue(regions.isNotEmpty)
+    }
+    
+    func liveRegionWithData() {
+        guard let region = self.testAPI.loadRegion(code: "sg").awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "sg")
+    }
+    
+    func liveUnsupportedRegion() {
+        // Note: This should be updated if we ever support Vanuatu.
+        guard let error = self.testAPI.loadRegion(code: "vu").awaitResultExpectingError(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        switch error {
+        case APIHelper.Error.jsonError(let jsonError):
+            XCTAssertEqual(jsonError.httpStatusCode, 404)
+            XCTAssertEqual(jsonError.errorCode, "FAILED_TO_FETCH_REGIONS")
+        default:
+            XCTFail("Unexpected error fetching unsupportedRegion: \(error)")
+        }
     }
 }

--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -25,6 +25,7 @@ class LiveAPITests: XCTestCase {
         self.liveInvalidNRIC()
         self.liveBundles()
         self.livePurchases()
+        self.liveProducts()
     }
 
     func liveFetchingContext() {
@@ -63,5 +64,10 @@ class LiveAPITests: XCTestCase {
     func livePurchases() {
         // Failures handled in `awaitResult`
         _ = self.testAPI.loadPurchases().awaitResult(in: self)
+    }
+    
+    func liveProducts() {
+        // Failures handled in `awaitResult`
+        _ = self.testAPI.loadProducts().awaitResult(in: self)
     }
 }

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -494,6 +494,17 @@ class MockAPITests: XCTestCase {
         }
     }
     
+    func testMockFetchingMyInfoConfig() {
+        self.stubPath("regions/sg/kyc/myInfoConfig", toLoad: "my_info_config")
+        
+        guard let config = self.mockAPI.loadMyInfoConfig().awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(config.url, "https://myinfosgstg.api.gov.sg/test/v2/authorise?client_id=STG-FAKE_CLIENT_ID&attributes=name,sex,dob,residentialstatus,nationality,mobileno,email,regadd&redirect_uri=https://dl-dev.oya.world/links/myinfo")
+    }
+    
     func testMockCreatingAddress() {
         let address = EKYCAddress(street: "123 Fake Street",
                                   unit: "3",

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -354,6 +354,31 @@ class MockAPITests: XCTestCase {
         XCTAssertEqual(simProfile.alias, "")
     }
     
+    func testMockLoadingRegionFromRegions() {
+        self.stubPath("regions", toLoad: "regions_multiple")
+        
+        guard let approvedRegion = self.mockAPI.getRegionFromRegions().awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(approvedRegion.region.id, "no")
+        XCTAssertEqual(approvedRegion.region.name, "Norway")
+        XCTAssertEqual(approvedRegion.status, .APPROVED)
+        
+        XCTAssertNil(approvedRegion.kycStatusMap.ADDRESS_AND_PHONE_NUMBER)
+        XCTAssertNil(approvedRegion.kycStatusMap.JUMIO)
+        XCTAssertNil(approvedRegion.kycStatusMap.MY_INFO)
+        XCTAssertNil(approvedRegion.kycStatusMap.NRIC_FIN)
+        
+        guard let simProfiles = approvedRegion.simProfiles else {
+            XCTFail("Sim profiles was nil when it shouldn't be!")
+            return
+        }
+        
+        XCTAssertTrue(simProfiles.isEmpty)
+    }
+    
     func testMockLoadingSingleSupportedRegion() {
         self.stubPath("regions/sg", toLoad: "region_singapore")
         

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -316,6 +316,8 @@ class MockAPITests: XCTestCase {
         
         XCTAssertEqual(product.presentation.price, "$1")
         XCTAssertEqual(product.presentation.label, "Annual subscription plan")
+        
+        XCTAssertEqual(product.type, "plan")
     }
     
     // MARK: - Purchases

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -254,6 +254,38 @@ class MockAPITests: XCTestCase {
         self.mockAPI.deleteCustomer().awaitResult(in: self)
     }
     
+    func testMockCreatingEphemeralKey() {
+        self.stubAbsolutePath("customer/stripe-ephemeral-key?api_version=2015-10-12", toLoad: "stripe_ephemeral_key")
+        
+        let request = StripeEphemeralKeyRequest(apiVersion: "2015-10-12")
+        
+        guard let keyDict = self.mockAPI.stripeEphemeralKey(with: request).awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(keyDict["id"] as? String, "ephkey_FAKE")
+        XCTAssertEqual(keyDict["object"] as? String, "ephemeral_key")
+        XCTAssertEqual(keyDict["created"] as? Int64, Int64(1557842380))
+        XCTAssertEqual(keyDict["expires"] as? Int64, Int64(1557845980))
+        XCTAssertEqual(keyDict["livemode"] as? Bool, true)
+        XCTAssertEqual(keyDict["secret"] as? String, "ek_live_FAKE")
+        
+        guard let associatedObjects = keyDict["associated_objects"] as? [[String: AnyHashable]] else {
+            XCTFail("Couldn't get associated objects")
+            return
+        }
+        
+        XCTAssertEqual(associatedObjects.count, 1)
+        guard let firstObject = associatedObjects.first else {
+            XCTFail("Couldn't get first associated object")
+            return
+        }
+        
+        XCTAssertEqual(firstObject["type"] as? String, "customer")
+        XCTAssertEqual(firstObject["id"] as? String, "5112d0bf-4f58-49ea-b417-2af8d69895d2")
+    }
+    
     // MARK: - Products
     
     func testMockLoadingProducts() {
@@ -516,7 +548,7 @@ class MockAPITests: XCTestCase {
     }
     
     func testMockRequestingSimProfilesForRegion() {
-        self.stubPath("regions/sg/simprofiles", toLoad: "sim_profiles_singapore")
+        self.stubPath("regions/sg/simProfiles", toLoad: "sim_profiles_singapore")
         
         guard let simProfiles = self.mockAPI.loadSimProfilesForRegion(code: "sg").awaitResult(in: self) else {
             // Failures handled in `awaitResult`

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -256,6 +256,38 @@ class MockAPITests: XCTestCase {
         self.mockAPI.deleteCustomer().awaitResult(in: self)
     }
     
+    // MARK: - Products
+    
+    func testMockLoadingProducts() {
+        self.stubPath("products", toLoad: "products")
+        
+        guard let products = self.mockAPI.loadProducts().awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(products.count, 1)
+        
+        guard let product = products.first else {
+            XCTFail("Could not access first product!")
+            return
+        }
+        
+        XCTAssertEqual(product.sku, "PLAN_1SGD_YEAR")
+        
+        XCTAssertEqual(product.price.amount, 100)
+        XCTAssertEqual(product.price.currency, "SGD")
+        
+        XCTAssertEqual(product.properties, [
+            "intervalCount": "1",
+            "productClass": "PLAN",
+            "interval": "year"
+        ])
+        
+        XCTAssertEqual(product.presentation.price, "$1")
+        XCTAssertEqual(product.presentation.label, "Annual subscription plan")
+    }
+    
     // MARK: - Purchases
     
     func testMockLoadingPurchases() {

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -514,4 +514,25 @@ class MockAPITests: XCTestCase {
         XCTAssertEqual(simProfile.status, .AVAILABLE_FOR_DOWNLOAD)
         XCTAssertEqual(simProfile.alias, "")
     }
+    
+    func testMockRequestingSimProfilesForRegion() {
+        self.stubPath("regions/sg/simprofiles", toLoad: "sim_profiles_singapore")
+        
+        guard let simProfiles = self.mockAPI.loadSimProfilesForRegion(code: "sg").awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(simProfiles.count, 1)
+        
+        guard let simProfile = simProfiles.first else {
+            XCTFail("Could not access first sim profile!")
+            return
+        }
+        
+        XCTAssertEqual(simProfile.iccId, "8947000000000001598")
+        XCTAssertEqual(simProfile.eSimActivationCode, "FAKE_ACTIVATION_CODE")
+        XCTAssertEqual(simProfile.status, .DOWNLOADED)
+        XCTAssertEqual(simProfile.alias, "")
+    }
 }

--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -324,6 +324,82 @@ class MockAPITests: XCTestCase {
     
     // MARK: - Regions
     
+    func testMockLoadingAllRegions() {
+        self.stubPath("regions", toLoad: "regions")
+        
+        guard let regions = self.mockAPI.loadRegions().awaitResult(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        guard let region = regions.first else {
+            XCTFail("Could not get region!")
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "sg")
+        XCTAssertEqual(region.region.name, "Singapore")
+        XCTAssertEqual(region.status, .APPROVED)
+        XCTAssertEqual(region.kycStatusMap.JUMIO, .APPROVED)
+        XCTAssertEqual(region.kycStatusMap.MY_INFO, .PENDING)
+        XCTAssertEqual(region.kycStatusMap.ADDRESS_AND_PHONE_NUMBER, .APPROVED)
+        XCTAssertEqual(region.kycStatusMap.NRIC_FIN, .APPROVED)
+        
+        guard let simProfile = region.getSimProfile() else {
+            XCTFail("Could not get sim profile from region!")
+            return
+        }
+        
+        XCTAssertEqual(simProfile.iccId, "8947000000000001598")
+        XCTAssertEqual(simProfile.eSimActivationCode, "FAKE_ACTIVATION_CODE")
+        XCTAssertEqual(simProfile.status, .AVAILABLE_FOR_DOWNLOAD)
+        XCTAssertEqual(simProfile.alias, "")
+    }
+    
+    func testMockLoadingSingleSupportedRegion() {
+        self.stubPath("regions/sg", toLoad: "region_singapore")
+        
+        guard let region = self.mockAPI.loadRegion(code: "sg").awaitResult(in: self) else {
+            // Failures handled by `awaitResult`
+            return
+        }
+        
+        XCTAssertEqual(region.region.id, "sg")
+        XCTAssertEqual(region.region.name, "Singapore")
+        XCTAssertEqual(region.status, .APPROVED)
+        XCTAssertEqual(region.kycStatusMap.JUMIO, .APPROVED)
+        XCTAssertEqual(region.kycStatusMap.MY_INFO, .PENDING)
+        XCTAssertEqual(region.kycStatusMap.ADDRESS_AND_PHONE_NUMBER, .APPROVED)
+        XCTAssertEqual(region.kycStatusMap.NRIC_FIN, .APPROVED)
+        
+        guard let simProfile = region.getSimProfile() else {
+            XCTFail("Could not get sim profile from region!")
+            return
+        }
+        
+        XCTAssertEqual(simProfile.iccId, "8947000000000001598")
+        XCTAssertEqual(simProfile.eSimActivationCode, "FAKE_ACTIVATION_CODE")
+        XCTAssertEqual(simProfile.status, .AVAILABLE_FOR_DOWNLOAD)
+        XCTAssertEqual(simProfile.alias, "")
+    }
+    
+    func testMockLoadingSingleUnsupportedRegion() {
+        self.stubPath("regions/vu", toLoad: "region_vanuatu", statusCode: 404)
+        guard let error = self.mockAPI.loadRegion(code: "vu").awaitResultExpectingError(in: self) else {
+            // Failures handled in `awaitResult`
+            return
+        }
+        
+        switch error {
+        case APIHelper.Error.jsonError(let jsonError):
+            XCTAssertEqual(jsonError.httpStatusCode, 404)
+            XCTAssertEqual(jsonError.errorCode, "FAILED_TO_FETCH_REGIONS")
+            XCTAssertEqual(jsonError.message, "Failed to get regions.")
+        default:
+            XCTFail("Unexpected error fetching unsupportedRegion: \(error)")
+        }
+    }
+    
     func testMockNRICCheckWithValidNRIC() {
         self.stubPath("regions/sg/kyc/dave/S9315107J", toLoad: "nric_check_valid")
         

--- a/dev-ostelco-ios-clientTests/MockJSON/my_info_config.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/my_info_config.json
@@ -1,0 +1,3 @@
+{
+	"url": "https://myinfosgstg.api.gov.sg/test/v2/authorise?client_id=STG-FAKE_CLIENT_ID&attributes=name,sex,dob,residentialstatus,nationality,mobileno,email,regadd&redirect_uri=https://dl-dev.oya.world/links/myinfo"
+}

--- a/dev-ostelco-ios-clientTests/MockJSON/products.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/products.json
@@ -1,0 +1,16 @@
+[{
+	"sku": "PLAN_1SGD_YEAR",
+	"price": {
+		"amount": 100,
+		"currency": "SGD"
+	},
+	"properties": {
+		"intervalCount": "1",
+		"productClass": "PLAN",
+		"interval": "year"
+	},
+	"presentation": {
+		"priceLabel": "$1",
+		"productLabel": "Annual subscription plan"
+	}
+}]

--- a/dev-ostelco-ios-clientTests/MockJSON/region_singapore.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/region_singapore.json
@@ -1,0 +1,19 @@
+{
+	"region": {
+		"id": "sg",
+		"name": "Singapore"
+	},
+	"status": "APPROVED",
+	"kycStatusMap": {
+		"JUMIO": "APPROVED",
+		"MY_INFO": "PENDING",
+		"ADDRESS_AND_PHONE_NUMBER": "APPROVED",
+		"NRIC_FIN": "APPROVED"
+	},
+	"simProfiles": [{
+		"iccId": "8947000000000001598",
+		"eSimActivationCode": "FAKE_ACTIVATION_CODE",
+		"status": "AVAILABLE_FOR_DOWNLOAD",
+		"alias": ""
+	}]
+}

--- a/dev-ostelco-ios-clientTests/MockJSON/region_vanuatu.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/region_vanuatu.json
@@ -1,0 +1,11 @@
+{
+	"errorCode": "FAILED_TO_FETCH_REGIONS",
+	"error": {
+		"type": "BELONG_TO_REGION",
+		"id": "5112d0bf-4f58-49ea-b417-2af8d69895d2 -> vu",
+		"error": null,
+		"message": "BELONG_TO_REGION - 5112d0bf-4f58-49ea-b417-2af8d69895d2 -> vu not found."
+	},
+	"status": 404,
+	"message": "Failed to get regions."
+}

--- a/dev-ostelco-ios-clientTests/MockJSON/regions.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/regions.json
@@ -1,0 +1,19 @@
+[{
+	"region": {
+		"id": "sg",
+		"name": "Singapore"
+	},
+	"status": "APPROVED",
+	"kycStatusMap": {
+		"JUMIO": "APPROVED",
+		"MY_INFO": "PENDING",
+		"ADDRESS_AND_PHONE_NUMBER": "APPROVED",
+		"NRIC_FIN": "APPROVED"
+	},
+	"simProfiles": [{
+		"iccId": "8947000000000001598",
+		"eSimActivationCode": "FAKE_ACTIVATION_CODE",
+		"status": "AVAILABLE_FOR_DOWNLOAD",
+		"alias": ""
+	}]
+}]

--- a/dev-ostelco-ios-clientTests/MockJSON/regions_multiple.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/regions_multiple.json
@@ -1,0 +1,23 @@
+[{
+	"region": {
+		"id": "sg",
+		"name": "Singapore"
+	},
+	"status": "PENDING",
+	"kycStatusMap": {
+		"JUMIO": "PENDING",
+		"MY_INFO": "PENDING",
+		"ADDRESS_AND_PHONE_NUMBER": "PENDING",
+		"NRIC_FIN": "PENDING"
+	},
+	"simProfiles": []
+},
+{
+	"region": {
+		"id": "no",
+		"name": "Norway"
+	},
+	"status": "APPROVED",
+	"kycStatusMap": {},
+	"simProfiles": []
+}]

--- a/dev-ostelco-ios-clientTests/MockJSON/sim_profiles_singapore.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/sim_profiles_singapore.json
@@ -1,0 +1,6 @@
+[{
+	"iccId": "8947000000000001598",
+	"eSimActivationCode": "FAKE_ACTIVATION_CODE",
+	"status": "DOWNLOADED",
+	"alias": ""
+}]

--- a/dev-ostelco-ios-clientTests/MockJSON/stripe_ephemeral_key.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/stripe_ephemeral_key.json
@@ -1,0 +1,12 @@
+{
+	"id": "ephkey_FAKE",
+	"object": "ephemeral_key",
+	"associated_objects": [{
+		"type": "customer",
+		"id": "5112d0bf-4f58-49ea-b417-2af8d69895d2"
+	}],
+	"created": 1557842380,
+	"expires": 1557845980,
+	"livemode": true,
+	"secret": "ek_live_FAKE"
+}

--- a/dev-ostelco-ios-clientTests/MyInfoTests.swift
+++ b/dev-ostelco-ios-clientTests/MyInfoTests.swift
@@ -34,6 +34,10 @@ class MyInfoTests: XCTestCase {
         XCTAssertEqual(address.floor, "09")
         XCTAssertEqual(address.building, "PEARL GARDEN")
         
+        XCTAssertEqual(address.addressLine1, "102 BEDOK NORTH AVENUE 4")
+        XCTAssertEqual(address.addressLine2, "460102 SG")
+        XCTAssertEqual(address.formattedAddress, "102 BEDOK NORTH AVENUE 4\n460102 SG")
+        
         guard let mobileNumber = testInfo.mobileNumber else {
             XCTFail("Could not access mobile number!")
             return
@@ -42,5 +46,89 @@ class MyInfoTests: XCTestCase {
         XCTAssertEqual(mobileNumber.prefix, "+")
         XCTAssertEqual(mobileNumber.number, "97399245")
         XCTAssertEqual(mobileNumber.formattedNumber, "+6597399245")
+    }
+    
+    func testAddressFormattingWithMissingBlock() {
+        let address = MyInfoAddress(country: "SG",
+                                    unit: "128",
+                                    street: "BEDOK NORTH AVENUE 4",
+                                    block: nil,
+                                    postal: "460102",
+                                    floor: "09",
+                                    building: "PEARL GARDEN")
+        
+        XCTAssertEqual(address.addressLine1, "BEDOK NORTH AVENUE 4")
+        XCTAssertEqual(address.addressLine2, "460102 SG")
+        XCTAssertEqual(address.formattedAddress, "BEDOK NORTH AVENUE 4\n460102 SG")
+    }
+    
+    func testAddressFormattingWithMissingStreet() {
+        let address = MyInfoAddress(country: "SG",
+                                    unit: "128",
+                                    street: nil,
+                                    block: "102",
+                                    postal: "460102",
+                                    floor: "09",
+                                    building: "PEARL GARDEN")
+        
+        XCTAssertEqual(address.addressLine1, "102")
+        XCTAssertEqual(address.addressLine2, "460102 SG")
+        XCTAssertEqual(address.formattedAddress, "102\n460102 SG")
+    }
+    
+    func testAddressFormattingWithMissingPostcode() {
+        let address = MyInfoAddress(country: "SG",
+                                    unit: "128",
+                                    street: "BEDOK NORTH AVENUE 4",
+                                    block: "102",
+                                    postal: nil,
+                                    floor: "09",
+                                    building: "PEARL GARDEN")
+        
+        XCTAssertEqual(address.addressLine1, "102 BEDOK NORTH AVENUE 4")
+        XCTAssertEqual(address.addressLine2, "SG")
+        XCTAssertEqual(address.formattedAddress, "102 BEDOK NORTH AVENUE 4\nSG")
+    }
+    
+    func testAddressFormattingWithMissingCountry() {
+        let address = MyInfoAddress(country: nil,
+                                    unit: "128",
+                                    street: "BEDOK NORTH AVENUE 4",
+                                    block: "102",
+                                    postal: "460102",
+                                    floor: "09",
+                                    building: "PEARL GARDEN")
+        
+        XCTAssertEqual(address.addressLine1, "102 BEDOK NORTH AVENUE 4")
+        XCTAssertEqual(address.addressLine2, "460102")
+        XCTAssertEqual(address.formattedAddress, "102 BEDOK NORTH AVENUE 4\n460102")
+    }
+    
+    func testAddressFormattingWithMissingBlockAndStreet() {
+        let address = MyInfoAddress(country: "SG",
+                                    unit: "128",
+                                    street: nil,
+                                    block: nil,
+                                    postal: "460102",
+                                    floor: "09",
+                                    building: "PEARL GARDEN")
+        
+        XCTAssertEqual(address.addressLine1, "")
+        XCTAssertEqual(address.addressLine2, "460102 SG")
+        XCTAssertEqual(address.formattedAddress, "460102 SG")
+    }
+    
+    func testAddressFormattingWithMissingPostcodeAndCountry() {
+        let address = MyInfoAddress(country: nil,
+                                    unit: "128",
+                                    street: "BEDOK NORTH AVENUE 4",
+                                    block: "102",
+                                    postal: nil,
+                                    floor: "09",
+                                    building: "PEARL GARDEN")
+        
+        XCTAssertEqual(address.addressLine1, "102 BEDOK NORTH AVENUE 4")
+        XCTAssertEqual(address.addressLine2, "")
+        XCTAssertEqual(address.formattedAddress, "102 BEDOK NORTH AVENUE 4")
     }
 }

--- a/dev-ostelco-ios-clientTests/XCTestCase+MockingHelpers.swift
+++ b/dev-ostelco-ios-clientTests/XCTestCase+MockingHelpers.swift
@@ -47,11 +47,12 @@ extension XCTestCase {
                                                                  line: line))
     }
     
-    func stubAbsoluteURLString(_ absoluteURLString: String,
-                               toLoad fileName: String,
-                               statusCode: Int32 = 200,
-                               file: StaticString = #file,
-                               line: UInt = #line) {
+    func stubAbsolutePath(_ absolutePath: String,
+                          toLoad fileName: String,
+                          statusCode: Int32 = 200,
+                          file: StaticString = #file,
+                          line: UInt = #line) {
+        let absoluteURLString = self.baseURL.absoluteString + "/" + absolutePath
         OHHTTPStubs.stubRequests(passingTest: isAbsoluteURLString(absoluteURLString),
                                  withStubResponse: self.loadFile(named: fileName,
                                                                  statusCode: statusCode,
@@ -78,6 +79,14 @@ extension XCTestCase {
     func stubEmptyDataAtPath(_ path: String,
                              statusCode: Int32) {
         OHHTTPStubs.stubRequests(passingTest: isPath("/\(path)")) { _ in
+            return OHHTTPStubsResponse(data: Data(), statusCode: statusCode, headers: nil)
+        }
+    }
+    
+    func stubEmptyDataAtAbsolutePath(_ absolutePath: String,
+                                     statusCode: Int32) {
+        let absoluteURLString = self.baseURL.absoluteString + "/" + absolutePath
+        OHHTTPStubs.stubRequests(passingTest: isAbsoluteURLString(absoluteURLString)) { _ in
             return OHHTTPStubsResponse(data: Data(), statusCode: statusCode, headers: nil)
         }
     }

--- a/ostelco-core/Extensions/Array+FancyAppend.swift
+++ b/ostelco-core/Extensions/Array+FancyAppend.swift
@@ -26,3 +26,17 @@ public extension Array {
         self.append(closure(unwrapped))
     }
 }
+
+public extension Array where Element: Collection {
+    
+    /// Checks if the passed in element conforming to `Collection` is empty. Discards the element if it's empty, appends it if it's not.
+    ///
+    /// - Parameter element: The element to optionally append.
+    mutating func appendIfNotEmpty(_ element: Element) {
+        guard element.isNotEmpty else {
+            return
+        }
+        
+        self.append(element)
+    }
+}

--- a/ostelco-core/Extensions/URLQueryItem+Codable.swift
+++ b/ostelco-core/Extensions/URLQueryItem+Codable.swift
@@ -1,0 +1,21 @@
+//
+//  URLQueryItem+Codable.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/14/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public extension URLQueryItem {
+    
+    /// Allows a `Codable` item's `CodingKey` to be passed in instead of a raw string as the key
+    ///
+    /// - Parameters:
+    ///   - codingKey: The coding key to use
+    ///   - value: The value to use
+    init(codingKey: CodingKey, value: String) {
+        self.init(name: codingKey.stringValue, value: value)
+    }
+}

--- a/ostelco-core/Models/EKYCAddress.swift
+++ b/ostelco-core/Models/EKYCAddress.swift
@@ -21,4 +21,16 @@ public struct EKYCAddress: Codable {
         self.phoneNumber = phone
         self.address = "\(street);;;\(unit);;;\(city);;;\(postcode);;;\(country)"
     }
+    
+    public enum CodingKeys: String, CodingKey {
+        case address
+        case phoneNumber
+    }
+    
+    public var asQueryItems: [URLQueryItem] {
+        return [
+            URLQueryItem(codingKey: CodingKeys.address, value: self.address),
+            URLQueryItem(codingKey: CodingKeys.phoneNumber, value: self.phoneNumber)
+        ]
+    }
 }

--- a/ostelco-core/Models/EKYCProfileUpdate.swift
+++ b/ostelco-core/Models/EKYCProfileUpdate.swift
@@ -17,4 +17,16 @@ public struct EKYCProfileUpdate: Codable {
         self.address = address
         self.phoneNumber = phoneNumber
     }
+    
+    public enum CodingKeys: String, CodingKey {
+        case address
+        case phoneNumber
+    }
+    
+    public var asQueryItems: [URLQueryItem] {
+        return [
+            URLQueryItem(codingKey: CodingKeys.address, value: self.address),
+            URLQueryItem(codingKey: CodingKeys.phoneNumber, value: self.phoneNumber)
+        ]
+    }
 }

--- a/ostelco-core/Models/EKYCProfileUpdate.swift
+++ b/ostelco-core/Models/EKYCProfileUpdate.swift
@@ -12,6 +12,15 @@ public struct EKYCProfileUpdate: Codable {
     public let address: String
     public let phoneNumber: String
     
+    public init?(myInfoDetails: MyInfoDetails) {
+        guard let phoneNumber = myInfoDetails.mobileNumber?.formattedNumber else {
+            return nil
+        }
+        
+        self.address = myInfoDetails.address.formattedAddress
+        self.phoneNumber = phoneNumber
+    }
+    
     public init(address: String,
                 phoneNumber: String) {
         self.address = address

--- a/ostelco-core/Models/MyInfoDetails.swift
+++ b/ostelco-core/Models/MyInfoDetails.swift
@@ -33,26 +33,25 @@ public struct MyInfoAddress: Codable {
         self.building = building
     }
     
-    public func getAddressLine1() -> String {
-        var addressLine1: String = ""
-        if let block = self.block {
-            addressLine1 = "\(block) "
-        }
-        if let street = self.street {
-            addressLine1 += "\(street) "
-        }
-        return addressLine1
+    public var addressLine1: String {
+        var addressBits = [String]()
+        addressBits.appendIfNotNil(self.block, string: { $0 })
+        addressBits.appendIfNotNil(self.street, string: { $0 })
+        return addressBits.joined(separator: " ")
     }
     
-    public func getAddressLine2() -> String {
-        var addressLine2: String = ""
-        if let postal = self.postal {
-            addressLine2 = "\(postal) "
-        }
-        if let country = self.country {
-            addressLine2 += "\(country) "
-        }
-        return addressLine2
+    public var addressLine2: String {
+        var addressBits = [String]()
+        addressBits.appendIfNotNil(self.postal, string: { $0 })
+        addressBits.appendIfNotNil(self.country, string: { $0 })
+        return addressBits.joined(separator: " ")
+    }
+    
+    public var formattedAddress: String {
+        var addressBits = [String]()
+        addressBits.appendIfNotEmpty(self.addressLine1)
+        addressBits.appendIfNotEmpty(self.addressLine2)
+        return addressBits.joined(separator: "\n")
     }
 }
 
@@ -128,7 +127,11 @@ public struct MyInfoMobileNumber: Codable {
                 return nil
         }
         
-        return "\(prefix)\(code)\(number)"
+        return [
+            prefix,
+            code,
+            number
+        ].joined()
     }
 }
 

--- a/ostelco-core/Models/PaymentInfo.swift
+++ b/ostelco-core/Models/PaymentInfo.swift
@@ -14,4 +14,14 @@ public struct PaymentInfo: Codable {
     public init(sourceID: String) {
         self.sourceId = sourceID
     }
+    
+    public enum CodingKeys: String, CodingKey {
+        case sourceId
+    }
+    
+    public var asQueryItems: [URLQueryItem] {
+        return [
+            URLQueryItem(codingKey: CodingKeys.sourceId, value: self.sourceId)
+        ]
+    }
 }

--- a/ostelco-core/Models/SimProfileRequest.swift
+++ b/ostelco-core/Models/SimProfileRequest.swift
@@ -14,4 +14,14 @@ public struct SimProfileRequest: Codable {
     public init() {
         self.profileType = "iphone"
     }
+    
+    public enum CodingKeys: String, CodingKey {
+        case profileType
+    }
+    
+    public var asQueryItems: [URLQueryItem] {
+        return [
+            URLQueryItem(codingKey: CodingKeys.profileType, value: self.profileType)
+        ]
+    }
 }

--- a/ostelco-core/Models/StripeEphemeralKeyRequest.swift
+++ b/ostelco-core/Models/StripeEphemeralKeyRequest.swift
@@ -1,0 +1,27 @@
+//
+//  StripeEphemeralKeyRequest.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/14/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct StripeEphemeralKeyRequest: Codable {
+    public let apiVersion: String
+    
+    public init(apiVersion: String) {
+        self.apiVersion = apiVersion
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case apiVersion = "api_version"
+    }
+    
+    public var asQueryItems: [URLQueryItem] {
+        return [
+            URLQueryItem(codingKey: CodingKeys.apiVersion, value: self.apiVersion)
+        ]
+    }
+}

--- a/ostelco-core/Models/UserSetup.swift
+++ b/ostelco-core/Models/UserSetup.swift
@@ -17,4 +17,16 @@ public struct UserSetup: Codable {
         self.nickname = nickname
         self.contactEmail = email
     }
+    
+    public enum CodingKeys: String, CodingKey {
+        case nickname
+        case contactEmail
+    }
+    
+    public var asQueryItems: [URLQueryItem] {
+        return [
+            URLQueryItem(codingKey: CodingKeys.nickname, value: self.nickname),
+            URLQueryItem(codingKey: CodingKeys.contactEmail, value: self.contactEmail)
+        ]
+    }
 }

--- a/ostelco-core/Network/APIHelper.swift
+++ b/ostelco-core/Network/APIHelper.swift
@@ -20,6 +20,7 @@ public struct APIHelper {
         case invalidResponseCode(_ code: Int, data: Data)
         case jsonError(_ error: JSONRequestError)
         case serverError(_ error: ServerError)
+        case unexpectedResponseFormat(data: Data)
         
         var localizedDescription: String {
             switch self {
@@ -57,6 +58,13 @@ public struct APIHelper {
                 return """
                 Received server error(s):
                 - \(error.errors.joined(separator: "\n- "))
+                """
+            case .unexpectedResponseFormat(let data):
+                let dataString = String(bytes: data, encoding: .utf8)
+                return """
+                We were expecting a different format than was received.
+                Data received as string:
+                \(String(describing: dataString))
                 """
             }
         }

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -139,10 +139,9 @@ open class PrimeAPI: BasicNetwork {
     }
 
     /// - Returns: A Promise which when fulfilled will contain the Stripe Ephemeral Key
-    public func stripeEphemeralKey(stripeAPIVersion: String) -> Promise<[String: AnyObject]?> {
+    public func stripeEphemeralKey(with request: StripeEphemeralKeyRequest) -> Promise<[String: AnyObject]?> {
         let path = RootEndpoint.customer.pathByAddingEndpoints([CustomerEndpoint.stripeEphemeralKey])
-        let apiQueryItem = URLQueryItem(name: "api_version", value: stripeAPIVersion)
-        return self.loadData(from: path, queryItems: [apiQueryItem])
+        return self.loadData(from: path, queryItems: request.asQueryItems)
             .map { try JSONSerialization.jsonObject(with: $0, options: []) as? [String: AnyObject] }
     }
 

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -139,12 +139,12 @@ open class PrimeAPI: BasicNetwork {
     }
 
     /// - Returns: A Promise which when fulfilled will contain the Stripe Ephemeral Key
-    public func stripeEphemeralKey(with request: StripeEphemeralKeyRequest) -> Promise<[String: AnyHashable]> {
+    public func stripeEphemeralKey(with request: StripeEphemeralKeyRequest) -> Promise<[AnyHashable: Any]> {
         let path = RootEndpoint.customer.pathByAddingEndpoints([CustomerEndpoint.stripeEphemeralKey])
         return self.loadData(from: path, queryItems: request.asQueryItems)
-            .map { data -> [String: AnyHashable] in
+            .map { data -> [AnyHashable: Any] in
                 let object = try JSONSerialization.jsonObject(with: data, options: [])
-                guard let dictionary = object as? [String: AnyHashable] else {
+                guard let dictionary = object as? [AnyHashable: Any] else {
                     throw APIHelper.Error.invalidResponseType(data: data)
                 }
                 return dictionary

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -383,16 +383,6 @@ open class PrimeAPI: BasicNetwork {
             .then { self.performValidatedRequest($0, decoder: self.decoder) }
     }
     
-    public func loadNonValidatedData(from path: String, queryItems: [URLQueryItem]? = nil) -> Promise<(data: Data, response: URLResponse)> {
-        return self.tokenProvider.getToken()
-            .map { Request(baseURL: self.baseURL,
-                           path: path,
-                           queryItems: queryItems,
-                           loggedIn: true,
-                           token: $0) }
-            .then { self.performRequest($0) }
-    }
-    
     /// Sends `Codable` object to the given path based on the base URL.
     /// NOTE: Does not validate directly, since we may need to parse error data which comes back.
     ///

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -139,10 +139,16 @@ open class PrimeAPI: BasicNetwork {
     }
 
     /// - Returns: A Promise which when fulfilled will contain the Stripe Ephemeral Key
-    public func stripeEphemeralKey(with request: StripeEphemeralKeyRequest) -> Promise<[String: AnyObject]?> {
+    public func stripeEphemeralKey(with request: StripeEphemeralKeyRequest) -> Promise<[String: AnyHashable]> {
         let path = RootEndpoint.customer.pathByAddingEndpoints([CustomerEndpoint.stripeEphemeralKey])
         return self.loadData(from: path, queryItems: request.asQueryItems)
-            .map { try JSONSerialization.jsonObject(with: $0, options: []) as? [String: AnyObject] }
+            .map { data -> [String: AnyHashable] in
+                let object = try JSONSerialization.jsonObject(with: data, options: [])
+                guard let dictionary = object as? [String: AnyHashable] else {
+                    throw APIHelper.Error.invalidResponseType(data: data)
+                }
+                return dictionary
+            }
     }
 
     // MARK: - Regions

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -95,9 +95,8 @@ open class PrimeAPI: BasicNetwork {
         ]
         
         let path = RootEndpoint.products.pathByAddingEndpoints(productEndpoints)
-        let queryItem = URLQueryItem(name: "sourceId", value: payment.sourceId)
 
-        return self.sendQuery(to: path, queryItems: [ queryItem ], method: .POST)
+        return self.sendQuery(to: path, queryItems: payment.asQueryItems, method: .POST)
             .done { data, response in
                 try APIHelper.validateAndLookForServerError(data: data,
                                                             response: response,
@@ -113,11 +112,7 @@ open class PrimeAPI: BasicNetwork {
     /// - Parameter userSetup: The `UserSetup` to use.
     /// - Returns: A promise which when fullfilled will contain the created customer model.
     public func createCustomer(with userSetup: UserSetup) -> Promise<CustomerModel> {
-        let queryItems = [
-            URLQueryItem(name: "nickname", value: userSetup.nickname),
-            URLQueryItem(name: "contactEmail", value: userSetup.contactEmail)
-        ]
-        return self.sendQuery(to: RootEndpoint.customer.value, queryItems: queryItems, method: .POST)
+        return self.sendQuery(to: RootEndpoint.customer.value, queryItems: userSetup.asQueryItems, method: .POST)
             .map { data, response in
                 try APIHelper.validateResponse(data: data, response: response, decoder: self.decoder)
             }
@@ -197,9 +192,8 @@ open class PrimeAPI: BasicNetwork {
         ]
     
         let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
-        let queryItem = URLQueryItem(name: "profileType", value: SimProfileRequest().profileType)
 
-        return self.sendQuery(to: path, queryItems: [ queryItem ], method: .POST)
+        return self.sendQuery(to: path, queryItems: SimProfileRequest().asQueryItems, method: .POST)
             .map { data, response in
                 try APIHelper.validateResponse(data: data, response: response, decoder: self.decoder)
             }
@@ -258,12 +252,8 @@ open class PrimeAPI: BasicNetwork {
         ]
 
         let path = RootEndpoint.regions.pathByAddingEndpoints(profileEndpoints)
-        let queryItems = [
-            URLQueryItem(name: "address", value: address.address),
-            URLQueryItem(name: "phoneNumber", value: address.phoneNumber)
-        ]
 
-        return self.sendQuery(to: path, queryItems: queryItems, method: .PUT)
+        return self.sendQuery(to: path, queryItems: address.asQueryItems, method: .PUT)
             .done { data, response in
                 try APIHelper.validateAndLookForServerError(data: data, response: response, decoder: self.decoder, dataCanBeEmpty: true)
             }
@@ -283,12 +273,8 @@ open class PrimeAPI: BasicNetwork {
         ]
 
         let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
-        let queryItems = [
-            URLQueryItem(name: "address", value: update.address),
-            URLQueryItem(name: "phoneNumber", value: update.phoneNumber)
-        ]
 
-        return self.sendQuery(to: path, queryItems: queryItems, method: .PUT)
+        return self.sendQuery(to: path, queryItems: update.asQueryItems, method: .PUT)
             .map { data, response in
                 try APIHelper.validateAndLookForServerError(data: data,
                                                             response: response,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		13590E50313513F4967C8381 /* Pods_ostelco_core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72DCE29F29767B2734BF3223 /* Pods_ostelco_core.framework */; };
 		3DE8BBC08DBE9CD31C4D8ACC /* Pods_ostelco_ios_dev_ostelco_ios_client.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C4A00F4D1901E266946834B /* Pods_ostelco_ios_dev_ostelco_ios_client.framework */; };
 		589A636D9395D888A25E7469 /* Pods_dev_ostelco_ios_clientTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BEE41DA855AF318565ECAFF /* Pods_dev_ostelco_ios_clientTests.framework */; };
+		9B0685F9228AC84F00AD3F3E /* URLQueryItem+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0685F8228AC84F00AD3F3E /* URLQueryItem+Codable.swift */; };
 		9B1745692276D6D800CF321B /* ScanICStepsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1745682276D6D800CF321B /* ScanICStepsViewController.swift */; };
 		9B17456A2276D75700CF321B /* ScanICStepsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1745682276D6D800CF321B /* ScanICStepsViewController.swift */; };
 		9B1745712276F60000CF321B /* Address.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B1745702276F60000CF321B /* Address.storyboard */; };
@@ -441,6 +442,7 @@
 		82A568CF407D7A453ED4152C /* Pods-ostelco-ios-ostelco-ios-client.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ostelco-ios-ostelco-ios-client.release.xcconfig"; path = "Target Support Files/Pods-ostelco-ios-ostelco-ios-client/Pods-ostelco-ios-ostelco-ios-client.release.xcconfig"; sourceTree = "<group>"; };
 		8578A6EA9583065A5342491B /* Pods-ostelco-ios-client.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ostelco-ios-client.debug.xcconfig"; path = "Target Support Files/Pods-ostelco-ios-client/Pods-ostelco-ios-client.debug.xcconfig"; sourceTree = "<group>"; };
 		917B0F5D4E06F092C2FE563F /* Pods-ostelco-core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ostelco-core.debug.xcconfig"; path = "Target Support Files/Pods-ostelco-core/Pods-ostelco-core.debug.xcconfig"; sourceTree = "<group>"; };
+		9B0685F8228AC84F00AD3F3E /* URLQueryItem+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLQueryItem+Codable.swift"; sourceTree = "<group>"; };
 		9B1745682276D6D800CF321B /* ScanICStepsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanICStepsViewController.swift; sourceTree = "<group>"; };
 		9B1745702276F60000CF321B /* Address.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Address.storyboard; sourceTree = "<group>"; };
 		9B1745732276F64B00CF321B /* TextEditCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCell.swift; sourceTree = "<group>"; };
@@ -893,6 +895,7 @@
 				9B9B324F225E423A00227EA3 /* Collection+Empty.swift */,
 				9BBF706A2266162F00E4B9B4 /* UITableView+Generics.swift */,
 				9B82159A227B225400DC6B64 /* String+Static.swift */,
+				9B0685F8228AC84F00AD3F3E /* URLQueryItem+Codable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1888,6 +1891,7 @@
 				9B9B324E225E411700227EA3 /* APIHelper.swift in Sources */,
 				9B851AE1225E33350076ABF3 /* RemainingDataViewController.swift in Sources */,
 				9B9B324A225E3D3900227EA3 /* ProductModel.swift in Sources */,
+				9B0685F9228AC84F00AD3F3E /* URLQueryItem+Codable.swift in Sources */,
 				9BBF70582265EE4F00E4B9B4 /* LocatableCell.swift in Sources */,
 				9B5CBF3C22803D3300D83D7B /* Context.swift in Sources */,
 				9B821590227AD6D200DC6B64 /* EKYCAddress.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		3DE8BBC08DBE9CD31C4D8ACC /* Pods_ostelco_ios_dev_ostelco_ios_client.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C4A00F4D1901E266946834B /* Pods_ostelco_ios_dev_ostelco_ios_client.framework */; };
 		589A636D9395D888A25E7469 /* Pods_dev_ostelco_ios_clientTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BEE41DA855AF318565ECAFF /* Pods_dev_ostelco_ios_clientTests.framework */; };
 		9B0685F9228AC84F00AD3F3E /* URLQueryItem+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0685F8228AC84F00AD3F3E /* URLQueryItem+Codable.swift */; };
+		9B0685FB228ACADA00AD3F3E /* StripeEphemeralKeyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0685FA228ACADA00AD3F3E /* StripeEphemeralKeyRequest.swift */; };
 		9B1745692276D6D800CF321B /* ScanICStepsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1745682276D6D800CF321B /* ScanICStepsViewController.swift */; };
 		9B17456A2276D75700CF321B /* ScanICStepsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1745682276D6D800CF321B /* ScanICStepsViewController.swift */; };
 		9B1745712276F60000CF321B /* Address.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B1745702276F60000CF321B /* Address.storyboard */; };
@@ -443,6 +444,7 @@
 		8578A6EA9583065A5342491B /* Pods-ostelco-ios-client.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ostelco-ios-client.debug.xcconfig"; path = "Target Support Files/Pods-ostelco-ios-client/Pods-ostelco-ios-client.debug.xcconfig"; sourceTree = "<group>"; };
 		917B0F5D4E06F092C2FE563F /* Pods-ostelco-core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ostelco-core.debug.xcconfig"; path = "Target Support Files/Pods-ostelco-core/Pods-ostelco-core.debug.xcconfig"; sourceTree = "<group>"; };
 		9B0685F8228AC84F00AD3F3E /* URLQueryItem+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLQueryItem+Codable.swift"; sourceTree = "<group>"; };
+		9B0685FA228ACADA00AD3F3E /* StripeEphemeralKeyRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeEphemeralKeyRequest.swift; sourceTree = "<group>"; };
 		9B1745682276D6D800CF321B /* ScanICStepsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanICStepsViewController.swift; sourceTree = "<group>"; };
 		9B1745702276F60000CF321B /* Address.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Address.storyboard; sourceTree = "<group>"; };
 		9B1745732276F64B00CF321B /* TextEditCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCell.swift; sourceTree = "<group>"; };
@@ -932,6 +934,7 @@
 				0493B80E2253943900989F40 /* ServerError.swift */,
 				0437CF85224D1E020022A2B8 /* SimProfile.swift */,
 				9B6A9284228418A4007F5EC9 /* SimProfileRequest.swift */,
+				9B0685FA228ACADA00AD3F3E /* StripeEphemeralKeyRequest.swift */,
 				9B5CBF3A22803A9A00D83D7B /* UserSetup.swift */,
 			);
 			path = Models;
@@ -1871,6 +1874,7 @@
 				9B8215822279DF6900DC6B64 /* Region.swift in Sources */,
 				9B851AE4225E33620076ABF3 /* NibLoadable.swift in Sources */,
 				9B82158C227A2F4100DC6B64 /* APIEndpoint.swift in Sources */,
+				9B0685FB228ACADA00AD3F3E /* StripeEphemeralKeyRequest.swift in Sources */,
 				9B5CBF3B22803A9A00D83D7B /* UserSetup.swift in Sources */,
 				9B821599227AFC4700DC6B64 /* ServerError.swift in Sources */,
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,

--- a/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
+++ b/ostelco-ios-client/Models/MyInfoDetails+Testing.swift
@@ -83,8 +83,8 @@ extension MyInfoDetails {
         do {
             let myInfo = try JSONDecoder().decode(MyInfoDetails.self, from: json)
             print("MyInfo \(myInfo)")
-            print("Address 1 \(myInfo.address.getAddressLine1())")
-            print("Address 2 \(myInfo.address.getAddressLine2())")
+            print("Address 1 \(myInfo.address.addressLine1)")
+            print("Address 2 \(myInfo.address.addressLine2)")
             return myInfo
         } catch {
             print("Error \(error)")

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -109,7 +109,7 @@ class MyInfoSummaryViewController: UIViewController {
         }
         name.text = myInfoDetails.name
         dob.text = myInfoDetails.dob
-        address.text = "\(myInfoDetails.address.getAddressLine1())\n\(myInfoDetails.address.getAddressLine2())"
+        address.text = myInfoDetails.address.formattedAddress
         if let nationality = myInfoDetails.nationality {
             self.nationality.text = nationality
         }

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -81,13 +81,12 @@ class MyInfoSummaryViewController: UIViewController {
     
     @IBAction private func `continue`(_ sender: Any) {
         guard
-            let address = self.address.text,
-            let phoneNumber = self.myInfoDetails?.mobileNumber?.formattedNumber else {
-                assertionFailure("Validation passed but we don't have either an address or a phone number?")
+            let details = self.myInfoDetails,
+            let profileUpdate = EKYCProfileUpdate(myInfoDetails: details) else {
+                assertionFailure("Validation passed but we can't create a profile update?")
                 return
         }
         
-        let profileUpdate = EKYCProfileUpdate(address: address, phoneNumber: phoneNumber)
         self.spinnerView = self.showSpinner(onView: self.view)
         APIManager.shared.primeAPI.updateEKYCProfile(with: profileUpdate, forRegion: "sg")
             .ensure { [weak self] in

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -163,7 +163,8 @@ extension ApplePayViewController: STPPaymentContextDelegate, STPCustomerEphemera
 
     // Called automatically by Stripe through the STPCustomerContext object
     func createCustomerKey(withAPIVersion apiVersion: String, completion: @escaping STPJSONResponseCompletionBlock) {
-        APIManager.shared.primeAPI.stripeEphemeralKey(stripeAPIVersion: apiVersion)
+        let request = StripeEphemeralKeyRequest(apiVersion: apiVersion)
+        APIManager.shared.primeAPI.stripeEphemeralKey(with: request)
             .done { key in
                 completion(key, nil)
             }


### PR DESCRIPTION
In this PR: 
- Added a whole mess more mock + live API tests (again, live API tests don't run on the server, and won't run locally unless you have a logged in user).
- Updated Stripe ephemeral token API to return a non optional `[String: AnyHashable]` (which is what auto-converts to `NSDictionary` nowadays)
- Moved some formatting stuff to `MyInfoAddress` and added tests around it
- Updated `Codable` things that are being sent as query params to have `asQueryParams` properties so that's all still under the hood of the object