### PR TITLE
Send more errors to Crashlytics

### DIFF
--- a/ostelco-ios-client/Coordinators/RootCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/RootCoordinator.swift
@@ -40,7 +40,7 @@ class RootCoordinator {
     
     func showEmailEntry() {
         guard let emailNav = Storyboard.email.asUIStoryboard.instantiateInitialViewController() else {
-            assertionFailure("Could not instantiate email nav!")
+            ApplicationErrors.assertAndLog("Could not instantiate email nav!")
             return
         }
         
@@ -54,7 +54,7 @@ class RootCoordinator {
         } else if let topVC = self.topViewController {
             presentingViewController = topVC
         } else {
-            assertionFailure("No view controller?!")
+            ApplicationErrors.assertAndLog("No view controller?!")
             return
         }
         

--- a/ostelco-ios-client/Extensions/UNAuthorizationStatusExtensions.swift
+++ b/ostelco-ios-client/Extensions/UNAuthorizationStatusExtensions.swift
@@ -21,7 +21,7 @@ extension UNAuthorizationStatus {
         case .provisional:
             return "provisional"
         @unknown default:
-            assertionFailure("Apple added something! You should handle it here.")
+            ApplicationErrors.assertAndLog("Apple added something! You should handle it here.")
             return ""
         }
     }

--- a/ostelco-ios-client/ModelControllers/AddressEditDataSource.swift
+++ b/ostelco-ios-client/ModelControllers/AddressEditDataSource.swift
@@ -213,7 +213,7 @@ extension AddressEditDataSource: UITextFieldDelegate {
             let nextSection = textField.tag + 1
             let indexPath = IndexPath(row: 0, section: nextSection)
             guard let cell = self.tableView?.cellForRow(at: indexPath) as? TextEditCell else {
-                assertionFailure("Couldn't get cell for section \(nextSection)")
+                ApplicationErrors.assertAndLog("Couldn't get cell for section \(nextSection)")
                 return false
             }
 

--- a/ostelco-ios-client/Network/AppErrors.swift
+++ b/ostelco-ios-client/Network/AppErrors.swift
@@ -13,11 +13,14 @@ import ostelco_core
 /// Wrapper for logging errors throughout the application
 struct ApplicationErrors {
     enum General: LocalizedError {
+        case assertionFailed(message: String, file: String, line: UInt)
         case noValidPlansFound
         case noMyInfoConfigFound
 
         var localizedDescription: String {
             switch self {
+            case .assertionFailed(let message, let file, let line):
+                return "Assertion failed in \(file) line \(line):\n\(message)"
             case .noValidPlansFound:
                 return "Did not find a valid subscription plan"
             case .noMyInfoConfigFound:
@@ -32,16 +35,54 @@ struct ApplicationErrors {
     /// - Parameters:
     ///   - error: The error to log
     ///   - userInfo: A dictionary with any additional user info to pass along. Defaults to nil.
+    ///   - file: The file where this method was called. Defaults to the direct caller.
+    ///   - line: The line where this method was called. Defaults to the direct caller.
     static func log(_ error: Error,
                     withAdditionalUserInfo userInfo: [String: Any]? = nil,
                     file: StaticString = #file,
                     line: UInt = #line) {
-        let fileName = (String(staticString: file) as NSString).lastPathComponent
         debugPrint("""
-            \(fileName) line \(line)
+            \(file.fileName) line \(line)
             - Error: \(error)
             - UserInfo: \(String(describing: userInfo))
             """)
         Crashlytics.sharedInstance().recordError(error, withAdditionalUserInfo: userInfo)
+    }
+    
+    /// Throws an assertion failure at the point where it's called in non-production builds.
+    ///
+    /// - Parameters:
+    ///   - error: Any error conforming to `LocalizedError`
+    ///   - file: The file where this method was called. Defaults to the direct caller.
+    ///   - line: The line where this method was called. Defaults to the direct caller.
+    static func assertAndLog(_ error: LocalizedError,
+                             file: StaticString = #file,
+                             line: UInt = #line) {
+        assertionFailure(error.localizedDescription, file: file, line: line)
+        self.log(error, file: file, line: line)
+    }
+    
+    /// Throws an assertion failure at the point where it's called in non-production builds.
+    /// Logs a non-fatal error in production builds.
+    ///
+    /// - Parameters:
+    ///   - message: The message to include with the assertion failure
+    ///   - file: The file where this method was called. Defaults to the direct caller.
+    ///   - line: The line where this method was called. Defaults to the direct caller.
+    static func assertAndLog(_ message: String,
+                             file: StaticString = #file,
+                             line: UInt = #line) {
+        assertionFailure(message, file: file, line: line)
+        let error = General.assertionFailed(message: message,
+                                            file: file.fileName,
+                                            line: line)
+        Crashlytics.sharedInstance().recordError(error)
+    }
+}
+
+fileprivate extension StaticString {
+    
+    var fileName: String {
+        return (String(staticString: self) as NSString).lastPathComponent
     }
 }

--- a/ostelco-ios-client/Protocols/ApplePayDelegate.swift
+++ b/ostelco-ios-client/Protocols/ApplePayDelegate.swift
@@ -77,6 +77,7 @@ extension ApplePayDelegate where Self: PKPaymentAuthorizationViewControllerDeleg
             }
             .catch { error in
                 debugPrint("Failed to buy product with sku %{public}@, got error: %{public}@", "123", "\(error)")
+                ApplicationErrors.log(error)
                 self.applePayError = ApplePayError.primeAPIError(error)
                 completion(PKPaymentAuthorizationResult(status: .failure, errors: [error]))
                 // Wait for finish method before we call paymentError()

--- a/ostelco-ios-client/Protocols/LocationCheckingViewController.swift
+++ b/ostelco-ios-client/Protocols/LocationCheckingViewController.swift
@@ -77,6 +77,7 @@ extension LocationChecking {
                 }
                 
                 debugPrint("- LocationChecking: Unable to get and/or reverse geocode location. Error: \(error)")
+                ApplicationErrors.log(error)
                 self?.showFailedToGetLocationAlert()
         }
     }

--- a/ostelco-ios-client/SupportingFiles/Environment.swift
+++ b/ostelco-ios-client/SupportingFiles/Environment.swift
@@ -39,7 +39,7 @@ public class Environment {
     
     public func configuration(_ key: PlistKey) -> String {
         guard let value = self.infoDict[key.rawValue] as? String else {
-            assertionFailure("Could not find string value for \(key.rawValue) in Environment dictionary!")
+            ApplicationErrors.assertAndLog("Could not find string value for \(key.rawValue) in Environment dictionary!")
             return ""
         }
         

--- a/ostelco-ios-client/ViewControllers/Country/AllowLocationAccessViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/AllowLocationAccessViewController.swift
@@ -66,7 +66,7 @@ class AllowLocationAccessViewController: UIViewController {
              .authorizedWhenInUse:
             self.checkLocation()
         @unknown default:
-            assertionFailure("Apple added another case to this! You should update your handling.")
+            ApplicationErrors.assertAndLog("Apple added another case to this! You should update your handling.")
         }
     }
 }

--- a/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
@@ -73,7 +73,7 @@ class LocationProblemViewController: UIViewController {
     
     @IBAction private func primaryButtonTapped() {
         guard let problem = self.locationProblem else {
-            assertionFailure("You should have a problem by this point!")
+            ApplicationErrors.assertAndLog("You should have a problem by this point!")
             return
         }
         
@@ -87,7 +87,7 @@ class LocationProblemViewController: UIViewController {
             // Re-check the user's location
             self.checkLocation()
         case .restrictedByParentalControls:
-            assertionFailure("You shouldn't be able to get here, this button should be gone!")
+            ApplicationErrors.assertAndLog("You shouldn't be able to get here, this button should be gone!")
         }
     }
     
@@ -116,7 +116,7 @@ class LocationProblemViewController: UIViewController {
              .authorizedWhenInUse:
             self.checkLocation()
         @unknown default:
-            assertionFailure("Apple added a new status here! You should update this handling.")
+            ApplicationErrors.assertAndLog("Apple added a new status here! You should update this handling.")
         }
     }
 }

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -154,7 +154,7 @@ class AddressEditViewController: UITableViewController {
     
     private func updateMyInfo() {
         guard let delegate = self.myInfoDelegate else {
-            assertionFailure("You're probably going to want to use a delegate here")
+            ApplicationErrors.assertAndLog("You're probably going to want to use a delegate here")
             return
         }
         

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -77,7 +77,7 @@ class MyInfoSummaryViewController: UIViewController {
             guard
                 let nav = segue.destination as? UINavigationController,
                 let addressVC = nav.topViewController as? AddressEditViewController else {
-                    assertionFailure("Could not access correct view controller!")
+                    ApplicationErrors.assertAndLog("Could not access correct view controller!")
                     return
             }
             
@@ -100,7 +100,7 @@ class MyInfoSummaryViewController: UIViewController {
         guard
             let details = self.myInfoDetails,
             let profileUpdate = EKYCProfileUpdate(myInfoDetails: details) else {
-                assertionFailure("Validation passed but we can't create a profile update?")
+                ApplicationErrors.assertAndLog("Validation passed but we can't create a profile update?")
                 return
         }
         

--- a/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
@@ -29,7 +29,7 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
         case self.scanICCheck:
             self.singPassCheck.isChecked = false
         default:
-            assertionFailure("Unknown option toggled!")
+            ApplicationErrors.assertAndLog("Unknown option toggled!")
         }
         
         self.updateContinue()
@@ -45,7 +45,7 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
             OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "jumio"))
             performSegue(withIdentifier: "nricVerify", sender: self)
         } else {
-            assertionFailure("At least one of these should be checked if continue is enabled!")
+            ApplicationErrors.assertAndLog("At least one of these should be checked if continue is enabled!")
         }
     }
     
@@ -99,7 +99,7 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
     func showMyInfoLogin(url: URL?) {
         guard let url = url else {
             let error = ApplicationErrors.General.noMyInfoConfigFound
-            assertionFailure(error.localizedDescription)
+            ApplicationErrors.assertAndLog(error.localizedDescription)
             ApplicationErrors.log(error)
             return
         }

--- a/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
@@ -99,8 +99,7 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
     func showMyInfoLogin(url: URL?) {
         guard let url = url else {
             let error = ApplicationErrors.General.noMyInfoConfigFound
-            ApplicationErrors.assertAndLog(error.localizedDescription)
-            ApplicationErrors.log(error)
+            ApplicationErrors.assertAndLog(error)
             return
         }
         debugPrint("URL for the login screen: \(url.absoluteString)")

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -39,6 +39,7 @@ class ESIMPendingDownloadViewController: UIViewController {
                 self?.getSimProfileForRegion(region: regionResponse)
             }
             .catch { [weak self] error in
+                ApplicationErrors.log(error)
                 debugPrint("Error getting region: \(error)")
                 self?.performSegue(withIdentifier: "showGenericOhNo", sender: self)
             }

--- a/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
@@ -31,7 +31,7 @@ class CheckEmailViewController: UIViewController {
     
     @IBAction private func resendTapped() {
         guard let email = UserDefaultsWrapper.pendingEmail else {
-            assertionFailure("No pending email?!")
+            ApplicationErrors.assertAndLog("No pending email?!")
             return
         }
         

--- a/ostelco-ios-client/ViewControllers/Email/EmailEntryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Email/EmailEntryViewController.swift
@@ -24,7 +24,7 @@ class EmailEntryViewController: UIViewController {
     
     @IBAction private func continueTapped() {
         guard let email = self.emailTextField.text else {
-            assertionFailure("Email validation passed but the field was nil?!")
+            ApplicationErrors.assertAndLog("Email validation passed but the field was nil?!")
             return
         }
         

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -121,6 +121,7 @@ extension ApplePayViewController: STPPaymentContextDelegate, STPCustomerEphemera
                 completion(nil)
             }
             .catch { error in
+                ApplicationErrors.log(error)
                 debugPrint("Failed to buy product with sku %{public}@, got error: %{public}@", "123", "\(error)")
                 completion(ApplePayError.primeAPIError(error))
             }
@@ -169,6 +170,7 @@ extension ApplePayViewController: STPPaymentContextDelegate, STPCustomerEphemera
                 completion(key, nil)
             }
             .catch { error in
+                ApplicationErrors.log(error)
                 completion(nil, error)
             }
     }

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -100,7 +100,7 @@ class HomeViewController: ApplePayViewController {
                 debugPrint("User has subscription ? \(self.hasSubscription)")
             }
             .catch { error in
-                debugPrint("error fetching products \(error)")
+                ApplicationErrors.log(error)
             }
     }
 

--- a/ostelco-ios-client/ViewControllers/OhNoViewController.swift
+++ b/ostelco-ios-client/ViewControllers/OhNoViewController.swift
@@ -149,7 +149,7 @@ class OhNoViewController: UIViewController {
     
     @IBAction private func primaryButtonTapped() {
         guard let action = self.primaryButtonAction else {
-            assertionFailure("You probably want to do something here!")
+            ApplicationErrors.assertAndLog("You probably want to do something here!")
             return
         }
         

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -34,7 +34,7 @@ class GetStartedViewController: UIViewController {
         }
         
         guard let nickname = self.nameTextField.text else {
-            assertionFailure("No nickname but passed validation?!")
+            ApplicationErrors.assertAndLog("No nickname but passed validation?!")
             return
         }
         


### PR DESCRIPTION
Went through and audited what we're sending to Crashlytics and made sure that: 
- All errors coming through the API or other `catch` blocks in PromiseKit that are not explicitly handled get logged
- We now have an `ApplicationErrors.assertAndLog` method that allows you to have an assertion failure at the point where `assertAndLog` is called during dev, and to send an error to crashlytics in production