### PR TITLE
Feature/add test cases for cold start

### DIFF
--- a/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
@@ -83,7 +83,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
     
     func testUserHasCompletedNRICAndCancelledJumioInSingapore() {
         let decider = StageDecider()
-        let localContext = LocalContext(selectedRegion: Region(id: "sg", name: "SG"), regionVerified: true, hasSeenVerifyIdentifyOnboarding: true, hasCompletedNRIC: true)
+        let localContext = LocalContext(selectedRegion: Region(id: "sg", name: "SG"), regionVerified: true, hasSeenVerifyIdentifyOnboarding: true)
         
         let context = Context(
             customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),
@@ -102,14 +102,14 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
     
     func testUserHasCompletedJumioButGotRejected() {
         let decider = StageDecider()
-        let localContext = LocalContext(selectedRegion: Region(id: "sg", name: "SG"), regionVerified: true, hasSeenVerifyIdentifyOnboarding: true, selectedVerificationOption: StageDecider.IdentityVerificationOption.scanIC, hasCompletedNRIC: true, hasCompletedJumio: true, hasCompletedAddress: true)
+        let localContext = LocalContext(selectedRegion: Region(id: "sg", name: "SG"), regionVerified: true, hasSeenVerifyIdentifyOnboarding: true, selectedVerificationOption: StageDecider.IdentityVerificationOption.scanIC, hasCompletedJumio: true, hasCompletedAddress: true)
         
         let context = Context(
             customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),
             regions: [
                 RegionResponse(
                     region: Region(id: "sg", name: "Singapore"),
-                    status: .PENDING,
+                    status: .REJECTED,
                     simProfiles: nil,
                     kycStatusMap: KYCStatusMap(jumio: .REJECTED, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .APPROVED)
                 )

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
@@ -109,7 +109,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
             regions: [
                 RegionResponse(
                     region: Region(id: "sg", name: "Singapore"),
-                    status: .REJECTED,
+                    status: .PENDING,
                     simProfiles: nil,
                     kycStatusMap: KYCStatusMap(jumio: .REJECTED, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .APPROVED)
                 )

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithScanICStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithScanICStageDeciderTests.swift
@@ -145,7 +145,7 @@ class SingaporeUserHappyFlowWithScanICStageDeciderTests: XCTestCase {
             regions: [
                 RegionResponse(
                     region: Region(id: "sg", name: "Singapore"),
-                    status: .REJECTED,
+                    status: .PENDING,
                     simProfiles: nil,
                     kycStatusMap: KYCStatusMap(jumio: .REJECTED, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .APPROVED)
                 )

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
@@ -31,6 +31,13 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
         XCTAssertEqual(decider.compute(context: nil, localContext: localContext), .checkYourEmail(email: "xxxx@xxxx.com"))
     }
     
+    func testUserHasEnteredEmailThenColdStart() {
+        let decider = StageDecider()
+        let localContext = LocalContext(enteredEmailAddress: "xxxx@xxxx.com")
+        
+        XCTAssertEqual(decider.compute(context: nil, localContext: localContext), .checkYourEmail(email: "xxxx@xxxx.com"))
+    }
+    
     func testUserHasAFirebaseUserButNoContextYet() {
         let decider = StageDecider()
         let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true)
@@ -43,6 +50,13 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
         let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true, hasAgreedToTerms: true)
         
         XCTAssertEqual(decider.compute(context: nil, localContext: localContext), .notificationPermissions)
+    }
+    
+    func testUserHasAgreedToLegalStuffThenColdStart() {
+        let decider = StageDecider()
+        let localContext = LocalContext(enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true)
+        
+        XCTAssertEqual(decider.compute(context: nil, localContext: localContext), .legalStuff)
     }
     
     func testUserHasSeenNotificationPermissions() {
@@ -100,6 +114,15 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
         let context = Context(customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"), regions: [])
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .verifyMyInfo(code: "xxx"))
+    }
+    
+    func testUserHasCompletedSingpassThenColdStart() {
+        let decider = StageDecider()
+        let localContext = LocalContext(myInfoCode: "xxx")
+        
+        let context = Context(customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"), regions: [])
+        
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .selectRegion)
     }
     
     func testUserHasCompletedSingpassAndVerifiedTheirAddress() {
@@ -178,6 +201,27 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
         )
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .awesome)
+    }
+    
+    func testUserHasInstalledESIMThenColdStart() {
+        let decider = StageDecider()
+        let localContext = LocalContext()
+        
+        let context = Context(
+            customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),
+            regions: [
+                RegionResponse(
+                    region: Region(id: "sg", name: "Singapore"),
+                    status: .APPROVED,
+                    simProfiles: [
+                        SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED)
+                    ],
+                    kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .APPROVED, nricFin: .PENDING, addressPhone: .PENDING)
+                )
+            ]
+        )
+        
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .home)
     }
     
     func testUserHasInstalledESIMAndSeenAwesome() {

--- a/ostelco-core/Models/OhNoIssueType.swift
+++ b/ostelco-core/Models/OhNoIssueType.swift
@@ -1,0 +1,16 @@
+//
+//  OhNoIssueType.swift
+//  ostelco-core
+//
+//  Created by mac on 7/2/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+public enum OhNoIssueType: Equatable {
+    case generic(code: String?)
+    case ekycRejected
+    case myInfoFailed
+    case noInternet
+    case paymentFailedGeneric
+    case paymentFailedCardDeclined
+}

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -187,11 +187,11 @@ struct StageDecider {
             return .nric
         }
         
