### PR TITLE
Handle push around Jumio approval/Rejection

### DIFF
--- a/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
+++ b/dev-ostelco-ios-clientTests/APITests/MockAPITests.swift
@@ -656,7 +656,7 @@ class MockAPITests: XCTestCase {
         
         XCTAssertEqual(scan.scanId, "326aceb6-3e54-4049-9f7b-0c922ad2c85a")
         XCTAssertEqual(scan.countryCode, "sg")
-        XCTAssertEqual(scan.status, "PENDING")
+        XCTAssertEqual(scan.status, .PENDING)
     }
     
     func testMockRequestingSimProfile() {

--- a/dev-ostelco-ios-clientTests/MockJSON/push_notification_scan_success.json
+++ b/dev-ostelco-ios-clientTests/MockJSON/push_notification_scan_success.json
@@ -1,0 +1,30 @@
+{
+  "SCAN_INFORMATION": {
+    "scanId":"fake_scan_id",
+    "countryCode":"sg",
+    "status":"APPROVED",
+    "scanResult":{
+      "vendorScanReference":"vendor_fake_scan_id",
+      "verificationStatus":"APPROVED_VERIFIED",
+      "time":1559310256200,
+      "type":"ID_CARD",
+      "country":"SG",
+      "firstName":"FAKEY",
+      "lastName":"MC FAKERSON",
+      "dob":"1970-01-01",
+      "rejectReason":null
+    }
+  },
+  "aps" : {
+    "alert" : {
+      "title" : "Test notification",
+      "body" : "I am a test!"
+    }
+  },
+  "google.c.a.c_id" : "fake_cac_id",
+  "google.c.a.e" : "1",
+  "gcm.message_id" : "1:fake_message_id%gibberish",
+  "gcm.n.e" : "1",
+  "google.c.a.ts" : "lol_cats",
+  "google.c.a.udt" : "0"
+}

--- a/dev-ostelco-ios-clientTests/RegionResponseTests.swift
+++ b/dev-ostelco-ios-clientTests/RegionResponseTests.swift
@@ -25,7 +25,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "1")
         XCTAssertEqual(region.region.name, "ApprovedRegion")
-        XCTAssertEqual(region.status, KycStatus.APPROVED)
+        XCTAssertEqual(region.status, .APPROVED)
     }
     
     func testApprovedIsReturnedWhenOnlyApprovedRejectedPresent() {
@@ -41,7 +41,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "1")
         XCTAssertEqual(region.region.name, "ApprovedRegion")
-        XCTAssertEqual(region.status, KycStatus.APPROVED)
+        XCTAssertEqual(region.status, .APPROVED)
     }
     
     func testApprovedIsReturnedWhenOnlyApprovedPendingPresent() {
@@ -57,7 +57,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "1")
         XCTAssertEqual(region.region.name, "ApprovedRegion")
-        XCTAssertEqual(region.status, KycStatus.APPROVED)
+        XCTAssertEqual(region.status, .APPROVED)
     }
     
     func testApprovedIsReturnedWhenThatsTheOnlyOption() {
@@ -72,7 +72,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "1")
         XCTAssertEqual(region.region.name, "ApprovedRegion")
-        XCTAssertEqual(region.status, KycStatus.APPROVED)
+        XCTAssertEqual(region.status, .APPROVED)
     }
     
     func testRejectedIsReturnedWhenPendingAndRejectedPresent() {
@@ -88,7 +88,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "3")
         XCTAssertEqual(region.region.name, "RejectedRegion")
-        XCTAssertEqual(region.status, KycStatus.REJECTED)
+        XCTAssertEqual(region.status, .REJECTED)
     }
     
     func testRejectedIsReturnedWhenThatsTheOnlyOption() {
@@ -103,7 +103,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "3")
         XCTAssertEqual(region.region.name, "RejectedRegion")
