### PR TITLE
Move Freshchat push stuff to the push notification controller

### DIFF
--- a/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/LiveAPITests.swift
@@ -42,7 +42,6 @@ class LiveAPITests: XCTestCase {
         }
         
         XCTAssertNotNil(context.customer)
-        XCTAssertNotNil(context.regions.first)
     }
     
     func liveValidNRIC() {

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -152,11 +152,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Notification handling
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
-        if Freshchat.sharedInstance().isFreshchatNotification(userInfo) {
-            Freshchat.sharedInstance().handleRemoteNotification(userInfo, andAppstate: application.applicationState)
-        } else {
-            PushNotificationController.shared.application(application, didReceiveRemoteNotification: userInfo)
-        }
+        PushNotificationController.shared.application(application, didReceiveRemoteNotification: userInfo)
     }
     
     func application(_ application: UIApplication,
@@ -172,7 +168,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        Freshchat.sharedInstance().setPushRegistrationToken(deviceToken)
         PushNotificationController.shared.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
     }
     


### PR DESCRIPTION
Was hoping to have more of this working, but it's probably worth merging what's in here so far since it'll make debugging all this crap a lot easier if we do another build while I'm at UIKonf.

In this PR: 
- Move all handling of FreshChat push notifications to the `PushNotificationController`. 
- Removed one check from the live tests that could fail for legit reasons. 