### PR TITLE
Linky Labels!

### DIFF
--- a/OstelcoStyles/LinkableText.swift
+++ b/OstelcoStyles/LinkableText.swift
@@ -1,0 +1,115 @@
+//
+//  LinkableText.swift
+//  ostelco-ios-client
+//
+//  Created by Ellen Shapiro on 5/23/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+/// A text structure for dealing with a large amount of text that potentially
+/// contains multiple links.
+public struct LinkableText {
+    
+    /// The text containing 0 or more links
+    public let fullText: String
+    
+    /// [optional] The bits of text to link, or nil to link nothing.
+    public let linkedBits: [String]?
+    
+    /// Failable Initializer for text with a single linked portion.
+    /// Fails when the `linkedPortion` is non-nil and is not contained within the full text.
+    ///
+    /// - Parameters:
+    ///   - fullText: The text you can potentially add links to
+    ///   - linkedPortion: [optional] The text which should be linked, or nil to link nothing.
+    public init?(fullText: String,
+                 linkedPortion: String?) {
+        if let singleLink = linkedPortion {
+            self.init(fullText: fullText, linkedBits: [singleLink])
+        } else {
+            self.init(fullText: fullText, linkedBits: nil)
+        }
+    }
+    
+    /// Failable Initializer for text with mutliple linked portions.
+    /// Fails when `linkedBits` is non-nil and not all of its contents are contained
+    /// within the full text.
+    ///
+    /// - Parameters:
+    ///   - fullText: The text containing 0 or more links
+    ///   - linkedBits: [optional] The bits of text to link, or nil to link nothing.
+    public init?(fullText: String,
+                 linkedBits: [String]?) {
+        self.fullText = fullText
+        
+        if let bits = linkedBits {
+            for bit in bits {
+                guard fullText.contains(bit) else {
+                    // The full text doesn't contain one of the things we're trying to link.
+                    return nil
+                }
+            }
+            
+            // Yay, it's all there.
+            self.linkedBits = bits
+        } else {
+            self.linkedBits = nil
+        }
+    }
+    
+    private func range(of bit: String) -> NSRange? {
+        let nsRange = (self.fullText as NSString).range(of: bit)
+        guard nsRange.location != NSNotFound else {
+            return nil
+        }
+        
+        return nsRange
+    }
+    
+    private func bit(_ bit: String, contains index: Int) -> Bool {
+        guard let range = self.range(of: bit) else {
+            return false
+        }
+        
+        return range.contains(index)
+    }
+    
+    /// Checks to see if the given index has any link at all.
+    /// This method is faster to check if there's only one link in a given
+    /// `linkableText`.
+    ///
+    /// - Parameter index: The index to check for a link
+    /// - Returns: True if that index is part of a link, false if not.
+    public func isIndexLinked(_ index: Int) -> Bool {
+        guard
+            index < (self.fullText as NSString).length,
+            let bits = self.linkedBits,
+            !bits.isEmpty else {
+                return false
+        }
+        
+        return bits.contains(where: { self.bit($0, contains: index) })
+    }
+    
+    /// Returns the linked text at the given index
+    ///
+    /// - Parameter index: The index to check for linked text
+    /// - Returns: [Optional] The linked text at the given index, or nil if the index
+    ///            did not contain a link.
+    public func linkedText(at index: Int) -> String? {
+        guard
+            index < (self.fullText as NSString).length,
+            let bits = self.linkedBits,
+            !bits.isEmpty else {
+                return nil
+        }
+        
+        guard self.isIndexLinked(index) else {
+            return nil
+        }
+        
+        return bits.first(where: { self.bit($0, contains: index) })
+    }
+}

--- a/OstelcoStyles/OstelcoLabel.swift
+++ b/OstelcoStyles/OstelcoLabel.swift
@@ -47,6 +47,24 @@ open class OstelcoLabel: UILabel {
         super.prepareForInterfaceBuilder()
         self.commonInit()
     }