-        // All other countries ekyc flow, where you only have jumio as an option
+        // All other countries ekyc flow, where you only have jumio as an option, also handles showing of selectIdentityVerificationMethod for Singapore flow
         if localContext.hasSeenVerifyIdentifyOnboarding, let selectedRegion = localContext.selectedRegion {
             let options = identityOptionsForRegion(selectedRegion)
             
-            if options.count == 1 {
+            if options.count == 1 { // All other countries
                 if localContext.hasCompletedJumio {
                     return .pendingVerification
                 }
@@ -200,7 +200,7 @@ struct StageDecider {
                 }
                 return .jumio
             }
-            return .selectIdentityVerificationMethod(options)
+            return .selectIdentityVerificationMethod(options) // Singapore flow specific
         }
         
         // 1. Select country.

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		04978D6922AB9B78002B09E0 /* UsernameAndPasswordLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6722AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift */; };
 		04978D6B22ABA012002B09E0 /* LinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6A22ABA012002B09E0 /* LinkHelper.swift */; };
 		04978D6C22ABA012002B09E0 /* LinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04978D6A22ABA012002B09E0 /* LinkHelper.swift */; };
+		04B9AB5122CB9062009234B6 /* OhNoIssueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B9AB5022CB9062009234B6 /* OhNoIssueType.swift */; };
 		04BA349A222587DD000359C4 /* Splash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 04BA3499222587DD000359C4 /* Splash.storyboard */; };
 		04BA349C222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
 		04BA349D222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
@@ -199,9 +200,9 @@
 		9B6A9DD022A562D10036AEE4 /* ESimCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A9DCE22A562D10036AEE4 /* ESimCoordinator.swift */; };
 		9B6A9DD222A566C90036AEE4 /* SignUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A9DD122A566C90036AEE4 /* SignUpCoordinator.swift */; };
 		9B6A9DD322A566C90036AEE4 /* SignUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6A9DD122A566C90036AEE4 /* SignUpCoordinator.swift */; };
-		9B6E34CB22B199840029AF76 /* String+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6E34CA22B199840029AF76 /* String+Empty.swift */; };
 		9B6E34C322B041500029AF76 /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6E34C222B041500029AF76 /* ImageAsset.swift */; };
 		9B6E34C422B042430029AF76 /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6E34C222B041500029AF76 /* ImageAsset.swift */; };
+		9B6E34CB22B199840029AF76 /* String+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6E34CA22B199840029AF76 /* String+Empty.swift */; };
 		9B6E3A19226F70300063EBAA /* OstelcoFontSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6E3A18226F70300063EBAA /* OstelcoFontSize.swift */; };
 		9B6E3A1E227048020063EBAA /* OstelcoStyles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BB6A793226F6513000D5E13 /* OstelcoStyles.framework */; };
 		9B6E3A20227080CE0063EBAA /* LocationProblemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6E3A1F227080CE0063EBAA /* LocationProblemViewController.swift */; };
