### PR TITLE
Add Internet Connection Monitor

### DIFF
--- a/OstelcoStyles/BoldableText.swift
+++ b/OstelcoStyles/BoldableText.swift
@@ -1,0 +1,20 @@
+//
+//  BoldableText.swift
+//  OstelcoStyles
+//
+//  Created by Ellen Shapiro on 5/31/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct BoldableText {
+    public let fullText: String
+    public let boldedPortion: String?
+    
+    public init(fullText: String,
+                boldedPortion: String?) {
+        self.fullText = fullText
+        self.boldedPortion = boldedPortion
+    }
+}

--- a/OstelcoStyles/OstelcoLabel.swift
+++ b/OstelcoStyles/OstelcoLabel.swift
@@ -274,8 +274,13 @@ public class BodyTextLabel: OstelcoLabel {
                                    fontSize: .body)
     }
     
-    public func setFullText(_ fullText: String, withBoldedPortion boldedPortion: String) {
-        self.setFullText(fullText,
+    public func setBoldableText(_ boldable: BoldableText) {
+        guard let boldedPortion = boldable.boldedPortion else {
+            self.text = boldable.fullText
+            return
+        }
+        
+        self.setFullText(boldable.fullText,
                          withAttributedPortion: boldedPortion,
                          attributes: [
                             .font: OstelcoFont(fontType: .bold, fontSize: self.appFont.fontSize).toUIFont

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		9B8AFF4622A12E3C00CC84B1 /* Telenor-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B8AFF4322A1204500CC84B1 /* Telenor-Bold.otf */; };
 		9B8AFF4722A12E3C00CC84B1 /* Telenor-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B8AFF4422A1204500CC84B1 /* Telenor-Medium.otf */; };
 		9B8AFF4822A12E3C00CC84B1 /* Telenor.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B8AFF4522A1204500CC84B1 /* Telenor.otf */; };
+		9B8AFF5322A1479E00CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
+		9B8AFF5422A147A600CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
 		9B920F5F225B8AF0001EF9CD /* VerifyIdentityOnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04834D47222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift */; };
 		9B920F62225B8C70001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
@@ -523,6 +525,7 @@
 		9B8AFF4322A1204500CC84B1 /* Telenor-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Telenor-Bold.otf"; sourceTree = "<group>"; };
 		9B8AFF4422A1204500CC84B1 /* Telenor-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Telenor-Medium.otf"; sourceTree = "<group>"; };
 		9B8AFF4522A1204500CC84B1 /* Telenor.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Telenor.otf; sourceTree = "<group>"; };
+		9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectionMonitor.swift; sourceTree = "<group>"; };
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeAPI.swift; sourceTree = "<group>"; };
 		9B9B324D225E411700227EA3 /* APIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
@@ -787,6 +790,7 @@
 				04834D6E2237ACFF00A01500 /* APIManager.swift */,
 				C2D2EAE822785C0C00010586 /* AppErrors.swift */,
 				9B4DAD8F228198F4003810BE /* EmailLinkManager.swift */,
+				9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */,
 				043E711A223AF3CF00E01993 /* OnBoardingManager.swift */,
 				04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */,
 			);
@@ -1843,6 +1847,7 @@
 				C25A95962226FF7F005958EC /* MyInfoSummaryViewController.swift in Sources */,
 				04D6C9852276E32700AE13DD /* OstelcoAnalytics.swift in Sources */,
 				9B17457D2277033300CF321B /* AddressEditViewController.swift in Sources */,
+				9B8AFF5322A1479E00CC84B1 /* InternetConnectionMonitor.swift in Sources */,
 				9B1745692276D6D800CF321B /* ScanICStepsViewController.swift in Sources */,
 				047B2795223BB8D900EE134B /* SettingsTableViewController.swift in Sources */,
 				047F29032224460B00FC6A8F /* LoginViewController.swift in Sources */,
@@ -2026,6 +2031,7 @@
 				04D6C9862276E32700AE13DD /* OstelcoAnalytics.swift in Sources */,
 				9B17457E2277033300CF321B /* AddressEditViewController.swift in Sources */,
 				9B17456A2276D75700CF321B /* ScanICStepsViewController.swift in Sources */,
+				9B8AFF5422A147A600CC84B1 /* InternetConnectionMonitor.swift in Sources */,
 				043E711C223AF3CF00E01993 /* OnBoardingManager.swift in Sources */,
 				0412168D2226BBBA00455278 /* GetStartedViewController.swift in Sources */,
 				9BE2D45F225B651600B51999 /* UIApplicaiton+Testing.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		9B8AFF4822A12E3C00CC84B1 /* Telenor.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9B8AFF4522A1204500CC84B1 /* Telenor.otf */; };
 		9B8AFF5322A1479E00CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
 		9B8AFF5422A147A600CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
+		9B8AFF5622A14E4500CC84B1 /* BoldableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */; };
 		9B920F5F225B8AF0001EF9CD /* VerifyIdentityOnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04834D47222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift */; };
 		9B920F62225B8C70001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