+    
+    open func setFullText(_ fullText: String, withAttributedPortion attributedPortion: String, attributes: [NSAttributedString.Key: Any]) {
+        guard let range = fullText.range(of: attributedPortion) else {
+            assertionFailure("You're trying to set attributed text that's not in the full text!")
+            // In prod: Fall back to just setting the text normally.
+            self.text = fullText
+            return
+        }
+        
+        let attributed = NSMutableAttributedString(string: fullText, attributes: [
+            .font: self.appFont.toUIFont,
+            .foregroundColor: self.appTextColor.toUIColor
+        ])
+        
+        attributed.addAttributes(attributes, range: NSRange(range, in: fullText))
+        
+        self.attributedText = attributed
+    }
 }
 
 // MARK: - Data labels
@@ -165,6 +183,15 @@ public class OnboardingLabel: OstelcoLabel {
         self.appFont = OstelcoFont(fontType: .medium,
                                    fontSize: .onboarding)
     }
+    
+    public func setFullText(_ fullText: String, withLinkedPortion linkedPortion: String) {
+        self.addTapRecognizer()
+        self.setFullText(fullText,
+                         withAttributedPortion: linkedPortion,
+                         attributes: [
+                            .foregroundColor: OstelcoColor.oyaBlue.toUIColor
+                         ])
+    }
 }
 
 public class BodyTextBoldLabel: OstelcoLabel {
@@ -187,23 +214,20 @@ public class BodyTextLabel: OstelcoLabel {
     }
     
     public func setFullText(_ fullText: String, withBoldedPortion boldedPortion: String) {
-        guard let range = fullText.range(of: boldedPortion) else {
-            assertionFailure("You're trying to set bolded text that's not in the full text!")
-            // In prod: Fall back to just setting the text normally.
-            self.text = fullText
-            return
-        }
-        
-        let attributed = NSMutableAttributedString(string: fullText, attributes: [
-            .font: self.appFont.toUIFont,
-            .foregroundColor: self.appTextColor.toUIColor
-            ])
-        
-        attributed.addAttributes([
-            .font: OstelcoFont(fontType: .bold, fontSize: self.appFont.fontSize).toUIFont
-            ], range: NSRange(range, in: fullText))
-        
-        self.attributedText = attributed
+        self.setFullText(fullText,
+                         withAttributedPortion: boldedPortion,
+                         attributes: [
+                            .font: OstelcoFont(fontType: .bold, fontSize: self.appFont.fontSize).toUIFont
+                         ])
+    }
+    
+    public func setFullText(_ fullText: String, withLinkedPortion linkedPortion: String) {
+        self.addTapRecognizer()
+        self.setFullText(fullText,
+                         withAttributedPortion: linkedPortion,
+                         attributes: [
+                            .foregroundColor: OstelcoColor.oyaBlue.toUIColor
+                         ])
     }
 }
 