@@ -487,6 +488,7 @@
 		0494336D22BB9E2400E5BB24 /* FreshchatManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshchatManager.swift; sourceTree = "<group>"; };
 		04978D6722AB9A37002B09E0 /* UsernameAndPasswordLinkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameAndPasswordLinkManager.swift; sourceTree = "<group>"; };
 		04978D6A22ABA012002B09E0 /* LinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHelper.swift; sourceTree = "<group>"; };
+		04B9AB5022CB9062009234B6 /* OhNoIssueType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhNoIssueType.swift; sourceTree = "<group>"; };
 		04BA3499222587DD000359C4 /* Splash.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Splash.storyboard; sourceTree = "<group>"; };
 		04BA349B222587F6000359C4 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		04BA349F2226B8D9000359C4 /* EnableNotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableNotificationsViewController.swift; sourceTree = "<group>"; };
@@ -569,8 +571,8 @@
 		9B6A9DCB22A55E850036AEE4 /* DefaultEKYCCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEKYCCoordinator.swift; sourceTree = "<group>"; };
 		9B6A9DCE22A562D10036AEE4 /* ESimCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ESimCoordinator.swift; sourceTree = "<group>"; };
 		9B6A9DD122A566C90036AEE4 /* SignUpCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpCoordinator.swift; sourceTree = "<group>"; };
-		9B6E34CA22B199840029AF76 /* String+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Empty.swift"; sourceTree = "<group>"; };
 		9B6E34C222B041500029AF76 /* ImageAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAsset.swift; sourceTree = "<group>"; };
+		9B6E34CA22B199840029AF76 /* String+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Empty.swift"; sourceTree = "<group>"; };
 		9B6E3A18226F70300063EBAA /* OstelcoFontSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstelcoFontSize.swift; sourceTree = "<group>"; };
 		9B6E3A1F227080CE0063EBAA /* LocationProblemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProblemViewController.swift; sourceTree = "<group>"; };
 		9B6E3A23227091EF0063EBAA /* LocationProblem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProblem.swift; sourceTree = "<group>"; };
@@ -1100,6 +1102,7 @@
 				0437197C22C4EB5D00609355 /* StageDecider.swift */,
 				9B0685FA228ACADA00AD3F3E /* StripeEphemeralKeyRequest.swift */,
 				9B5CBF3A22803A9A00D83D7B /* UserSetup.swift */,
+				04B9AB5022CB9062009234B6 /* OhNoIssueType.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2120,6 +2123,7 @@
 				9B821596227ADCE000DC6B64 /* BasicNetwork.swift in Sources */,
 				9B5CBF512281808B00D83D7B /* TokenProvider.swift in Sources */,
 				9B8215762279B0F800DC6B64 /* Headers.swift in Sources */,
+				04B9AB5122CB9062009234B6 /* OhNoIssueType.swift in Sources */,
 				9B6E34CB22B199840029AF76 /* String+Empty.swift in Sources */,
 				9B8215832279DF8700DC6B64 /* SimProfile.swift in Sources */,
 			);

--- a/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/ApplePayViewController.swift
@@ -59,7 +59,7 @@ class ApplePayViewController: UIViewController, ApplePayDelegate {
         }
     }
 
