### PR TITLE
add deep link to allow login with username and password

### DIFF
--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -83,6 +83,10 @@
 		048C78822191ED430041F135 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04488172217924B800F59758 /* Assets.xcassets */; };
 		048C78D92191F46D0041F135 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 048C78D82191F46D0041F135 /* LaunchScreen.storyboard */; };
 		048C78DA2191F46D0041F135 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 048C78D82191F46D0041F135 /* LaunchScreen.storyboard */; };
+		04978D6822AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6722AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift */; };
+		04978D6922AB9B78002B09E0 /* UsernameAndPasswordLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6722AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift */; };
+		04978D6B22ABA012002B09E0 /* LinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6A22ABA012002B09E0 /* LinkHelper.swift */; };
+		04978D6C22ABA012002B09E0 /* LinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6A22ABA012002B09E0 /* LinkHelper.swift */; };
 		04BA349A222587DD000359C4 /* Splash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 04BA3499222587DD000359C4 /* Splash.storyboard */; };
 		04BA349C222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
 		04BA349D222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
@@ -455,6 +459,8 @@
 		048C78D82191F46D0041F135 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0493B80B2252BE0900989F40 /* JSONRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRequestError.swift; sourceTree = "<group>"; };
 		0493B80E2253943900989F40 /* ServerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerError.swift; sourceTree = "<group>"; };
+		04978D6722AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameAndPasswordLinkManager.swift; sourceTree = "<group>"; };
+		04978D6A22ABA012002B09E0 /* LinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHelper.swift; sourceTree = "<group>"; };
 		04BA3499222587DD000359C4 /* Splash.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Splash.storyboard; sourceTree = "<group>"; };
 		04BA349B222587F6000359C4 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		04BA349F2226B8D9000359C4 /* EnableNotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableNotificationsViewController.swift; sourceTree = "<group>"; };
@@ -839,6 +845,8 @@
 				9B8AFF5222A1479E00CC84B1 /* InternetConnectionMonitor.swift */,
 				043E711A223AF3CF00E01993 /* OnBoardingManager.swift */,
 				04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */,
+				04978D6722AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift */,
+				04978D6A22ABA012002B09E0 /* LinkHelper.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1922,7 +1930,9 @@
 				043E711B223AF3CF00E01993 /* OnBoardingManager.swift in Sources */,
 				9BBF7075226751A200E4B9B4 /* Netverify+Ostelco.swift in Sources */,
 				04834D3F222EC92C00A01500 /* UIViewController+UIActivityIndicator.swift in Sources */,
+				04978D6822AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift in Sources */,
 				9BBEEE0F228D917600EED7F5 /* DidBecomeActiveHandling.swift in Sources */,
+				04978D6B22ABA012002B09E0 /* LinkHelper.swift in Sources */,
 				9B6A9DD222A566C90036AEE4 /* SignUpCoordinator.swift in Sources */,
 				9B17457A2276F6E900CF321B /* AddressEditDataSource.swift in Sources */,
 				9BBF705A2265F02200E4B9B4 /* CountryDataSource.swift in Sources */,
@@ -2126,7 +2136,9 @@
 				04834D49222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift in Sources */,
 				9B17457B2276F6E900CF321B /* AddressEditDataSource.swift in Sources */,
 				9BBF70672265FA3100E4B9B4 /* UITableView+Footer.swift in Sources */,
+				04978D6922AB9B78002B09E0 /* UsernameAndPasswordLinkManager.swift in Sources */,
 				9BBEEE10228D917600EED7F5 /* DidBecomeActiveHandling.swift in Sources */,
+				04978D6C22ABA012002B09E0 /* LinkHelper.swift in Sources */,
 				9B6A9DD322A566C90036AEE4 /* SignUpCoordinator.swift in Sources */,
 				9BC4653D2271AE0F001951BF /* LocationProblem+UserFacingCopy.swift in Sources */,
 				9B4F1A4022A6A9FE00FCC8CC /* SingaporeEKYCCoordinator.swift in Sources */,

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -133,6 +133,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
         
