### PR TITLE
Allow refactor branches to be built in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,3 +89,4 @@ workflows:
                 - /feature/.*/
                 - /release/.*/
                 - /fix/.*/
+                - /refactor/.*/


### PR DESCRIPTION
To merge PR into develop, we require CI to pass, CI only builds braches with certain prefixes, refactor prefix is now one of those.