@@ -526,6 +527,7 @@
 		9B8AFF4422A1204500CC84B1 /* Telenor-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Telenor-Medium.otf"; sourceTree = "<group>"; };
 		9B8AFF4522A1204500CC84B1 /* Telenor.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Telenor.otf; sourceTree = "<group>"; };
 		9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectionMonitor.swift; sourceTree = "<group>"; };
+		9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldableText.swift; sourceTree = "<group>"; };
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeAPI.swift; sourceTree = "<group>"; };
 		9B9B324D225E411700227EA3 /* APIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
@@ -976,6 +978,7 @@
 			children = (
 				9BB6A795226F6514000D5E13 /* OstelcoStyles.h */,
 				9B6E3A0B226F6FA70063EBAA /* fonts */,
+				9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */,
 				9BBA3DBD2296EA280014FADE /* LinkableText.swift */,
 				9B9D957F22957E3400CAB0E7 /* LoopingVideoView.swift */,
 				9B46D650226F0E5D0030A8EB /* OstelcoButton.swift */,
@@ -1980,6 +1983,7 @@
 				9B1745832277428A00CF321B /* OstelcoTextField.swift in Sources */,
 				9BB6A7A3226F6529000D5E13 /* UIColor+Pixel.swift in Sources */,
 				9BB6A7A0226F6523000D5E13 /* OstelcoColor.swift in Sources */,