+        if UsernameAndPasswordLinkManager.isUsernameAndPasswordLink(incomingURL) {
+            UsernameAndPasswordLinkManager.signInWithUsernameAndPassword(incomingURL)
+                .done { [weak self] in
+ self?.rootCoordinator.determineAndNavigateToDestination()
+                }
+                .catch { error in
+                    ApplicationErrors.log(error)
+                    debugPrint("ERROR SIGNING IN WITH USERNAME AND PASSWORD: \(error)")
+                }
+            
+            return true
+        }
+        
         // If we've gotten here, it's some other kind of universal link.
         return DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLink, error in
             guard error == nil else {

--- a/ostelco-ios-client/Network/LinkHelper.swift
+++ b/ostelco-ios-client/Network/LinkHelper.swift
@@ -1,0 +1,39 @@
+//
+//  LinkHelper.swift
+//  ostelco-ios-client
+//
+//  Created by mac on 6/8/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+
+public struct LinkHelper {
+    public static func getLastPathFromLink(_ link: URL) -> String {
+        return link.pathComponents.last ?? ""
+    }
+    
+    public static func parseLink(_ link: URL) -> [String:String] {
+        var ret = [String:String]()
+        
+        if let urlComponents = URLComponents(url: link, resolvingAgainstBaseURL: false), let queryItems = urlComponents.queryItems {
+            for queryItem in queryItems {
+                ret[queryItem.name] = queryItem.value
+            }
+        }
+        
+        return ret
+    }
+    
+    public static func linkContainsParams(_ link: URL, paramKeys: [String]) -> Bool {
+        let params = parseLink(link)
+        
+        for key in paramKeys {
+            if params[key] == nil {
+                return false
+            }
+        }
+        
+        return true
+    }
+}

--- a/ostelco-ios-client/Network/UsernameAndPasswordLinkManager.swift
+++ b/ostelco-ios-client/Network/UsernameAndPasswordLinkManager.swift
@@ -1,0 +1,62 @@
+//
+//  UsernameAndPasswordLinkManager.swift
+//  ostelco-ios-client
+//
+//  Created by mac on 6/8/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import Foundation
+import FirebaseAuth
+import PromiseKit
+
+struct UsernameAndPasswordLinkManager {
+    
+    enum Error: Swift.Error, LocalizedError {
+        case noUsernameOrPassword
+        case noErrorAndNoUser
+        
+        var localizedDescription: String {
+            switch self {
+            case .noUsernameOrPassword:
+                return "Could not find username or password in URL"
+            case .noErrorAndNoUser:
+                return "Signed into Firebase and received neither a user nor an error!"
+            }
+        }
+    }
+        
+    static func isUsernameAndPasswordLink(_ link: URL) -> Bool {
+        if LinkHelper.getLastPathFromLink(link) == "login-with-username-and-password", LinkHelper.linkContainsParams(link, paramKeys: ["username", "password"]) {
+            return true
+        }
+        
+        return false
+    }
+    
+    static func signInWithUsernameAndPassword(_ link: URL) -> Promise<Void> {
+        return Promise { seal in
+            
+            let params = LinkHelper.parseLink(link)
+            
+            guard let username = params["username"], let password = params["password"] else {
+                seal.reject(Error.noUsernameOrPassword)
+                return
+            }
+            
+            Auth.auth().signIn(withEmail: username, password: password) { authDataResult, error in
+                if let firebaseError = error {
+                    seal.reject(firebaseError)
+                    return
+                }
+                
+                guard authDataResult?.user != nil else {
+                    seal.reject(Error.noErrorAndNoUser)
+                    return
+                }
+                
+                seal.fulfill(())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows username and password login using deep link.

You can only use this deep link to share credentials to existing users.

To share credentials of existing user:
1. Set a password for an existing user by resetting the password for an existing user in firebase console
2. Construct the deep link https://dl-dev.oya.world/login-with-username-and-password?username=[email]&password=[password]
3. Make sure the app is already closed to prevent routing logic issues
4. enter the url from 2 to a browser on the phone
5. then manually open the app from the status bar in the browser if the app doesn't open automatically