### PR TITLE
Checkmarks + Radio Buttons + Drop Shadow Buttons

### DIFF
--- a/OstelcoStyles/OstelcoButton.swift
+++ b/OstelcoStyles/OstelcoButton.swift
@@ -239,3 +239,62 @@ public class CheckButton: OstelcoButton {
                       height: 44)
     }
 }
+
+public class RadioButton: OstelcoButton {
+    
+    private let outerCircleWidth: CGFloat = 30
+    private let innerCircleWidth: CGFloat = 14
+    
+    private lazy var outerLayer = CAShapeLayer()
+    private lazy var innerLayer = CAShapeLayer()
+    
+    @IBInspectable
+    public var isCurrentSelected: Bool = false {
+        didSet {
+            self.configureForSelected()
+        }
+    }
+    
+    public override func commonInit() {
+        super.commonInit()
+        self.setupLayers(background: .oyaBlue)
+        self.configureForSelected()
+    }
+    
+    private func configureForSelected() {
+        if self.isCurrentSelected {
+            self.layer.addSublayer(self.innerLayer)
+            // TODO: Localize accessibility
+            self.accessibilityLabel = "Selected"
+            self.layer.addSublayer(self.innerLayer)
+        } else {
+            self.innerLayer.removeFromSuperlayer()
+            self.accessibilityLabel = "Deselected"
+        }
+    }
+    
+    public override var intrinsicContentSize: CGSize {
+        return CGSize(width: 44,
+                      height: 44)
+    }
+    
+    private func setupLayers(background color: OstelcoColor) {
+        let outerLayerInset = (self.intrinsicContentSize.width - self.outerCircleWidth) / 2
+        let outerCornerRadius = self.outerCircleWidth / 2
+        self.outerLayer.path = UIBezierPath(roundedRect: self.bounds.insetBy(dx: outerLayerInset, dy: outerLayerInset),
+                                            cornerRadius: outerCornerRadius).cgPath
+        self.outerLayer.strokeColor = color.toUIColor.cgColor
+        self.outerLayer.lineWidth = 1
+        self.outerLayer.fillColor = nil
+        
+        self.layer.insertSublayer(self.outerLayer, at: 0)
+        
+        let innerLayerInset = (self.intrinsicContentSize.width - self.innerCircleWidth) / 2
+        let innerCornerRadius = self.innerCircleWidth / 2
+        self.innerLayer.path = UIBezierPath(roundedRect: self.bounds.insetBy(dx: innerLayerInset, dy: innerLayerInset),
+                                            cornerRadius: innerCornerRadius).cgPath
+        
+        self.innerLayer.fillColor = color.toUIColor.cgColor
+        self.innerLayer.strokeColor = color.toUIColor.cgColor
+    }
+}