--- a/OstelcoStyles/OstelcoLabel.swift
+++ b/OstelcoStyles/OstelcoLabel.swift
@@ -70,74 +70,62 @@ open class OstelcoLabel: UILabel {
 // MARK: - Data labels
 
 public class DataAmountOnHomeLabel: OstelcoLabel {
+    
+    public var smallFont: OstelcoFont!
+    
+    @IBInspectable
+    public var dataAmountString: String? {
+        didSet {
+            self.configureForDataAmountString()
+        }
+    }
 
     public override func commonInit() {
         super.commonInit()
         self.appTextColor = .oyaBlue
         self.appFont = OstelcoFont(fontType: .alternateBold,
                                    fontSize: .data)
-    }
-    override public var text: String? {
-        didSet {
-            setAttributedText()
-        }
-    }
-    override public var textColor: UIColor? {
-        didSet {
-            setAttributedText()
-        }
-    }
-    override public var font: UIFont? {
-        didSet {
-            setAttributedText()
-        }
+        self.smallFont = OstelcoFont(fontType: .alternateBold,
+                                     fontSize: .dataDecimals)
+        self.configureForDataAmountString()
     }
 
-    private func setAttributedText() {
-        attributedText = getStylizeBalanceString(text: self.text ?? "")
-    }
-
-    // Make the string with all the styles required for the balance text
-    // Input text e.g. "54.5 GB"
-    private func getStylizeBalanceString(text: String) -> NSMutableAttributedString {
-        let decimalSeparator: String = Locale.current.decimalSeparator!
-        let bigFont = appFont.toUIFont
-        let smallFont = appFont.toUIFont.withSize(OstelcoFontSize.dataDecimals.toCGFloat)
-        let color = appTextColor.toUIColor
+    /// Make the string with all the styles required for the balance text
+    /// Input text e.g. "54.5 GB"
+    private func configureForDataAmountString() {
+        guard let text = self.dataAmountString else {
+            // Nothing to format.
+            self.text = nil
+            return
+        }
 
         // Split text to 2 parts, number and units
         let textArray: [String] = text.components(separatedBy: " ")
         guard textArray.count >= 2 else {
-            return NSMutableAttributedString(string: text)
+            // We don't have enough info to format this correctly, just set it normally.
+            self.text = text
+            return
         }
-
+    
         // Split number string to integer and decimal parts.
-        let numberArray: [String] = textArray[0].components(separatedBy: decimalSeparator)
-        guard numberArray.count >= 1 else {
-            return NSMutableAttributedString(string: text)
+        let decimalSeparator: String = Locale.current.decimalSeparator!
+        let numberBit = textArray[0]
+        let numberArray = numberBit.components(separatedBy: decimalSeparator)
+        guard numberArray.count >= 2 else {
+            // There isn't a decimal separator, don't bother formatting.
+            self.text = text
+            return
         }
-
-        let integerPart = numberArray[0]
-        // If there is a decimal part.
-        let decimalPart: String? = (numberArray.count >= 2) ? "\(decimalSeparator)\(numberArray[1])": nil
-        let unit = " \(textArray[1])"
-
-        // Add integer part with the big font.
-        let attrString = NSMutableAttributedString(string: integerPart, attributes: [.font: bigFont, .foregroundColor: color])
-        if let decimalPart = decimalPart {
-            // Add decimal part including the decimal character
-            // This portion of text is aligned to top with a smaller font
-            let offset = bigFont.capHeight - smallFont.capHeight
-            let attributes: [NSAttributedString.Key: Any] = [
-                .font: smallFont,
-                .baselineOffset: offset,
-                .foregroundColor: color
-            ]
-            attrString.append(NSMutableAttributedString(string: decimalPart, attributes: attributes))
-        }
-        // Add the modifier part with bigger font.
-        attrString.append(NSMutableAttributedString(string: unit, attributes: [.font: bigFont, .foregroundColor: color]))
-        return attrString
+        
+        let decimalPart = numberArray[1]
+        let offset = self.appFont.toUIFont.capHeight - self.smallFont.toUIFont.capHeight
+        self.setFullText(text,
+                         withAttributedPortion: decimalSeparator + decimalPart,
+                         attributes: [
+                            .font: self.smallFont.toUIFont,
+                            .baselineOffset: offset,
+                            .foregroundColor: self.appTextColor.toUIColor
+                        ])
     }
 }
 

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -5985,7 +5985,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -8597,6 +8597,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -8728,6 +8729,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/dev-ostelco-ios-clientTests/APITests/LinkableTextTests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LinkableTextTests.swift
@@ -1,0 +1,100 @@
+//
+//  LinkableTextTests.swift
+//  dev-ostelco-ios-clientTests
+//
+//  Created by Ellen Shapiro on 5/23/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+@testable import Oya_Development_app
+import OstelcoStyles
+import XCTest
+
+class LinkableTextTests: XCTestCase {
+    
+    // MARK: - Generic linkable text
+    
+    private let testText = "She sells seashells by the seashore"
+    
+    func testNilPassedToInitializersWorks() {
+        XCTAssertNotNil(LinkableText(fullText: self.testText, linkedBits: nil))
+        XCTAssertNotNil(LinkableText(fullText: self.testText, linkedPortion: nil))
+    }
+    
+    func testSingleLinkInitializerWorksWithIncludedText() {
+        let linkedPortion = "seashells"
+        
+        guard let linkableText = LinkableText(fullText: self.testText, linkedPortion: linkedPortion) else {
+            XCTFail("This should have worked!")
+            return
+        }
+        
+        // Link should start at the beginning of the word
+        XCTAssertFalse(linkableText.isIndexLinked(9))
+        XCTAssertNil(linkableText.linkedText(at: 9))
+        XCTAssertTrue(linkableText.isIndexLinked(10))
+        XCTAssertEqual(linkableText.linkedText(at: 10), linkedPortion)
+        
+        // Link should end at the end of the word.
+        XCTAssertTrue(linkableText.isIndexLinked(18))
+        XCTAssertEqual(linkableText.linkedText(at: 18), linkedPortion)
+        XCTAssertFalse(linkableText.isIndexLinked(19))
+        XCTAssertNil(linkableText.linkedText(at: 19))
+    }
+    
+    func testSingleLinkInitializerFailsWithNotIncludedText() {
+        let linkedPortion = "sea monsters"
+        XCTAssertNil(LinkableText(fullText: self.testText, linkedPortion: linkedPortion))
+    }
+    
+    func testMultipleLinkInitializerWorksWithAllIncludedText() {
+        let bits = ["seashells", "seashore"]
+        
+        guard let linkableText = LinkableText(fullText: self.testText, linkedBits: bits) else {
+            XCTFail("Both of these are contained, this should have worked!")
+            return
+        }
+        
+        // First link should start at the beginning of the first word
+        XCTAssertFalse(linkableText.isIndexLinked(9))
+        XCTAssertNil(linkableText.linkedText(at: 9))
+        XCTAssertTrue(linkableText.isIndexLinked(10))
+        XCTAssertEqual(linkableText.linkedText(at: 10), bits[0])
+        
+        // First link should end at the end of the first word.
+        XCTAssertTrue(linkableText.isIndexLinked(18))
+        XCTAssertEqual(linkableText.linkedText(at: 18), bits[0])
+        XCTAssertFalse(linkableText.isIndexLinked(19))
+        XCTAssertNil(linkableText.linkedText(at: 19))
+        
+        // Second link should start at the beginning of the second word
+        XCTAssertFalse(linkableText.isIndexLinked(26))
+        XCTAssertNil(linkableText.linkedText(at: 26))
+        XCTAssertTrue(linkableText.isIndexLinked(27))
+        XCTAssertEqual(linkableText.linkedText(at: 27), bits[1])
+        
+        // Second link should end at the end of the word
+        let length = (self.testText as NSString).length
+        let lastIndex = length - 1
+        XCTAssertTrue(linkableText.isIndexLinked(lastIndex))
+        XCTAssertEqual(linkableText.linkedText(at: lastIndex), bits[1])
+        
+        // Do we just get false and nil instead of IOOB'ing with a too long index?
+        XCTAssertFalse(linkableText.isIndexLinked(length))
+        XCTAssertNil(linkableText.linkedText(at: length))
+    }
+    
+    func testMultipleLinkInitializerFailsWithSingleNotIncludedText() {
+        let bits = ["seashells", "sea lion"]
+
+        XCTAssertNil(LinkableText(fullText: self.testText, linkedBits: bits))
+    }
+    
+    // MARK: - Individual instances of linkable text
+    
+    func testLinkableTextInOnboardingInstantiates() {
+        for page in OnboardingPage.allCases {
+            XCTAssertNotNil(page.linkableText)
+        }
+    }
+}

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -215,6 +215,8 @@
 		9BB6A7A2226F6523000D5E13 /* OstelcoLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B46D64C226F01D60030A8EB /* OstelcoLabel.swift */; };
 		9BB6A7A3226F6529000D5E13 /* UIColor+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B46D652226F1ADA0030A8EB /* UIColor+Pixel.swift */; };
 		9BB6A7A6226F656E000D5E13 /* OstelcoStyles.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9BB6A793226F6513000D5E13 /* OstelcoStyles.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9BBA3DC02296EB8F0014FADE /* LinkableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBA3DBD2296EA280014FADE /* LinkableText.swift */; };