+				9B8AFF5622A14E4500CC84B1 /* BoldableText.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
-
+    
         STPPaymentConfiguration.shared().publishableKey = Environment().configuration(.StripePublishableKey)
         #if STRIPE_PAYMENT
             debugPrint("Stripe Payment enabled")
@@ -54,8 +54,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         application.applicationSupportsShakeToEdit = true
         
         self.registerForNotifications()
-        print("App started")
-        
+        InternetConnectionMonitor.shared.start()
+
         return true
     }
     

--- a/ostelco-ios-client/Coordinators/RootCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/RootCoordinator.swift
@@ -21,6 +21,8 @@ class RootCoordinator {
     
     let window: UIWindow
     
+    private var noInternetVC: UIViewController?
+    
     init(window: UIWindow) {
         self.window = window
     }
@@ -92,5 +94,35 @@ class RootCoordinator {
             })
         }
         viewController.present(ohNo, animated: true)
+    }
+    
+    func showNoInternet() {
+        guard self.noInternetVC == nil else {
+            // Already showing
+            return
+        }
+        
+        let noInternet = OhNoViewController.fromStoryboard(type: .noInternet)
+        noInternet.primaryButtonAction = {
+            guard InternetConnectionMonitor.shared.isCurrentlyConnected() else {
+                // Still no internet for you.
+                return
+            }
+            
+            self.hideNoInternet()
+        }
+        
+        self.noInternetVC = noInternet
+        self.topViewController?.present(noInternet, animated: true)
+    }
+    
+    func hideNoInternet() {
+        guard let vc = self.noInternetVC else {
+            // Nothing to hide
+            return
+        }
+        
+        self.noInternetVC = nil
+        vc.dismiss(animated: true, completion: nil)
     }
 }

--- a/ostelco-ios-client/Network/InternetConnectionMonitor.swift
+++ b/ostelco-ios-client/Network/InternetConnectionMonitor.swift
@@ -1,0 +1,57 @@
+//
+//  InternetConnectionManager.swift
+//  ostelco-ios-client
+//
+//  Created by Ellen Shapiro on 5/31/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+import Network
+
+class InternetConnectionMonitor {
+    static let shared = InternetConnectionMonitor()
+    
+    private let monitor = NWPathMonitor()
+    
+    private init() {
+        self.monitor.pathUpdateHandler = self.handleUpdatedPath
+    }
+    
+    func start() {
+        let bg = DispatchQueue.global(qos: .background)
+        self.monitor.start(queue: bg)
+    }
+    
+    func isCurrentlyConnected() -> Bool {
+        switch self.monitor.currentPath.status {
+        case .satisfied:
+            return true
+        case .requiresConnection,
+             .unsatisfied:
+            return false
+        @unknown default:
+            ApplicationErrors.assertAndLog("Apple added something else here you need to handle!")
+            return false
+        }
+    }
+    
+    deinit {
+        self.monitor.cancel()
+    }
+    
+    private func handleUpdatedPath(_ path: NWPath) {
+        DispatchQueue.main.async {
+            let coordinator = UIApplication.shared.typedDelegate.rootCoordinator
+            switch path.status {
+            case .satisfied:
+                coordinator.hideNoInternet()
+            case .unsatisfied,
+                 .requiresConnection:
+                coordinator.showNoInternet()
+            @unknown default:
+                ApplicationErrors.assertAndLog("Apple added something else here you need to handle!")
+            }
+        }
+    }
+}

--- a/ostelco-ios-client/Network/InternetConnectionMonitor.swift
+++ b/ostelco-ios-client/Network/InternetConnectionMonitor.swift
@@ -9,7 +9,14 @@
 import Foundation
 import Network
 
+/// A class to monitor the internet connection status.
+/// NOTE: This works great on device, but if you try to test
+///       on the simulator by toggling your computer wifi off
+///       and on, it'll detect the connection going off but not
+///       going back on. TODO: File a Radar.
 class InternetConnectionMonitor {
+    
+    /// Singleton instance
     static let shared = InternetConnectionMonitor()
     
     private let monitor = NWPathMonitor()
@@ -18,11 +25,19 @@ class InternetConnectionMonitor {
         self.monitor.pathUpdateHandler = self.handleUpdatedPath
     }
     
+    deinit {
+        self.monitor.cancel()
+    }
+    
+    /// Start monitoring the network connection asynchronously
     func start() {
         let bg = DispatchQueue.global(qos: .background)
         self.monitor.start(queue: bg)
     }
     
+    /// Checks if the current path is connected synchronously
+    ///
+    /// - Returns: True if connected, false if not.
     func isCurrentlyConnected() -> Bool {
         switch self.monitor.currentPath.status {
         case .satisfied:
@@ -34,10 +49,6 @@ class InternetConnectionMonitor {
             ApplicationErrors.assertAndLog("Apple added something else here you need to handle!")
             return false
         }
-    }
-    
-    deinit {
-        self.monitor.cancel()
     }
     
     private func handleUpdatedPath(_ path: NWPath) {

--- a/ostelco-ios-client/Storyboards/OhNo.storyboard
+++ b/ostelco-ios-client/Storyboards/OhNo.storyboard
@@ -26,20 +26,20 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HH9-bZ-tBx" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="144" y="617" width="87" height="33"/>
+                                <rect key="frame" x="142" y="617" width="91" height="33"/>
                                 <state key="normal" title="Need help?"/>
                                 <connections>
                                     <action selector="needHelpTapped" destination="O3r-5k-dV9" eventType="touchUpInside" id="obY-ED-bg9"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Oh no" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Yd-Zwn" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="34.666666666666657"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Oh no" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Yd-Zwn" customClass="Heading2Label" customModule="OstelcoStyles">
+                                <rect key="frame" x="24" y="88" width="327" height="38.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="751" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RNV-H2-eGR" customClass="BodyTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="488" width="327" height="105"/>
+                                <rect key="frame" x="24" y="491.33333333333331" width="327" height="101.66666666666669"/>
                                 <string key="text">Something went wrong. Try again in a while.
 
 If you contact customer support, please use this error code: E333</string>
@@ -48,7 +48,7 @@ If you contact customer support, please use this error code: E333</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A2r-SU-Y1X" customClass="LoopingVideoView" customModule="OstelcoStyles">
-                                <rect key="frame" x="29" y="146.66666666666666" width="317.33333333333331" height="317.33333333333337"/>
+                                <rect key="frame" x="29" y="150.33333333333337" width="317" height="317"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="A2r-SU-Y1X" secondAttribute="height" multiplier="1:1" id="YZB-mJ-XVy"/>

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPageViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPageViewController.swift
@@ -11,11 +11,6 @@ import OstelcoStyles
 import UIKit
 import AVKit
 
-struct BoldableText {
-    public let fullText: String
-    public let boldedPortion: String?
-}
-
 enum ESIMPage: Int, CaseIterable {
     case instructions
     case scanQRCode
@@ -120,32 +115,24 @@ class ESIMPageViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setTextLabel(topTextLabel, esimPage.topText)
+        self.topTextLabel.setBoldableText(self.esimPage.topText)
         
-        if let bottomText = esimPage.bottomText {
-            setTextLabel(bottomTextLabel, bottomText)
+        if let bottomText = self.esimPage.bottomText {
+            self.bottomTextLabel.setBoldableText(bottomText)
         } else {
-            bottomTextLabel.isHidden = true
+            self.bottomTextLabel.isHidden = true
         }
         
-        if let image = esimPage.image {
-            imageView.image = image
+        if let image = self.esimPage.image {
+            self.imageView.image = image
         } else {
-            imageView.isHidden = true
+            self.imageView.isHidden = true
         }
         
-        if let videoURL = esimPage.videoURL {
-            playerController.player = AVPlayer(url: videoURL)
+        if let videoURL = self.esimPage.videoURL {
+            self.playerController.player = AVPlayer(url: videoURL)
         } else {
-            playerView.isHidden = true
-        }
-    }
-    
-    private func setTextLabel(_ label: BodyTextLabel, _ text: BoldableText) {
-        if let boldedPortion = text.boldedPortion {
-            label.setFullText(text.fullText, withBoldedPortion: boldedPortion)
-        } else {
-            label.text = text.fullText
+            self.playerView.isHidden = true
         }
     }
     


### PR DESCRIPTION
In this PR: 
- Added an Internet Connection Monitor that uses `NWPathMonitor` under the hood. This is a new class in iOS 12, and it's got some weirdness going on about it with the simulator, but otherwise works well. 
- Updated the `OhNo` view controller to handle showing the no internet connection screen
- Moved `BoldableText` into `OstelcoStyles` for easier future use.