--- a/OstelcoStyles/OstelcoButton.swift
+++ b/OstelcoStyles/OstelcoButton.swift
@@ -189,7 +189,7 @@ public class BuyButton: OstelcoButton {
 
 public class CheckButton: OstelcoButton {
     
-    private let checkSize: CGFloat = 25
+    private let checkSize: CGFloat = 30
   
     @IBInspectable
     public var isChecked: Bool = false {
@@ -205,7 +205,7 @@ public class CheckButton: OstelcoButton {
         
         self.appTitleColor = .white
         self.appFont = OstelcoFont(fontType: .bold,
-                                   fontSize: .body)
+                                   fontSize: .onboarding)
         self.tintColor = .white
         self.setupRoundedCenter(background: .oyaBlue)
         self.configureForChecked()
@@ -225,10 +225,9 @@ public class CheckButton: OstelcoButton {
     }
     
     public func setupRoundedCenter(background color: OstelcoColor) {
-        let cornerRadius = self.checkSize / 2
         let inset = (self.intrinsicContentSize.width - self.checkSize) / 2
         self.shapeLayer.path = UIBezierPath(roundedRect: self.bounds.insetBy(dx: inset, dy: inset),
-                                            cornerRadius: cornerRadius).cgPath
+                                            cornerRadius: 5).cgPath
         self.shapeLayer.strokeColor = color.toUIColor.cgColor
         self.shapeLayer.lineWidth = 1
                 

--- a/OstelcoStyles/OstelcoButton.swift
+++ b/OstelcoStyles/OstelcoButton.swift
@@ -320,8 +320,6 @@ public class DropShadowButton: OstelcoButton {
         self.appTitleColor = .blackForText
         self.appFont = OstelcoFont(fontType: .medium,
                                    fontSize: .body)
-        
-       
         self.layer.insertSublayer(self.dropShadowLayer, at: 0)
        
         if let imageView = self.imageView {

--- a/OstelcoStyles/OstelcoButton.swift
+++ b/OstelcoStyles/OstelcoButton.swift
@@ -298,3 +298,45 @@ public class RadioButton: OstelcoButton {
         self.innerLayer.strokeColor = color.toUIColor.cgColor
     }
 }
+
+public class DropShadowButton: OstelcoButton {
+    
+    private lazy var dropShadowLayer: CAShapeLayer = {
+        let layer = CAShapeLayer()
+        layer.path = UIBezierPath(roundedRect: self.bounds,
+                                  cornerRadius: self.defaultCornerRadius).cgPath
+        
+        layer.shadowColor = OstelcoColor.black.toUIColor.cgColor
+        layer.shadowRadius = 10
+        layer.shadowOpacity = 0.1
+        layer.fillColor = OstelcoColor.white.toUIColor.cgColor
+        
+        return layer
+    }()
+    
+    public override func commonInit() {
+        super.commonInit()
+        
+        self.appTitleColor = .blackForText
+        self.appFont = OstelcoFont(fontType: .medium,
+                                   fontSize: .body)
+        
+       
+        self.layer.insertSublayer(self.dropShadowLayer, at: 0)
+       
+        if let imageView = self.imageView {
+            self.bringSubviewToFront(imageView)
+        }
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        self.dropShadowLayer.path = UIBezierPath(roundedRect: self.bounds,
+                                  cornerRadius: self.defaultCornerRadius).cgPath
+    }
+    
+    public override var intrinsicContentSize: CGSize {
+        return CGSize(width: 154,
+                      height: 56)
+    }
+}

--- a/ostelco-ios-client/Storyboards/EKYC.storyboard
+++ b/ostelco-ios-client/Storyboards/EKYC.storyboard
@@ -18,7 +18,7 @@
                         <viewControllerLayoutGuide type="bottom" id="p4c-8F-xgI"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Dcw-mJ-c2k">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Here is the info  we fetched:" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="16o-pg-vOP">
@@ -101,13 +101,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12 Coronation Rd 078881 Singapore" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5ky-Ux-hgl">
-                                <rect key="frame" x="24" y="493" width="266" height="36"/>
+                                <rect key="frame" x="24" y="493" width="264" height="36"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hw2-9i-yMz" customClass="SmallButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="298" y="493" width="53" height="31"/>
+                                <rect key="frame" x="296" y="493" width="55" height="31"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <state key="normal" title="Edit"/>
                                 <connections>
@@ -127,7 +127,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fyA-B6-gXk" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="102.66666666666669" y="641" width="170" height="33"/>
+                                <rect key="frame" x="98" y="641" width="179" height="33"/>
                                 <state key="normal" title="Try Loading Info Again"/>
                                 <connections>
                                     <action selector="tryAgainTapped" destination="gvs-yG-kvc" eventType="touchUpInside" id="2sS-yZ-6ol"/>
@@ -229,7 +229,7 @@
                         <viewControllerLayoutGuide type="bottom" id="iV4-pi-NqU"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="rVO-dG-aIs">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We're checking your docs right now" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Cv-wX-vOS" customClass="Heading2Label" customModule="OstelcoStyles">
@@ -246,14 +246,14 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KD3-aa-FLQ" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="144" y="617" width="87" height="33"/>
+                                <rect key="frame" x="142" y="617" width="91" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="PEw-c6-lRR" eventType="touchUpInside" id="MNI-eQ-D3e"/>
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="illustrationWaiting" translatesAutoresizingMaskIntoConstraints="NO" id="Aki-Tt-fsJ">
-                                <rect key="frame" x="179.66666666666666" y="229.66666666666666" width="16" height="16"/>
+                                <rect key="frame" x="78.666666666666686" y="229.66666666666663" width="218" height="162"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h7C-ps-86K" customClass="BodyTextLabel" customModule="OstelcoStyles">
                                 <rect key="frame" x="24" y="515.66666666666663" width="327" height="81.333333333333371"/>
@@ -311,24 +311,24 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="2kh-cD-2FL"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="BiG-lB-MH2">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O1J-bp-uX1" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="144" y="617" width="87" height="33"/>
+                                <rect key="frame" x="142" y="617" width="91" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="wph-HM-hyl"/>
                                 </connections>
                             </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="xGh-vN-iQu">
-                                <rect key="frame" x="24" y="362" width="150" height="88"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="xGh-vN-iQu">
+                                <rect key="frame" x="24" y="340" width="210" height="132"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="gCK-9w-EEr">
-                                        <rect key="frame" x="0.0" y="0.0" width="72" height="44"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="210" height="56"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Sx-rK-YKd" customClass="RadioButton" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                <rect key="frame" x="0.0" y="6" width="44" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="44" id="XRY-LM-H4R"/>
                                                     <constraint firstAttribute="height" constant="44" id="hyI-f2-acn"/>
@@ -337,16 +337,20 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                                     <action selector="selectRadioButton:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="w2m-C6-DrG"/>
                                                 </connections>
                                             </button>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="singpass" translatesAutoresizingMaskIntoConstraints="NO" id="6LJ-xY-zOu">
-                                                <rect key="frame" x="56" y="14" width="16" height="16"/>
-                                            </imageView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bjK-SN-c4T" customClass="DropShadowButton" customModule="OstelcoStyles">
+                                                <rect key="frame" x="56" y="0.0" width="154" height="56"/>
+                                                <state key="normal" image="singpass"/>
+                                                <connections>
+                                                    <action selector="singPassTapped" destination="OlM-wU-Qkj" eventType="touchUpInside" id="7Ly-1q-gNW"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="16r-bq-CwZ">
-                                        <rect key="frame" x="0.0" y="44" width="150" height="44"/>
+                                        <rect key="frame" x="0.0" y="76" width="210" height="56"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7f-eC-N4m" customClass="RadioButton" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                <rect key="frame" x="0.0" y="6" width="44" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="AIk-27-VlB"/>
                                                     <constraint firstAttribute="width" constant="44" id="KHj-0z-ggu"/>
@@ -355,15 +359,15 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                                     <action selector="selectRadioButton:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="0K3-A2-fOU"/>
                                                 </connections>
                                             </button>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icIcon" translatesAutoresizingMaskIntoConstraints="NO" id="HlJ-yW-QF5">
-                                                <rect key="frame" x="63.333333333333329" y="14" width="16" height="16"/>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan IC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eew-xB-q0X" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="91.333333333333329" y="11.999999999999998" width="58.666666666666671" height="20.333333333333329"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dig-FV-m5B" customClass="DropShadowButton" customModule="OstelcoStyles">
+                                                <rect key="frame" x="56" y="0.0" width="154" height="56"/>
+                                                <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-10" maxY="0.0"/>
+                                                <inset key="imageEdgeInsets" minX="-10" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                <state key="normal" title="Scan IC" image="icIcon"/>
+                                                <connections>
+                                                    <action selector="scanICTapped" destination="OlM-wU-Qkj" eventType="touchUpInside" id="FzN-Tw-ZMR"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
@@ -399,8 +403,8 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                     </view>
                     <connections>
                         <outlet property="continueButton" destination="Mc8-hP-V8V" id="HU7-u0-dFL"/>
-                        <outlet property="scanICButton" destination="q7f-eC-N4m" id="41k-hd-9Ew"/>
-                        <outlet property="singPassButton" destination="9Sx-rK-YKd" id="TsF-4d-3Q6"/>
+                        <outlet property="scanICRadioButton" destination="q7f-eC-N4m" id="41k-hd-9Ew"/>
+                        <outlet property="singPassRadioButton" destination="9Sx-rK-YKd" id="TsF-4d-3Q6"/>
                         <segue destination="gvs-yG-kvc" kind="show" identifier="myInfoSummary" id="bEO-EU-hWV"/>
                         <segue destination="FwH-jf-eYg" kind="show" identifier="nricVerify" id="Lbu-Hw-uvg"/>
                     </connections>
@@ -418,7 +422,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="3pc-Zv-e1V"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="hBZ-M3-Brj">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nice!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="46U-nA-Oi9" customClass="Heading2Label" customModule="OstelcoStyles">
@@ -428,31 +432,31 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Three steps to get your 2GB of free data" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMb-4L-NZF" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="158.33333333333334" width="327" height="20.333333333333343"/>
+                                <rect key="frame" x="24" y="158.33333333333334" width="327" height="40.666666666666657"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepDoneIcon" translatesAutoresizingMaskIntoConstraints="NO" id="DjD-3R-kYh">
-                                <rect key="frame" x="24" y="210.66666666666666" width="16" height="16"/>
+                                <rect key="frame" x="24" y="231" width="25" height="25"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepArrowIcon" translatesAutoresizingMaskIntoConstraints="NO" id="wHp-SC-2Gv">
-                                <rect key="frame" x="24" y="258.66666666666669" width="16" height="16"/>
+                                <rect key="frame" x="24" y="288" width="25" height="25"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="3." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E0K-H9-c0e" customClass="StepNumberLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24.666666666666671" y="306.66666666666669" width="15" height="21"/>
+                                <rect key="frame" x="29" y="345" width="15" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose country" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gQp-Uu-blB" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="56" y="208.33333333333334" width="122" height="21"/>
+                                <rect key="frame" x="65.000000000000014" y="233" width="130.33333333333337" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set up data = eSIM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wl5-Cn-N6y" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="56" y="306.66666666666669" width="146" height="21"/>
+                                <rect key="frame" x="64.999999999999986" y="345" width="155.66666666666663" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -465,14 +469,14 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KHe-Fa-gNJ" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="144" y="617" width="87" height="33"/>
+                                <rect key="frame" x="142" y="617" width="91" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="GWU-ht-SLC" eventType="touchUpInside" id="BMM-Ak-wo9"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify your identity" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aQM-f2-0Z1" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="56" y="256.33333333333331" width="144" height="21"/>
+                                <rect key="frame" x="65" y="290" width="156" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -525,7 +529,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="F0D-Lc-Y8H"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ue5-OE-BQC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan IC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rBv-vb-fbU" customClass="Heading2Label" customModule="OstelcoStyles">
@@ -541,7 +545,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3T0-Yr-iT7" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="144" y="617" width="87" height="33"/>
+                                <rect key="frame" x="142" y="617" width="91" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped" destination="FwH-jf-eYg" eventType="touchUpInside" id="7cR-DZ-xuB"/>
@@ -555,19 +559,19 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="HNL-Qz-6Vj">
-                                <rect key="frame" x="60" y="275" width="255" height="182"/>
+                                <rect key="frame" x="60" y="275" width="255" height="202.33333333333337"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="27A-Pe-HQh">
-                                        <rect key="frame" x="0.0" y="0.0" width="255" height="20.333333333333332"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="255" height="40.666666666666664"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="1." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZU-3N-JQX" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="12" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="14.333333333333334" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify your NRIC/FIN number" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fbk-ug-6QS" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="28" y="0.0" width="227" height="20.333333333333332"/>
+                                                <rect key="frame" x="30.333333333333329" y="0.0" width="224.66666666666669" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -575,16 +579,16 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="42Y-x0-Ulq">
-                                        <rect key="frame" x="0.0" y="40.333333333333314" width="255" height="20.333333333333329"/>
+                                        <rect key="frame" x="0.0" y="60.666666666666693" width="255" height="20.333333333333336"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="2." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kft-bY-Qe9" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="14.333333333333334" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="17" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan your IC card" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2IE-pd-quO" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="30.333333333333329" y="0.0" width="224.66666666666669" height="20.333333333333332"/>
+                                                <rect key="frame" x="33" y="0.0" width="222" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -592,16 +596,16 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jci-De-sMQ">
-                                        <rect key="frame" x="0.0" y="80.666666666666686" width="255" height="40.666666666666657"/>
+                                        <rect key="frame" x="0.0" y="101" width="255" height="40.666666666666657"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="3." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1c2-oO-6wu" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="14.666666666666666" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="16.666666666666668" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify that you look like the photo on your IC card" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xb2-uC-Py9" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="30.666666666666671" y="0.0" width="224.33333333333331" height="40.666666666666664"/>
+                                                <rect key="frame" x="32.666666666666671" y="0.0" width="222.33333333333331" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -609,16 +613,16 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Mgw-vN-84h">
-                                        <rect key="frame" x="0.0" y="141.33333333333331" width="255" height="40.666666666666657"/>
+                                        <rect key="frame" x="0.0" y="161.66666666666669" width="255" height="40.666666666666657"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="4." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YBz-xS-yJa" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="14.666666666666666" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="17.333333333333332" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We will ask you for your address" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nd8-hl-wR3" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="30.666666666666671" y="0.0" width="224.33333333333331" height="40.666666666666664"/>
+                                                <rect key="frame" x="33.333333333333329" y="0.0" width="221.66666666666669" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -628,7 +632,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Fv-ik-v5D" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="9" y="64" width="54" height="21"/>
+                                <rect key="frame" x="9" y="64" width="52" height="21"/>
                                 <inset key="titleEdgeInsets" minX="8" minY="0.0" maxX="-8" maxY="0.0"/>
                                 <state key="normal" title="Back" image="backChevron"/>
                                 <connections>
@@ -670,17 +674,17 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="Tux-FP-Dur"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="tpz-qF-L8m">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What is your NRIC/FIN?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vEw-Za-1UP" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="38.333333333333343"/>
+                                <rect key="frame" x="24" y="88" width="327" height="76.666666666666686"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="e.g S XXX XXX XXD" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MrK-sD-vRV" userLabel="NRIC Text Field" customClass="TopBottomBorderedTextField" customModule="OstelcoStyles">
-                                <rect key="frame" x="0.0" y="158.33333333333334" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="196.66666666666666" width="375" height="44"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" spellCheckingType="no" returnKeyType="done"/>
@@ -689,13 +693,13 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </connections>
                             </textField>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This seems to be an invalid NRIC" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDg-bU-7nA" customClass="ErrorTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="226.33333333333334" width="327" height="20.333333333333343"/>
+                                <rect key="frame" x="24" y="264.66666666666669" width="327" height="20.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cv2-1J-Hak" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="144" y="617" width="87" height="33"/>
+                                <rect key="frame" x="142" y="617" width="91" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="6Sh-M6-Cr3" eventType="touchUpInside" id="0oS-XB-bc9"/>

--- a/ostelco-ios-client/Storyboards/EKYC.storyboard
+++ b/ostelco-ios-client/Storyboards/EKYC.storyboard
@@ -18,7 +18,7 @@
                         <viewControllerLayoutGuide type="bottom" id="p4c-8F-xgI"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Dcw-mJ-c2k">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Here is the info  we fetched:" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="16o-pg-vOP">
@@ -101,13 +101,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12 Coronation Rd 078881 Singapore" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5ky-Ux-hgl">
-                                <rect key="frame" x="24" y="493" width="264" height="36"/>
+                                <rect key="frame" x="24" y="493" width="266" height="36"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hw2-9i-yMz" customClass="SmallButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="296" y="493" width="55" height="31"/>
+                                <rect key="frame" x="298" y="493" width="53" height="31"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <state key="normal" title="Edit"/>
                                 <connections>
@@ -127,7 +127,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fyA-B6-gXk" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="98" y="641" width="179" height="33"/>
+                                <rect key="frame" x="102.66666666666669" y="641" width="170" height="33"/>
                                 <state key="normal" title="Try Loading Info Again"/>
                                 <connections>
                                     <action selector="tryAgainTapped" destination="gvs-yG-kvc" eventType="touchUpInside" id="2sS-yZ-6ol"/>
@@ -229,7 +229,7 @@
                         <viewControllerLayoutGuide type="bottom" id="iV4-pi-NqU"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="rVO-dG-aIs">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We're checking your docs right now" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Cv-wX-vOS" customClass="Heading2Label" customModule="OstelcoStyles">
@@ -246,14 +246,14 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KD3-aa-FLQ" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="144" y="617" width="87" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="PEw-c6-lRR" eventType="touchUpInside" id="MNI-eQ-D3e"/>
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="illustrationWaiting" translatesAutoresizingMaskIntoConstraints="NO" id="Aki-Tt-fsJ">
-                                <rect key="frame" x="78.666666666666686" y="229.66666666666663" width="218" height="162"/>
+                                <rect key="frame" x="179.66666666666666" y="229.66666666666666" width="16" height="16"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h7C-ps-86K" customClass="BodyTextLabel" customModule="OstelcoStyles">
                                 <rect key="frame" x="24" y="515.66666666666663" width="327" height="81.333333333333371"/>
@@ -311,55 +311,55 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="2kh-cD-2FL"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="BiG-lB-MH2">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O1J-bp-uX1" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="144" y="617" width="87" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="wph-HM-hyl"/>
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="xGh-vN-iQu">
-                                <rect key="frame" x="24" y="362" width="166" height="88"/>
+                                <rect key="frame" x="24" y="362" width="150" height="88"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="gCK-9w-EEr">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="44"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="72" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Sx-rK-YKd" customClass="CheckButton" customModule="OstelcoStyles">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Sx-rK-YKd" customClass="RadioButton" customModule="OstelcoStyles">
                                                 <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="44" id="XRY-LM-H4R"/>
                                                     <constraint firstAttribute="height" constant="44" id="hyI-f2-acn"/>
                                                 </constraints>
                                                 <connections>
-                                                    <action selector="checkTapped:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="w2m-C6-DrG"/>
+                                                    <action selector="selectRadioButton:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="w2m-C6-DrG"/>
                                                 </connections>
                                             </button>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="singpass" translatesAutoresizingMaskIntoConstraints="NO" id="6LJ-xY-zOu">
-                                                <rect key="frame" x="56" y="4" width="76" height="36"/>
+                                                <rect key="frame" x="56" y="14" width="16" height="16"/>
                                             </imageView>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="16r-bq-CwZ">
-                                        <rect key="frame" x="0.0" y="44" width="166" height="44"/>
+                                        <rect key="frame" x="0.0" y="44" width="150" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7f-eC-N4m" customClass="CheckButton" customModule="OstelcoStyles">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7f-eC-N4m" customClass="RadioButton" customModule="OstelcoStyles">
                                                 <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="AIk-27-VlB"/>
                                                     <constraint firstAttribute="width" constant="44" id="KHj-0z-ggu"/>
                                                 </constraints>
                                                 <connections>
-                                                    <action selector="checkTapped:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="0K3-A2-fOU"/>
+                                                    <action selector="selectRadioButton:" destination="OlM-wU-Qkj" eventType="touchUpInside" id="0K3-A2-fOU"/>
                                                 </connections>
                                             </button>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icIcon" translatesAutoresizingMaskIntoConstraints="NO" id="HlJ-yW-QF5">
-                                                <rect key="frame" x="65.333333333333329" y="15" width="26" height="14"/>
+                                                <rect key="frame" x="63.333333333333329" y="14" width="16" height="16"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan IC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eew-xB-q0X" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="103.33333333333333" y="11.999999999999998" width="62.666666666666671" height="20.333333333333329"/>
+                                                <rect key="frame" x="91.333333333333329" y="11.999999999999998" width="58.666666666666671" height="20.333333333333329"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -399,8 +399,8 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                     </view>
                     <connections>
                         <outlet property="continueButton" destination="Mc8-hP-V8V" id="HU7-u0-dFL"/>
-                        <outlet property="scanICCheck" destination="q7f-eC-N4m" id="41k-hd-9Ew"/>
-                        <outlet property="singPassCheck" destination="9Sx-rK-YKd" id="TsF-4d-3Q6"/>
+                        <outlet property="scanICButton" destination="q7f-eC-N4m" id="41k-hd-9Ew"/>
+                        <outlet property="singPassButton" destination="9Sx-rK-YKd" id="TsF-4d-3Q6"/>
                         <segue destination="gvs-yG-kvc" kind="show" identifier="myInfoSummary" id="bEO-EU-hWV"/>
                         <segue destination="FwH-jf-eYg" kind="show" identifier="nricVerify" id="Lbu-Hw-uvg"/>
                     </connections>
@@ -418,7 +418,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="3pc-Zv-e1V"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="hBZ-M3-Brj">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nice!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="46U-nA-Oi9" customClass="Heading2Label" customModule="OstelcoStyles">
@@ -428,31 +428,31 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Three steps to get your 2GB of free data" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMb-4L-NZF" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="158.33333333333334" width="327" height="40.666666666666657"/>
+                                <rect key="frame" x="24" y="158.33333333333334" width="327" height="20.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepDoneIcon" translatesAutoresizingMaskIntoConstraints="NO" id="DjD-3R-kYh">
-                                <rect key="frame" x="24" y="231" width="25" height="25"/>
+                                <rect key="frame" x="24" y="210.66666666666666" width="16" height="16"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepArrowIcon" translatesAutoresizingMaskIntoConstraints="NO" id="wHp-SC-2Gv">
-                                <rect key="frame" x="24" y="288" width="25" height="25"/>
+                                <rect key="frame" x="24" y="258.66666666666669" width="16" height="16"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="3." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E0K-H9-c0e" customClass="StepNumberLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="29.333333333333332" y="345" width="14.666666666666668" height="21"/>
+                                <rect key="frame" x="24.666666666666671" y="306.66666666666669" width="15" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose country" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gQp-Uu-blB" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="65.000000000000014" y="233" width="130.33333333333337" height="21"/>
+                                <rect key="frame" x="56" y="208.33333333333334" width="122" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set up data = eSIM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wl5-Cn-N6y" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="64.999999999999986" y="345" width="155.66666666666663" height="21"/>
+                                <rect key="frame" x="56" y="306.66666666666669" width="146" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -465,14 +465,14 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KHe-Fa-gNJ" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="144" y="617" width="87" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="GWU-ht-SLC" eventType="touchUpInside" id="BMM-Ak-wo9"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify your identity" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aQM-f2-0Z1" customClass="StepsTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="65" y="290.33333333333331" width="156" height="20.666666666666686"/>
+                                <rect key="frame" x="56" y="256.33333333333331" width="144" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -525,7 +525,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="F0D-Lc-Y8H"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ue5-OE-BQC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan IC" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rBv-vb-fbU" customClass="Heading2Label" customModule="OstelcoStyles">
@@ -541,7 +541,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3T0-Yr-iT7" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="144" y="617" width="87" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped" destination="FwH-jf-eYg" eventType="touchUpInside" id="7cR-DZ-xuB"/>
@@ -555,19 +555,19 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="HNL-Qz-6Vj">
-                                <rect key="frame" x="60" y="275" width="255" height="202.33333333333337"/>
+                                <rect key="frame" x="60" y="275" width="255" height="182"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="27A-Pe-HQh">
-                                        <rect key="frame" x="0.0" y="0.0" width="255" height="40.666666666666664"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="255" height="20.333333333333332"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="1." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZU-3N-JQX" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="14.333333333333334" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="12" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify your NRIC/FIN number" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fbk-ug-6QS" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="30.333333333333329" y="0.0" width="224.66666666666669" height="40.666666666666664"/>
+                                                <rect key="frame" x="28" y="0.0" width="227" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -575,16 +575,16 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="42Y-x0-Ulq">
-                                        <rect key="frame" x="0.0" y="60.666666666666693" width="255" height="20.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="40.333333333333314" width="255" height="20.333333333333329"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="2." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kft-bY-Qe9" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="17" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="14.333333333333334" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan your IC card" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2IE-pd-quO" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="33" y="0.0" width="222" height="20.333333333333332"/>
+                                                <rect key="frame" x="30.333333333333329" y="0.0" width="224.66666666666669" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -592,16 +592,16 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jci-De-sMQ">
-                                        <rect key="frame" x="0.0" y="101" width="255" height="40.666666666666657"/>
+                                        <rect key="frame" x="0.0" y="80.666666666666686" width="255" height="40.666666666666657"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="3." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1c2-oO-6wu" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="16.666666666666668" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="14.666666666666666" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verify that you look like the photo on your IC card" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xb2-uC-Py9" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="32.666666666666671" y="0.0" width="222.33333333333331" height="40.666666666666664"/>
+                                                <rect key="frame" x="30.666666666666671" y="0.0" width="224.33333333333331" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -609,16 +609,16 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Mgw-vN-84h">
-                                        <rect key="frame" x="0.0" y="161.66666666666669" width="255" height="40.666666666666657"/>
+                                        <rect key="frame" x="0.0" y="141.33333333333331" width="255" height="40.666666666666657"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="4." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YBz-xS-yJa" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="0.0" y="0.0" width="17.333333333333332" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="14.666666666666666" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We will ask you for your address" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nd8-hl-wR3" customClass="BodyTextBoldLabel" customModule="OstelcoStyles">
-                                                <rect key="frame" x="33.333333333333329" y="0.0" width="221.66666666666669" height="40.666666666666664"/>
+                                                <rect key="frame" x="30.666666666666671" y="0.0" width="224.33333333333331" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -628,7 +628,7 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Fv-ik-v5D" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="9" y="64" width="52" height="21"/>
+                                <rect key="frame" x="9" y="64" width="54" height="21"/>
                                 <inset key="titleEdgeInsets" minX="8" minY="0.0" maxX="-8" maxY="0.0"/>
                                 <state key="normal" title="Back" image="backChevron"/>
                                 <connections>
@@ -670,17 +670,17 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                         <viewControllerLayoutGuide type="bottom" id="Tux-FP-Dur"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="tpz-qF-L8m">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What is your NRIC/FIN?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vEw-Za-1UP" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="76.666666666666686"/>
+                                <rect key="frame" x="24" y="88" width="327" height="38.333333333333343"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="e.g S XXX XXX XXD" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MrK-sD-vRV" userLabel="NRIC Text Field" customClass="TopBottomBorderedTextField" customModule="OstelcoStyles">
-                                <rect key="frame" x="0.0" y="196.66666666666666" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="158.33333333333334" width="375" height="44"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" spellCheckingType="no" returnKeyType="done"/>
@@ -689,13 +689,13 @@ If you've enabled push notifications we'll let you know when it's done!</string>
                                 </connections>
                             </textField>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This seems to be an invalid NRIC" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDg-bU-7nA" customClass="ErrorTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="264.66666666666669" width="327" height="20.333333333333314"/>
+                                <rect key="frame" x="24" y="226.33333333333334" width="327" height="20.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cv2-1J-Hak" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="144" y="617" width="87" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped:" destination="6Sh-M6-Cr3" eventType="touchUpInside" id="0oS-XB-bc9"/>

--- a/ostelco-ios-client/Storyboards/SignUp.storyboard
+++ b/ostelco-ios-client/Storyboards/SignUp.storyboard
@@ -84,35 +84,63 @@
                                     <action selector="needHelpTapped" destination="Q2B-DW-NZJ" eventType="touchUpInside" id="Jcv-PQ-0I3"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z7I-ar-SNO" customClass="CheckButton" customModule="OstelcoStyles">
+                                <rect key="frame" x="65" y="404.33333333333331" width="44" height="44"/>
+                                <gestureRecognizers/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="44" id="Nyb-6M-zL2"/>
+                                    <constraint firstAttribute="height" constant="44" id="uL1-iU-ZVt"/>
+                                </constraints>
+                                <connections>
+                                    <action selector="checkButtonTapped:" destination="Q2B-DW-NZJ" eventType="touchUpInside" id="8xU-Qe-F1k"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="I am at least 18 years of age" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TvT-X2-jqG" customClass="BodyTextLabel" customModule="OstelcoStyles">
+                                <rect key="frame" x="132" y="406" width="178" height="40.666666666666686"/>
+                                <gestureRecognizers/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="bjz-VS-NgE" appends="YES" id="9G7-NM-o7J"/>
+                                </connections>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="NBH-PE-WSS" firstAttribute="top" secondItem="lio-dE-X4q" secondAttribute="top" constant="44" id="0cg-Fv-WhP"/>
                             <constraint firstItem="lio-dE-X4q" firstAttribute="trailing" secondItem="fhX-lv-Abz" secondAttribute="trailing" constant="65" id="3E6-mj-6hA"/>
-                            <constraint firstItem="lio-dE-X4q" firstAttribute="trailing" secondItem="4ct-C6-Ngo" secondAttribute="trailing" constant="65" id="5Rb-94-nUc"/>
                             <constraint firstItem="BD5-xy-nGB" firstAttribute="centerX" secondItem="zpm-C6-zzH" secondAttribute="centerX" id="8dJ-8r-QWn"/>
                             <constraint firstItem="NBH-PE-WSS" firstAttribute="leading" secondItem="lio-dE-X4q" secondAttribute="leading" constant="24" id="BeZ-UY-Gdf"/>
-                            <constraint firstItem="4ct-C6-Ngo" firstAttribute="leading" secondItem="oKo-ag-iar" secondAttribute="trailing" constant="23" id="GNE-Kg-32f"/>
                             <constraint firstItem="lio-dE-X4q" firstAttribute="trailing" secondItem="MU2-9r-kL0" secondAttribute="trailing" constant="24" id="GNQ-Lg-84S"/>
+                            <constraint firstItem="4ct-C6-Ngo" firstAttribute="trailing" secondItem="fhX-lv-Abz" secondAttribute="trailing" id="GOw-Mp-bYD"/>
                             <constraint firstItem="5XH-1y-ENz" firstAttribute="top" secondItem="BD5-xy-nGB" secondAttribute="bottom" constant="100" id="GfF-9T-6zt"/>
                             <constraint firstItem="4ct-C6-Ngo" firstAttribute="top" secondItem="fhX-lv-Abz" secondAttribute="bottom" constant="20" id="IUE-5g-NOK"/>
+                            <constraint firstItem="TvT-X2-jqG" firstAttribute="centerY" secondItem="Z7I-ar-SNO" secondAttribute="centerY" id="JgO-vc-8AU"/>
                             <constraint firstItem="fhX-lv-Abz" firstAttribute="leading" secondItem="5XH-1y-ENz" secondAttribute="trailing" constant="23" id="LEK-hf-ddd"/>
                             <constraint firstItem="4ct-C6-Ngo" firstAttribute="centerY" secondItem="oKo-ag-iar" secondAttribute="centerY" id="LbA-yV-Ff1"/>
+                            <constraint firstItem="TvT-X2-jqG" firstAttribute="leading" secondItem="fhX-lv-Abz" secondAttribute="leading" id="OtN-kO-PDx"/>
                             <constraint firstItem="BD5-xy-nGB" firstAttribute="top" secondItem="NBH-PE-WSS" secondAttribute="bottom" constant="16" id="U39-4i-Nkw"/>
                             <constraint firstItem="oKo-ag-iar" firstAttribute="leading" secondItem="lio-dE-X4q" secondAttribute="leading" constant="65" id="VFI-OQ-ZEj"/>
                             <constraint firstItem="IDd-hs-GvP" firstAttribute="centerX" secondItem="zpm-C6-zzH" secondAttribute="centerX" id="W8Z-E6-2jP"/>
+                            <constraint firstItem="TvT-X2-jqG" firstAttribute="trailing" secondItem="fhX-lv-Abz" secondAttribute="trailing" id="XE1-Zb-85r"/>
                             <constraint firstItem="lio-dE-X4q" firstAttribute="trailing" secondItem="BD5-xy-nGB" secondAttribute="trailing" constant="16" id="ZJn-iF-S9D"/>
+                            <constraint firstItem="4ct-C6-Ngo" firstAttribute="leading" secondItem="fhX-lv-Abz" secondAttribute="leading" id="ZaO-ao-Ckd"/>
                             <constraint firstItem="BD5-xy-nGB" firstAttribute="leading" secondItem="lio-dE-X4q" secondAttribute="leading" constant="16" id="aFU-nu-jr4"/>
+                            <constraint firstItem="TvT-X2-jqG" firstAttribute="top" secondItem="4ct-C6-Ngo" secondAttribute="bottom" constant="20" id="bNp-SB-VZa"/>
                             <constraint firstItem="lio-dE-X4q" firstAttribute="bottom" secondItem="MU2-9r-kL0" secondAttribute="bottom" constant="44" id="icc-2j-d81"/>
                             <constraint firstItem="MU2-9r-kL0" firstAttribute="top" secondItem="IDd-hs-GvP" secondAttribute="bottom" constant="34" id="sKh-zY-Lq2"/>
                             <constraint firstItem="fhX-lv-Abz" firstAttribute="centerY" secondItem="5XH-1y-ENz" secondAttribute="centerY" id="t7m-si-hg8"/>
                             <constraint firstItem="MU2-9r-kL0" firstAttribute="leading" secondItem="lio-dE-X4q" secondAttribute="leading" constant="24" id="tTI-YA-gy5"/>
+                            <constraint firstItem="TvT-X2-jqG" firstAttribute="leading" secondItem="Z7I-ar-SNO" secondAttribute="trailing" constant="23" id="vJa-Sd-San"/>
                             <constraint firstItem="5XH-1y-ENz" firstAttribute="leading" secondItem="lio-dE-X4q" secondAttribute="leading" constant="65" id="vNj-e6-gl9"/>
                             <constraint firstItem="lio-dE-X4q" firstAttribute="trailing" secondItem="NBH-PE-WSS" secondAttribute="trailing" constant="24" id="w4f-oW-00N"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="lio-dE-X4q"/>
                     </view>
                     <connections>
+                        <outlet property="ageCheck" destination="Z7I-ar-SNO" id="T66-cr-rlM"/>
+                        <outlet property="ageLabel" destination="TvT-X2-jqG" id="dpO-OW-wPQ"/>
                         <outlet property="continueButton" destination="MU2-9r-kL0" id="0g2-uG-RTP"/>
                         <outlet property="privacyPolicyCheck" destination="oKo-ag-iar" id="gbE-PR-csP"/>
                         <outlet property="privacyPolicyLabel" destination="4ct-C6-Ngo" id="enC-yd-tzb"/>
@@ -131,6 +159,11 @@
                         <action selector="privacyPolicyTappedWithSender:" destination="Q2B-DW-NZJ" id="GEg-Cz-lQG"/>
                     </connections>
                 </tapGestureRecognizer>
+                <tapGestureRecognizer id="bjz-VS-NgE">
+                    <connections>
+                        <action selector="ageTappedWithSender:" destination="Q2B-DW-NZJ" id="HI6-zz-Z5D"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="60" y="28.335832083958024"/>
         </scene>
@@ -143,19 +176,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Allow push notifications" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dam-4t-AgC" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="76.666666666666686"/>
+                                <rect key="frame" x="24" y="88" width="327" height="36"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you let us, we'll let you know when your 2GB is ready to use" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n4R-BI-FHP" customClass="BodyTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="16" y="180.66666666666666" width="343" height="40.666666666666657"/>
+                                <rect key="frame" x="16" y="140" width="343" height="40.666666666666657"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Uy-4i-IUw" customClass="PrimaryButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="684" width="327" height="50"/>
+                                <rect key="frame" x="24" y="704" width="327" height="30"/>
                                 <state key="normal" title="Continue"/>
                                 <connections>
                                     <action selector="continueTapped" destination="Cs5-Hy-gA9" eventType="touchUpInside" id="USN-HI-rjY"/>
@@ -165,7 +198,7 @@
                                 <rect key="frame" x="56" y="304" width="291" height="204"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DAB-Zm-rhZ" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="148.66666666666666" y="640" width="78" height="30"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped" destination="Cs5-Hy-gA9" eventType="touchUpInside" id="WQL-DB-YsR"/>
@@ -209,19 +242,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Get Started" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="58z-OV-xk5" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="38.333333333333343"/>
+                                <rect key="frame" x="24" y="88" width="327" height="36"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WHAT SHOULD WE CALL YOU?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nv8-qY-Xwu">
-                                <rect key="frame" x="16" y="182.33333333333334" width="193" height="16"/>
+                                <rect key="frame" x="16" y="180" width="193" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="e.g Jolly" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j3T-mX-GWu" customClass="TopBottomBorderedTextField" customModule="OstelcoStyles">
-                                <rect key="frame" x="0.0" y="206.33333333333334" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="204" width="375" height="17"/>
                                 <accessibility key="accessibilityConfiguration" hint="test"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -231,14 +264,14 @@
                                 </connections>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ERf-ng-eZR" customClass="PrimaryButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="684" width="327" height="50"/>
+                                <rect key="frame" x="24" y="704" width="327" height="30"/>
                                 <state key="normal" title="Continue"/>
                                 <connections>
                                     <action selector="continueTapped:" destination="kSR-PZ-JWA" eventType="touchUpInside" id="QEI-Mx-3pr"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uVN-En-ghf" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="142" y="617" width="91" height="33"/>
+                                <rect key="frame" x="148.66666666666666" y="640" width="78" height="30"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped" destination="kSR-PZ-JWA" eventType="touchUpInside" id="uXb-1v-ADe"/>

--- a/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
@@ -12,36 +12,38 @@ import OstelcoStyles
 
 class SelectIdentityVerificationMethodViewController: UIViewController {
     
-    @IBOutlet private var singPassCheck: CheckButton!
-    @IBOutlet private var scanICCheck: CheckButton!
+    @IBOutlet private var singPassButton: RadioButton!
+    @IBOutlet private var scanICButton: RadioButton!
     @IBOutlet private var continueButton: UIButton!
+
+    private lazy var radioButtons: [RadioButton] = [
+        self.singPassButton,
+        self.scanICButton
+    ]
     
     var webView: SFSafariViewController?
     var myInfoQueryItems: [URLQueryItem]?
     var spinnerView: UIView?
 
-    @IBAction private func checkTapped(_ check: CheckButton) {
-        check.isChecked.toggle()
-        
-        switch check {
-        case self.singPassCheck:
-            self.scanICCheck.isChecked = false
-        case self.scanICCheck:
-            self.singPassCheck.isChecked = false
-        default:
-            ApplicationErrors.assertAndLog("Unknown option toggled!")
+    @IBAction private func selectRadioButton(_ radioButton: RadioButton) {
+        self.radioButtons.forEach { button in
+            if button == radioButton {
+                button.isCurrentSelected = true
+            } else {
+                button.isCurrentSelected = false
+            }
         }
         
         self.updateContinue()
     }
     
     @IBAction private func continueTapped() {
-        if self.singPassCheck.isChecked {
+        if self.singPassButton.isCurrentSelected {
             OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "singpass"))
             //performSegue(withIdentifier: "myInfoSummary", sender: self)
             UIApplication.shared.typedDelegate.myInfoDelegate = self
             startMyInfoLogin()
-        } else if self.scanICCheck.isChecked {
+        } else if self.singPassButton.isCurrentSelected {
             OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "jumio"))
             performSegue(withIdentifier: "nricVerify", sender: self)
         } else {
@@ -50,15 +52,16 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
     }
     
     private func updateContinue() {
-        if self.singPassCheck.isChecked || self.scanICCheck.isChecked {
+        if self.radioButtons.contains(where: { $0.isCurrentSelected }) {
             self.continueButton.isEnabled = true
         } else {
+            // No option has been selected yet. Disable.
             self.continueButton.isEnabled = false
         }
     }
     
     @IBAction private func needHelpTapped(_ sender: Any) {
-        showNeedHelpActionSheet()
+        self.showNeedHelpActionSheet()
     }
     
     func startMyInfoLogin() {

--- a/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
@@ -12,18 +12,23 @@ import OstelcoStyles
 
 class SelectIdentityVerificationMethodViewController: UIViewController {
     
-    @IBOutlet private var singPassButton: RadioButton!
-    @IBOutlet private var scanICButton: RadioButton!
+    @IBOutlet private var singPassRadioButton: RadioButton!
+    @IBOutlet private var scanICRadioButton: RadioButton!
     @IBOutlet private var continueButton: UIButton!
 
     private lazy var radioButtons: [RadioButton] = [
-        self.singPassButton,
-        self.scanICButton
+        self.singPassRadioButton,
+        self.scanICRadioButton
     ]
     
     var webView: SFSafariViewController?
     var myInfoQueryItems: [URLQueryItem]?
     var spinnerView: UIView?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.updateContinue()
+    }
 
     @IBAction private func selectRadioButton(_ radioButton: RadioButton) {
         self.radioButtons.forEach { button in
@@ -38,12 +43,12 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
     }
     
     @IBAction private func continueTapped() {
-        if self.singPassButton.isCurrentSelected {
+        if self.singPassRadioButton.isCurrentSelected {
             OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "singpass"))
             //performSegue(withIdentifier: "myInfoSummary", sender: self)
             UIApplication.shared.typedDelegate.myInfoDelegate = self
             startMyInfoLogin()
-        } else if self.singPassButton.isCurrentSelected {
+        } else if self.scanICRadioButton.isCurrentSelected {
             OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "jumio"))
             performSegue(withIdentifier: "nricVerify", sender: self)
         } else {
@@ -62,6 +67,14 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
     
     @IBAction private func needHelpTapped(_ sender: Any) {
         self.showNeedHelpActionSheet()
+    }
+    
+    @IBAction private func singPassTapped() {
+        self.selectRadioButton(self.singPassRadioButton)
+    }
+    
+    @IBAction private func scanICTapped() {
+        self.selectRadioButton(self.scanICRadioButton)
     }
     
     func startMyInfoLogin() {

--- a/ostelco-ios-client/ViewControllers/SignUp/TheLegalStuffViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/TheLegalStuffViewController.swift
@@ -13,14 +13,17 @@ class TheLegalStuffViewController: UIViewController {
     
     @IBOutlet private weak var termsAndConditionsLabel: BodyTextLabel!
     @IBOutlet private weak var privacyPolicyLabel: BodyTextLabel!
+    @IBOutlet private weak var ageLabel: BodyTextLabel!
     
     @IBOutlet private weak var termsAndConditionsCheck: CheckButton!
     @IBOutlet private weak var privacyPolicyCheck: CheckButton!
+    @IBOutlet private weak var ageCheck: CheckButton!
     
     private var allChecks: [CheckButton] {
         return [
             self.termsAndConditionsCheck,
-            self.privacyPolicyCheck
+            self.privacyPolicyCheck,
+            self.ageCheck
         ]
     }
     
@@ -31,7 +34,8 @@ class TheLegalStuffViewController: UIViewController {
         
         self.termsAndConditionsLabel.setFullText("I hereby agree to the Terms & Conditions", withBoldedPortion: "Terms & Conditions")
         self.privacyPolicyLabel.setFullText("I agree to the Privacy Policy", withBoldedPortion: "Privacy Policy")
-
+        self.ageLabel.setFullText("I am at least 18 years of age", withBoldedPortion: "18 years")
+        
         self.updateContinueButtonState()
     }
 
@@ -60,6 +64,11 @@ class TheLegalStuffViewController: UIViewController {
     
     @IBAction private func privacyPolicyTapped(sender: UITapGestureRecognizer) {
         UIApplication.shared.open(ExternalLink.privacyPolicy.url)
+    }
+    
+    @IBAction private func ageTapped(sender: UITapGestureRecognizer) {
+        #warning("Get actual link for this before launch!")
+        self.showAlert(title: "Placeholder", msg: "Must get actual URL here!")
     }
 }
 


### PR DESCRIPTION
In this PR: 
- Update look of checkmark to match updated designs
- Add age check to legal stuff screen
- Add Radio buttons per updated designs
- Add drop-shadow buttons to go with radio buttons
- Use radio buttons + drop shadow  buttons  in the choose-your-own-EKYC-adventure view controller