+		9BBA3DC22296FB9D0014FADE /* LinkableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBA3DC12296FB9D0014FADE /* LinkableTextTests.swift */; };
 		9BBEEE06228D6E6A00EED7F5 /* PushNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBEEE05228D6E6A00EED7F5 /* PushNotificationController.swift */; };
 		9BBEEE07228D700000EED7F5 /* PushNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBEEE05228D6E6A00EED7F5 /* PushNotificationController.swift */; };
 		9BBEEE0C228D88F600EED7F5 /* PushNotificationHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBEEE0B228D88F600EED7F5 /* PushNotificationHandling.swift */; };
@@ -534,6 +536,8 @@
 		9BB6A793226F6513000D5E13 /* OstelcoStyles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OstelcoStyles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BB6A795226F6514000D5E13 /* OstelcoStyles.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OstelcoStyles.h; sourceTree = "<group>"; };
 		9BB6A796226F6514000D5E13 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9BBA3DBD2296EA280014FADE /* LinkableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkableText.swift; sourceTree = "<group>"; };
+		9BBA3DC12296FB9D0014FADE /* LinkableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkableTextTests.swift; sourceTree = "<group>"; };
 		9BBEEE05228D6E6A00EED7F5 /* PushNotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationController.swift; sourceTree = "<group>"; };
 		9BBEEE0B228D88F600EED7F5 /* PushNotificationHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationHandling.swift; sourceTree = "<group>"; };
 		9BBEEE0E228D917600EED7F5 /* DidBecomeActiveHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidBecomeActiveHandling.swift; sourceTree = "<group>"; };
@@ -836,6 +840,7 @@
 			children = (
 				9B6A928C22844F95007F5EC9 /* LiveAPITests.swift */,
 				9B6A928A22844F8A007F5EC9 /* MockAPITests.swift */,