-        XCTAssertEqual(region.status, KycStatus.REJECTED)
+        XCTAssertEqual(region.status, .REJECTED)
     }
     
     func testPendingIsReturnedWhenThatsTheOnlyOption() {
@@ -118,7 +118,7 @@ class RegionResponseTests: XCTestCase {
         
         XCTAssertEqual(region.region.id, "2")
         XCTAssertEqual(region.region.name, "PendingRegion")
-        XCTAssertEqual(region.status, KycStatus.PENDING)
+        XCTAssertEqual(region.status, .PENDING)
     }
     
     func testNilIsReturnedForAnEmptyArray() {

--- a/ostelco-core/Models/EKYCStatus.swift
+++ b/ostelco-core/Models/EKYCStatus.swift
@@ -1,0 +1,15 @@
+//
+//  EKYCStatus.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/31/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public enum EKYCStatus: String, Codable {
+    case APPROVED
+    case REJECTED
+    case PENDING
+}

--- a/ostelco-core/Models/JumioScanInfo.swift
+++ b/ostelco-core/Models/JumioScanInfo.swift
@@ -1,0 +1,174 @@
+//
+//  JumioScanInfo.swift
+//  ostelco-core
+//
+//  Created by Ellen Shapiro on 5/31/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+///https://github.com/Jumio/implementation-guides/blob/master/netverify/callback.md
+public enum JumioVerificationStatus: String, Codable {
+    case APPROVED_VERIFIED
+    case DENIED_FRAUD
+    case DENIED_UNSUPPORTED_ID_TYPE
+    case DENIED_UNSUPPORTED_ID_COUNTRY
+    case ERROR_NOT_READABLE_ID
+    case NO_ID_UPLOADED
+}
+
+/// https://github.com/Jumio/implementation-guides/blob/master/netverify/callback.md#reject-reason
+public struct JumioRejectionReason: Codable {
+    public enum Description: String, Codable {
+        case MANIPULATED_DOCUMENT
+        case PHOTOCOPY_BLACK_WHITE
+        case PHOTOCOPY_COLOR
+        case DIGITAL_COPY
+        case FRAUDSTER
+        case FAKE
+        case PHOTO_MISMATCH
+        case MRZ_CHECK_FAILED
+        case PUNCHED_DOCUMENT
+        case CHIP_DATA_MANIPULATED
+        case MISMATCH_PRINTED_BARCODE_DATA
+        case NOT_READABLE_DOCUMENT
+        case NO_DOCUMENT
+        case SAMPLE_DOCUMENT
+        case MISSING_BACK
+        case WRONG_DOCUMENT_PAGE
+        case MISSING_SIGNATURE
+        case CAMERA_BLACK_WHITE
+        case DIFFERENT_PERSONS_SHOWN
+        case MANUAL_REJECTION
+        
+        public init?(code: String) {
+            guard let intCode = Int(code) else {
+                return nil
+            }
+            
+            switch intCode {
+            case 100:
+                self = .MANIPULATED_DOCUMENT
+            case 102:
+                self = .PHOTOCOPY_BLACK_WHITE
+            case 103:
+                self = .PHOTOCOPY_COLOR
+            case 104:
+                self = .DIGITAL_COPY
+            case 105:
+                self = .FRAUDSTER
+            case 106:
+                self = .FAKE
+            case 107:
+                self = .PHOTO_MISMATCH
+            case 108:
+                self = .MRZ_CHECK_FAILED
+            case 109:
+                self = .PUNCHED_DOCUMENT
+            case 110:
+                self = .CHIP_DATA_MANIPULATED
+            case 111:
+                self = .MISMATCH_PRINTED_BARCODE_DATA
+            case 200:
+                self = .NOT_READABLE_DOCUMENT
+            case 201:
+                self = .NO_DOCUMENT
+            case 206:
+                self = .MISSING_BACK
+            case 207:
+                self = .WRONG_DOCUMENT_PAGE
+            case 209:
+                self = .MISSING_SIGNATURE
+            case 210:
+                self = .CAMERA_BLACK_WHITE
+            case 211:
+                self = .DIFFERENT_PERSONS_SHOWN
+            case 300:
+                self = .MANUAL_REJECTION
+            default:
+                return nil
+            }
+        }
+    }
+    
+    public let code: String?
+    public let description: JumioRejectionReason.Description?
+    public let details: JumioRejectionReasonDetails?
+    
+    public enum CodingKeys: String, CodingKey {
+        case code = "rejectReasonCode"
+        case description = "rejectReasonDescription"
+        case details = "rejectReasonDetails"
+    }
+}
+
+/// https://github.com/Jumio/implementation-guides/blob/master/netverify/callback.md#reject-reason-details
+public struct JumioRejectionReasonDetails: Codable {
+    public enum Description: String, Codable {
+        case PHOTO
+        case DOCUMENT_NUMBER
+        case EXPIRY
+        case DOB
+        case NAME
+        case ADDRESS
+        case SECURITY_CHECKS
+        case SIGNATURE
+        case PERSONAL_NUMBER
+        case PLACE_OF_BIRTH
+        case BLURRED
+        case BAD_QUALITY
+        case MISSING_PART_DOCUMENT
+        case HIDDEN_PART_DOCUMENT
+        case DAMAGED_DOCUMENT
+        
+        public init?(code: String) {
+            guard let intCode = Int(code) else {
+                return nil
+            }
+            
+            switch intCode {
+            case 1001:
+                self = .PHOTO
+            case 1002:
+                self = .DOCUMENT_NUMBER
+            case 1003:
+                self = .EXPIRY
+            case 1004:
+                self = .DOB
+            case 1005:
+                self = .NAME
+            case 1006:
+                self = .ADDRESS
+            case 1007:
+                self = .SECURITY_CHECKS
+            case 1008:
+                self = .SIGNATURE
+            case 1009:
+                self = .PERSONAL_NUMBER
+            case 10011:
+                self = .PLACE_OF_BIRTH
+            case 2001:
+                self = .BLURRED
+            case 2002:
+                self = .BAD_QUALITY
+            case 2003:
+                self = .MISSING_PART_DOCUMENT
+            case 2004:
+                self = .HIDDEN_PART_DOCUMENT
+            case 2005:
+                self = .DAMAGED_DOCUMENT
+            default:
+                return nil
+            }
+        }
+    }
+    
+    public let code: String?
+    public let description: JumioRejectionReasonDetails.Description?
+    
+    public enum CodingKeys: String, CodingKey {
+        case code = "detailsCode"
+        case description = "detailsDescription"
+    }
+}

--- a/ostelco-core/Models/PushNotificationModel.swift
+++ b/ostelco-core/Models/PushNotificationModel.swift
@@ -11,10 +11,12 @@ import Foundation
 public struct PushNotificationContainer: Codable {
     public let alert: PushAlert?
     public let gcmMessageID: String?
+    public let scanInfo: Scan?
     
     public enum CodingKeys: String, CodingKey {
         case alert = "aps"
         case gcmMessageID = "gcm.message_id"
+        case scanInfo = "SCAN_INFORMATION"
     }
     
     public init?(dictionary: [AnyHashable: Any]) {

--- a/ostelco-core/Models/Region.swift
+++ b/ostelco-core/Models/Region.swift
@@ -6,23 +6,17 @@
 //  Copyright © 2019 mac. All rights reserved.
 //
 
-public enum KycStatus: String, Codable {
-    case APPROVED
-    case REJECTED
-    case PENDING
-}
-
 public struct KYCStatusMap: Codable {
-    public let JUMIO: KycStatus?
-    public let MY_INFO: KycStatus?
-    public let NRIC_FIN: KycStatus?
-    public let ADDRESS_AND_PHONE_NUMBER: KycStatus?
+    public let JUMIO: EKYCStatus?
+    public let MY_INFO: EKYCStatus?
+    public let NRIC_FIN: EKYCStatus?
+    public let ADDRESS_AND_PHONE_NUMBER: EKYCStatus?
     
     /// Testing initializer
-    init(jumio: KycStatus? = nil,
-         myInfo: KycStatus? = nil,
-         nricFin: KycStatus? = nil,
-         addressPhone: KycStatus? = nil) {
+    init(jumio: EKYCStatus? = nil,
+         myInfo: EKYCStatus? = nil,
+         nricFin: EKYCStatus? = nil,
+         addressPhone: EKYCStatus? = nil) {
         self.JUMIO = jumio
         self.MY_INFO = myInfo
         self.NRIC_FIN = nricFin
@@ -44,13 +38,13 @@ public struct Region: Codable {
 
 public struct RegionResponse: Codable {
     public let region: Region
-    public let status: KycStatus
+    public let status: EKYCStatus
     public let simProfiles: [SimProfile]?
     public let kycStatusMap: KYCStatusMap
     
     /// Testing initializer
     init(region: Region,
-         status: KycStatus,
+         status: EKYCStatus,
          simProfiles: [SimProfile]?,
          kycStatusMap: KYCStatusMap) {
         self.region = region

--- a/ostelco-core/Models/Scan.swift
+++ b/ostelco-core/Models/Scan.swift
@@ -9,5 +9,5 @@
 public struct Scan: Codable {
     public let countryCode: String
     public let scanId: String
-    public let status: String
+    public let status: EKYCStatus
 }

--- a/ostelco-core/Models/Scan.swift
+++ b/ostelco-core/Models/Scan.swift
@@ -10,4 +10,11 @@ public struct Scan: Codable {
     public let countryCode: String
     public let scanId: String
     public let status: EKYCStatus
+    public let scanResult: ScanResult?
+}
+
+public struct ScanResult: Codable {
+    public let vendorScanReference: String
+    public let verificationStatus: JumioVerificationStatus
+    public let rejectReason: JumioRejectionReason?
 }

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		9B8AFF5422A147A600CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
 		9B8AFF5622A14E4500CC84B1 /* BoldableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */; };
 		9B8AFF5822A1698500CC84B1 /* EKYCStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5722A1698500CC84B1 /* EKYCStatus.swift */; };
+		9B8AFF5A22A16F8400CC84B1 /* JumioScanInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5922A16F8400CC84B1 /* JumioScanInfo.swift */; };
 		9B920F5F225B8AF0001EF9CD /* VerifyIdentityOnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04834D47222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift */; };
 		9B920F62225B8C70001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
@@ -530,6 +531,7 @@
 		9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectionMonitor.swift; sourceTree = "<group>"; };
 		9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldableText.swift; sourceTree = "<group>"; };
 		9B8AFF5722A1698500CC84B1 /* EKYCStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCStatus.swift; sourceTree = "<group>"; };
+		9B8AFF5922A16F8400CC84B1 /* JumioScanInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumioScanInfo.swift; sourceTree = "<group>"; };
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeAPI.swift; sourceTree = "<group>"; };
 		9B9B324D225E411700227EA3 /* APIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
@@ -958,6 +960,7 @@
 				9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */,
 				9B8AFF5722A1698500CC84B1 /* EKYCStatus.swift */,
 				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
+				9B8AFF5922A16F8400CC84B1 /* JumioScanInfo.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
 				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
 				9B6A927E22832F5B007F5EC9 /* PaymentInfo.swift */,
@@ -1938,6 +1941,7 @@
 				9B821599227AFC4700DC6B64 /* ServerError.swift in Sources */,
 				9BBF70562265EE4500E4B9B4 /* GenericTableViewDataSource.swift in Sources */,
 				9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */,
+				9B8AFF5A22A16F8400CC84B1 /* JumioScanInfo.swift in Sources */,
 				9B9B3243225E3B7B00227EA3 /* PrimeAPI.swift in Sources */,
 				9B6A92892284209A007F5EC9 /* PushToken.swift in Sources */,
 				9B821594227ADA1000DC6B64 /* Request.swift in Sources */,

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		9B8AFF5322A1479E00CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
 		9B8AFF5422A147A600CC84B1 /* InternetConnectionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */; };
 		9B8AFF5622A14E4500CC84B1 /* BoldableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */; };
+		9B8AFF5822A1698500CC84B1 /* EKYCStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8AFF5722A1698500CC84B1 /* EKYCStatus.swift */; };
 		9B920F5F225B8AF0001EF9CD /* VerifyIdentityOnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04834D47222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift */; };
 		9B920F62225B8C70001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
