### PR TITLE
Add lane for Fastlane to call the SPM script so dysms can be properly uploaded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "fastlane", "2.120.0"
+gem "fastlane", "2.123.0"
 gem "cocoapods", "1.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     dotenv (2.7.2)
     emoji_regex (1.0.1)
     escape (0.0.4)
-    excon (0.62.0)
+    excon (0.64.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -67,7 +67,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
-    fastlane (2.120.0)
+    fastlane (2.123.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -153,7 +153,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    os (1.0.0)
+    os (1.0.1)
     plist (3.5.0)
     public_suffix (2.0.5)
     representable (3.0.4)
@@ -187,8 +187,8 @@ GEM
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
-    unicode-display_width (1.5.0)
+    unf_ext (0.0.7.6)
+    unicode-display_width (1.6.0)
     word_wrap (1.0.0)
     xcodeproj (1.8.2)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -206,7 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.6.1)
-  fastlane (= 2.120.0)
+  fastlane (= 2.123.0)
 
 BUNDLED WITH
    2.0.1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -141,16 +141,48 @@ platform :ios do
     )
   end
 
-  desc "Upload latest symbol file to crashlytics"
+  desc "Upload latest iTunes Connect bitcode symbol file to crashlytics"
   lane :refresh_dsyms_beta do
+    # Download latest recompiled dSYM files from iTC
     latest_build_number = latest_testflight_build_number(
       version: "1.1"
     )
     build_number = ((latest_build_number.is_a? String) ? latest_build_number : latest_build_number.to_s)
     download_dsyms(version: "1.1", build_number: build_number)
-#   download_dsyms
-    upload_symbols_to_crashlytics(gsp_path: "./.secrets/GoogleService-Info-dev.plist")   # Upload them to Crashlytics
-    clean_build_artifacts           # Delete the local dSYM files
+
+    # Update the `GoogleService-Info.plist` with secrets
+    run_spm_pre_script
+    upload_symbols_to_crashlytics
+
+    # Delete the local dSYM files
+    clean_build_artifacts
+
+    #Reset the secrets files
+    run_spm_post_script   
+  end
+
+  desc "Runs the SPM pre-build script."
+  desc "Pass in a value for `prod` to use the prod argument"
+  lane :run_spm_pre_script do |options|
+    srcroot = sh("cd .. && pwd")
+    sh("cd ../scripts/SPM && swift build")
+
+    if options[:prod]
+      sh("cd ../scripts/SPM && swift run SPM -pre -prod -src=#{srcroot}")
+    else
+      sh("cd ../scripts/SPM && swift run SPM -pre -src=#{srcroot}")
+    end
+  end
+
+  desc "Runs the SPM post-build script."
+  desc "Pass in a value for `prod` to use the prod argument"
+  lane :run_spm_post_script do |options|
+    srcroot = sh("cd .. && pwd")
+    if options[:prod]
+      sh("cd ../scripts/SPM && swift run SPM -post -prod -src=#{srcroot}")
+    else
+      sh("cd ../scripts/SPM && swift run SPM -post -src=#{srcroot}")
+    end
   end
 
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,7 +45,21 @@ Runs all the tests
 ```
 fastlane ios refresh_dsyms_beta
 ```
-Upload latest symbol file to crashlytics
+Upload latest iTunes Connect bitcode symbol file to crashlytics
+### ios run_spm_pre_script
+```
+fastlane ios run_spm_pre_script
+```
+Runs the SPM pre-build script.
+
+Pass in a value for `prod` to use the prod argument
+### ios run_spm_post_script
+```
+fastlane ios run_spm_post_script
+```
+Runs the SPM post-build script.
+
+Pass in a value for `prod` to use the prod argument
 
 ----
 


### PR DESCRIPTION
In this PR:
- Bumped Fastlane to latest version
- Added a way for Fastlane to call the SPM script. This allows us to keep the `secrets` JSON files as the single source of truth for what needs to go into the `GoogleServices-Info.plist`. 