+				9BBA3DC12296FB9D0014FADE /* LinkableTextTests.swift */,
 			);
 			path = APITests;
 			sourceTree = "<group>";
@@ -972,7 +977,8 @@
 			children = (
 				9BB6A795226F6514000D5E13 /* OstelcoStyles.h */,
 				9B6E3A0B226F6FA70063EBAA /* fonts */,
-				9B9D957F22957E3400CAB0E7 /* LoopingVideoView.swift */,
+				9BBA3DBD2296EA280014FADE /* LinkableText.swift */,
+                9B9D957F22957E3400CAB0E7 /* LoopingVideoView.swift */,
 				9B46D650226F0E5D0030A8EB /* OstelcoButton.swift */,
 				9B46D64A226F00210030A8EB /* OstelcoColor.swift */,
 				9B46D64E226F02C30030A8EB /* OstelcoFont.swift */,
@@ -1978,6 +1984,7 @@
 				9BB6A79F226F6523000D5E13 /* OstelcoButton.swift in Sources */,
 				9B9D958022957E3400CAB0E7 /* LoopingVideoView.swift in Sources */,
 				9BB6A7A2226F6523000D5E13 /* OstelcoLabel.swift in Sources */,
+				9BBA3DC02296EB8F0014FADE /* LinkableText.swift in Sources */,
 				9B1745832277428A00CF321B /* OstelcoTextField.swift in Sources */,
 				9BB6A7A3226F6529000D5E13 /* UIColor+Pixel.swift in Sources */,
 				9BB6A7A0226F6523000D5E13 /* OstelcoColor.swift in Sources */,
@@ -2008,6 +2015,7 @@
 				9BBEEE1F228DA82600EED7F5 /* PushNotificationControllerTests.swift in Sources */,
 				9B6A928D22844F95007F5EC9 /* LiveAPITests.swift in Sources */,
 				9BBF704B2265DAC300E4B9B4 /* MyInfoTests.swift in Sources */,
+				9BBA3DC22296FB9D0014FADE /* LinkableTextTests.swift in Sources */,
 				9B6A929222847124007F5EC9 /* PromiseKit+Testing.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ostelco-ios-client/Storyboards/Home.storyboard
+++ b/ostelco-ios-client/Storyboards/Home.storyboard
@@ -25,16 +25,19 @@
                                         <rect key="frame" x="57.5" y="230.5" width="260" height="186"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="gNe-Me-PfP">
-                                                <rect key="frame" x="51" y="0.0" width="158" height="115"/>
+                                                <rect key="frame" x="23.5" y="0.0" width="213.5" height="115"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="2GB" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T7Z-5F-Y8h" customClass="DataAmountOnHomeLabel" customModule="OstelcoStyles">
-                                                        <rect key="frame" x="0.0" y="0.0" width="158" height="100.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T7Z-5F-Y8h" customClass="DataAmountOnHomeLabel" customModule="OstelcoStyles">
+                                                        <rect key="frame" x="0.0" y="0.0" width="213.5" height="100.5"/>
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="dataAmountString" value="2.3 GB"/>
+                                                        </userDefinedRuntimeAttributes>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gw9-S7-EM7" customClass="DataRemainingLabel" customModule="OstelcoStyles">
-                                                        <rect key="frame" x="68" y="100.5" width="22.5" height="14.5"/>
+                                                        <rect key="frame" x="95.5" y="100.5" width="22.5" height="14.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -90,6 +90,7 @@ class HomeViewController: ApplePayViewController {
         super.viewDidLoad()
 
         self.registerForPushNotificationsIfNeeded()
+        self.balanceLabel.dataAmountString = nil
 
         scrollView.alwaysBounceVertical = true
         scrollView.bounces = true
@@ -176,7 +177,7 @@ class HomeViewController: ApplePayViewController {
         }
         
         let formattedBalance = self.byteCountFormatter.string(fromByteCount: bundle.balance)
-        self.balanceLabel.text = formattedBalance
+        self.balanceLabel.dataAmountString = formattedBalance
     }
     
     private func showProductListActionSheet(products: [Product]) {

--- a/ostelco-ios-client/ViewControllers/Login/OnboardingPageViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/OnboardingPageViewController.swift
@@ -51,8 +51,18 @@ enum OnboardingPage: Int, CaseIterable {
             
             No need to wait for a SIM card in the mail
             
-            Try it now, with 2GB free data!
+            Try it now! With 1GB free data
             """
+        }
+    }
+    
+    var linkedText: String? {
+        switch self {
+        case .whatIsOya,
+             .noNeedToChange:
+            return nil
+        case .fullyDigital:
+            return "fully digital"
         }
     }
     
@@ -63,7 +73,7 @@ enum OnboardingPage: Int, CaseIterable {
 
 class OnboardingPageViewController: UIViewController {
     
-    @IBOutlet private var copyLabel: UILabel!
+    @IBOutlet private var copyLabel: OnboardingLabel!
     
     @IBOutlet private var gifView: LoopingVideoView!
     
@@ -83,9 +93,13 @@ class OnboardingPageViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.gifView.videoURL = self.onboardingPage.gifVideo.url
-        self.copyLabel.text = self.onboardingPage.copyText
+        if let linkText = self.onboardingPage.linkedText {
+            self.copyLabel.setFullText(self.onboardingPage.copyText, withLinkedPortion: linkText)
+        } else {
+            self.copyLabel.text = self.onboardingPage.copyText
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
In this PR: 
- Added and tested a data structure around having an amount of full text with an arbitrary number of links contained within
- Added support for using that data structure to set up links within an `OstelcoLabel`
- Consolidated support for setting up attributed strings within a larger string for both bolding and links
- Used that consolidation to considerably simplify the logic for the `DataAmountOnHomeLabel` (which will come in handy for the Today widget)
- Added handling of tapping on `OstelcoLabels`
- Set all this up for realsies in the login carousel

Next PR: 
- Implement links in the rest of the app. 