@@ -528,6 +529,7 @@
 		9B8AFF4522A1204500CC84B1 /* Telenor.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Telenor.otf; sourceTree = "<group>"; };
 		9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectionMonitor.swift; sourceTree = "<group>"; };
 		9B8AFF5522A14E4500CC84B1 /* BoldableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldableText.swift; sourceTree = "<group>"; };
+		9B8AFF5722A1698500CC84B1 /* EKYCStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKYCStatus.swift; sourceTree = "<group>"; };
 		9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeAPI.swift; sourceTree = "<group>"; };
 		9B9B324D225E411700227EA3 /* APIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
@@ -954,6 +956,7 @@
 				04834D712237B11800A01500 /* CustomerModel.swift */,
 				9B82158F227AD6D200DC6B64 /* EKYCAddress.swift */,
 				9B6A928622841C38007F5EC9 /* EKYCProfileUpdate.swift */,
+				9B8AFF5722A1698500CC84B1 /* EKYCStatus.swift */,
 				0493B80B2252BE0900989F40 /* JSONRequestError.swift */,
 				9B6E3A23227091EF0063EBAA /* LocationProblem.swift */,
 				C224D91F225FADFC00AE10FD /* MyInfoDetails.swift */,
@@ -1926,6 +1929,7 @@
 				9B6A928322833586007F5EC9 /* Scan.swift in Sources */,
 				9BBF706B2266162F00E4B9B4 /* UITableView+Generics.swift in Sources */,
 				9BBF707A22675C3900E4B9B4 /* Array+FancyAppend.swift in Sources */,