-    func showOhNo(type: OhNoViewController.IssueType) {
+    func showOhNo(type: OhNoIssueType) {
         let ohNo = OhNoViewController.fromStoryboard(type: type)
         ohNo.primaryButtonAction = {
             ohNo.dismiss(animated: true, completion: nil)

--- a/ostelco-ios-client/ViewControllers/OhNoViewController.swift
+++ b/ostelco-ios-client/ViewControllers/OhNoViewController.swift
@@ -8,107 +8,10 @@
 
 import OstelcoStyles
 import UIKit
+import ostelco_core
 
 /// A view controller for handling errors
 class OhNoViewController: UIViewController {
-    
-    enum IssueType {
-        case generic(code: String?)
-        case ekycRejected
-        case myInfoFailed
-        case noInternet
-        case paymentFailedGeneric
-        case paymentFailedCardDeclined
-
-        var displayTitle: String {
-            switch self {
-            case .generic,
-                 .ekycRejected,
-                 .myInfoFailed:
-                return "Oh no"
-            case .noInternet:
-                return "No internet connection"
-            case .paymentFailedGeneric:
-                return "Payment Failed"
-            case .paymentFailedCardDeclined:
-                return "Card Declined"
-            }
-        }
-        
-        var gifVideo: GifVideo {
-            switch self {
-            case .generic,
-                 .myInfoFailed:
-                return .taken
-            case .ekycRejected:
-                return .blank_canvas
-            case .noInternet,
-                 .paymentFailedGeneric,
-                 .paymentFailedCardDeclined:
-                return .no_connection
-            }
-        }
-        
-        var linkableText: LinkableText? {
-            switch self {
-            case .noInternet:
-                return LinkableText(fullText: """
-Try again in a while or contact support
-
-support@oya.world
-""",
-                                    linkedBits: ["support@oya.world"])
-            case .ekycRejected,
-                 .generic,
-                 .myInfoFailed,
-                 .paymentFailedCardDeclined,
-                 .paymentFailedGeneric:
-                return nil
-            }
-        }
-        
-        var boldableText: BoldableText? {
-            switch self {
-            case .noInternet:
-                return nil
-            case .generic(let code):
-                guard let errorCode = code else {
-                    return BoldableText(fullText: "Something went wrong. Try again in a while.",
-                                        boldedPortion: nil)
-                }
-                
-                return BoldableText(fullText:
-                    "Something went wrong. Try again in a while. If you contact customer support, please use this error code: \(errorCode)", boldedPortion: "\(errorCode)")
-            case .ekycRejected:
-                return BoldableText(fullText: "Something went wrong.\n\nTry again in a while, or contact support",
-                                    boldedPortion: nil)
-            case .myInfoFailed:
-                return BoldableText(fullText: "We're unable to retrieve your info from MyInfo.\n\n. Try later.",
-                                    boldedPortion: nil)
-            case .paymentFailedGeneric:
-                return BoldableText(fullText: "Something went wrong in our system. We have not taken any money from your account. Try again in a while or contact customer support.",
-                                    boldedPortion: nil)
-            case .paymentFailedCardDeclined:
-                return BoldableText(fullText: "Your card was declined. Contact your bank or try with another card.",
-                                    boldedPortion: nil)
-            }
-        }
-        
-        var buttonTitle: String {
-            switch self {
-            case .generic,
-                 .myInfoFailed:
-                return "Try again"
-            case .ekycRejected:
-                return "Retry"
-            case .noInternet:
-                return "Check again"
-            case .paymentFailedGeneric,
-                 .paymentFailedCardDeclined:
-                return "OK"
-            }
-        }
-    }
     
     @IBOutlet private var primaryButton: UIButton!
     @IBOutlet private var titleLabel: UILabel!
@@ -119,7 +22,7 @@ support@oya.world
     ///
     /// - Parameter type: The type to use to configure copy and image
     /// - Returns: The instantiated and configured VC.
-    static func fromStoryboard(type: IssueType) -> OhNoViewController {
+    static func fromStoryboard(type: OhNoIssueType) -> OhNoViewController {
         let vc = self.fromStoryboard()
         vc.displayTitle = type.displayTitle
         vc.videoURL = type.gifVideo.url
@@ -227,5 +130,96 @@ extension OhNoViewController: StoryboardLoadable {
     
     static var storyboard: Storyboard {
         return .ohNo
+    }
+}
+
+extension OhNoIssueType {
+    var displayTitle: String {
+        switch self {
+        case .generic,
+             .ekycRejected,
+             .myInfoFailed:
+            return "Oh no"
+        case .noInternet:
+            return "No internet connection"
+        case .paymentFailedGeneric:
+            return "Payment Failed"
+        case .paymentFailedCardDeclined:
+            return "Card Declined"
+        }
+    }
+    
+    var gifVideo: GifVideo {
+        switch self {
+        case .generic,
+             .myInfoFailed:
+            return .taken
+        case .ekycRejected:
+            return .blank_canvas
+        case .noInternet,
+             .paymentFailedGeneric,
+             .paymentFailedCardDeclined:
+            return .no_connection
+        }
+    }
+    
+    var linkableText: LinkableText? {
+        switch self {
+        case .noInternet:
+            return LinkableText(fullText: """
+Try again in a while or contact support
+
+support@oya.world
+""",
+                                linkedBits: ["support@oya.world"])
+        case .ekycRejected,
+             .generic,
+             .myInfoFailed,
+             .paymentFailedCardDeclined,
+             .paymentFailedGeneric:
+            return nil
+        }
+    }
+    
+    var boldableText: BoldableText? {
+        switch self {
+        case .noInternet:
+            return nil
+        case .generic(let code):
+            guard let errorCode = code else {
+                return BoldableText(fullText: "Something went wrong. Try again in a while.",
+                                    boldedPortion: nil)
+            }
+            
+            return BoldableText(fullText:
+                "Something went wrong. Try again in a while. If you contact customer support, please use this error code: \(errorCode)", boldedPortion: "\(errorCode)")
+        case .ekycRejected:
+            return BoldableText(fullText: "Something went wrong.\n\nTry again in a while, or contact support",
+                                boldedPortion: nil)
+        case .myInfoFailed:
+            return BoldableText(fullText: "We're unable to retrieve your info from MyInfo.\n\n. Try later.",
+                                boldedPortion: nil)
+        case .paymentFailedGeneric:
+            return BoldableText(fullText: "Something went wrong in our system. We have not taken any money from your account. Try again in a while or contact customer support.",
+                                boldedPortion: nil)
+        case .paymentFailedCardDeclined:
+            return BoldableText(fullText: "Your card was declined. Contact your bank or try with another card.",
+                                boldedPortion: nil)
+        }
+    }
+    
+    var buttonTitle: String {
+        switch self {
+        case .generic,
+             .myInfoFailed:
+            return "Try again"
+        case .ekycRejected:
+            return "Retry"
+        case .noInternet:
+            return "Check again"
+        case .paymentFailedGeneric,
+             .paymentFailedCardDeclined:
+            return "OK"
+        }
     }
 }


### PR DESCRIPTION
- Replaced localContext.hasCompletedNRIC with kYCStatusMap.NRIC.APPROVED because it's redundant information.
- Fixed context in testUserHasCompletedJumioButGotRejected to status.REJECTED.
- Added cold start cases to show how the app today functions if you kill the app during on boarding.
- Marked fields that needs to be persisted in localContext for the cold test cases.