### PR TITLE
Fix Button stretchiness

### DIFF
--- a/OstelcoStyles/OstelcoButton.swift
+++ b/OstelcoStyles/OstelcoButton.swift
@@ -54,6 +54,8 @@ open class OstelcoButton: UIButton {
         }
     }
     
+    fileprivate var roundedBackgroundLayer: CAShapeLayer?
+    
     // MARK: - Overridden variables
     
     open override var isEnabled: Bool {
@@ -96,6 +98,17 @@ open class OstelcoButton: UIButton {
     
     // MARK: - Shadow helpers
     
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let shapeLayer = self.roundedBackgroundLayer else {
+            return
+        }
+        
+        let cornerRadius = self.intrinsicContentSize.height / 2
+        shapeLayer.path = UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius).cgPath
+        shapeLayer.shadowPath = shapeLayer.path
+    }
+    
     fileprivate func addRoundingAndShadow(background color: OstelcoColor) {
         let cornerRadius = self.intrinsicContentSize.height / 2
         let shapeLayer = CAShapeLayer()
@@ -110,6 +123,7 @@ open class OstelcoButton: UIButton {
         shapeLayer.shadowRadius = 18
         
         self.layer.insertSublayer(shapeLayer, at: 0)
+        self.roundedBackgroundLayer = shapeLayer
     }
 }
 

--- a/ostelco-ios-client/Storyboards/OhNo.storyboard
+++ b/ostelco-ios-client/Storyboards/OhNo.storyboard
@@ -33,16 +33,16 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Oh no" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Yd-Zwn" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="38.333333333333343"/>
+                                <rect key="frame" x="24" y="88" width="327" height="38.666666666666657"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="illustrationGhost" translatesAutoresizingMaskIntoConstraints="NO" id="AV7-Q3-B39">
-                                <rect key="frame" x="77" y="166.33333333333337" width="221" height="191"/>
+                                <rect key="frame" x="77" y="166.66666666666663" width="221" height="191"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RNV-H2-eGR" customClass="BodyTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="397.33333333333331" width="327" height="101.66666666666669"/>
+                                <rect key="frame" x="24" y="397.66666666666669" width="327" height="101.66666666666669"/>
                                 <string key="text">Something went wrong. Try again in a while.
 
 If you contact customer support, please use this error code: E333</string>


### PR DESCRIPTION
This PR fixes an issue where a rounded button's background was not properly adjusting size when a view was re-laid out, which made `PrimaryButton` in particular look lopsided on an iPhone XS Max. (Good catch @prasanthu)