+				9B8AFF5822A1698500CC84B1 /* EKYCStatus.swift in Sources */,
 				9B8215822279DF6900DC6B64 /* Region.swift in Sources */,
 				9B851AE4225E33620076ABF3 /* NibLoadable.swift in Sources */,
 				9B82158C227A2F4100DC6B64 /* APIEndpoint.swift in Sources */,

--- a/ostelco-ios-client/Protocols/PushNotificationHandling.swift
+++ b/ostelco-ios-client/Protocols/PushNotificationHandling.swift
@@ -17,8 +17,8 @@ protocol PushNotificationHandling: class {
     
     /// Called when a push notification NSNotification is recevied.
     ///
-    /// - Parameter userInfo: The parsed notification from the NSNotification.
-    func handlePushNotification(_ notification: PushNotification)
+    /// - Parameter notification: The parsed object from the NSNotification.
+    func handlePushNotification(_ notification: PushNotificationContainer)
 }
 
 // MARK: - Default implementation
@@ -36,8 +36,7 @@ extension PushNotificationHandling {
                     return
                 }
                 
-                guard
-                    let pushObject = self.convertToNotification(userInfo: notification.userInfo) else {
+                guard let pushObject = self.convertToNotificationContainer(userInfo: notification.userInfo) else {
                     let error = ApplicationErrors.General.couldntConvertUserInfoToNotificaitonData(userInfo: notification.userInfo)
                     ApplicationErrors.assertAndLog(error)
                         return
@@ -51,14 +50,12 @@ extension PushNotificationHandling {
     ///
     /// - Parameter dictionary: The user info dictionary to parse, or nil
     /// - Returns: The parsed push notification, or nil if one could not be parsed.
-    func convertToNotification(userInfo dictionary: [AnyHashable: Any]?) -> PushNotification? {
-        guard
-            let dictionary = dictionary,
-            let container = PushNotificationContainer(dictionary: dictionary) else {
-                return nil
+    func convertToNotificationContainer(userInfo dictionary: [AnyHashable: Any]?) -> PushNotificationContainer? {
+        guard let dictionary = dictionary else {
+            return nil
         }
         
-        return container.alert?.notification
+        return PushNotificationContainer(dictionary: dictionary)
     }
     
     func removePushNotificationListener() {

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -150,8 +150,20 @@ extension PendingVerificationViewController: StoryboardLoadable {
 
 extension PendingVerificationViewController: PushNotificationHandling {
     
-    func handlePushNotification(_ notification: PushNotification) {
-        debugPrint("Got notification: \(notification)")
+    func handlePushNotification(_ notification: PushNotificationContainer) {
+        guard let scanInfo = notification.scanInfo else {
+            // This is some other kind of notification
+            return
+        }
+        
+        switch scanInfo.status {
+        case .APPROVED:
+            self.handleRegionApproved()
+        case .REJECTED:
+            self.showEKYCOhNo()
+        case .PENDING:
+            self.handleRegionPending(silentCheck: true)
+        }
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -91,7 +91,7 @@ class PendingVerificationViewController: UIViewController {
                 self.showEKYCOhNo()
             case (.APPROVED, .APPROVED, .APPROVED):
                 // Should not happend, because this case should've been handled further up the stack, but we will let them pass for now
-                self.performSegue(withIdentifier: "ESim", sender: self)
+                self.handleRegionApproved()
             case (.PENDING, _, _), (_, .PENDING, _), (_, _, .PENDING):
                 self.handleRegionPending(silentCheck: silentCheck)
             default:

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -12,9 +12,6 @@ import ostelco_core
 
 class ESIMPendingDownloadViewController: UIViewController {
     
-    // for PushNotificationHandling
-    var pushNotificationObserver: NSObjectProtocol?
-    
     var spinnerView: UIView?
     var simProfile: SimProfile? {
         didSet {
@@ -127,24 +124,5 @@ class ESIMPendingDownloadViewController: UIViewController {
                     self?.performSegue(withIdentifier: "showGenericOhNo", sender: self)
                 }
         }
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.addPushNotificationListener()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        self.removePushNotificationListener()
-    }
-}
-
-// MARK: - PushNotificationHandling
-
-extension ESIMPendingDownloadViewController: PushNotificationHandling {
-    
-    func handlePushNotification(_ notification: PushNotificationContainer) {
-        debugPrint("GOT PUSH: \(notification)")
     }
 }

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -144,7 +144,7 @@ class ESIMPendingDownloadViewController: UIViewController {
 
 extension ESIMPendingDownloadViewController: PushNotificationHandling {
     
-    func handlePushNotification(_ notification: PushNotification) {
+    func handlePushNotification(_ notification: PushNotificationContainer) {
         debugPrint("GOT PUSH: \(notification)")
     }
 }


### PR DESCRIPTION
In this PR: 
- Add and test handling of receiving of actual push notifications
- Handle associated data coming in from notification
- Add a whole mess of stuff around Jumio error types based on their docs
- Remove handling of push around ESim since we're not actually sending pushes about this. 

NOT in this PR: 
- Actual handling of those Jumio errors (this is a separate ticket)