### PR TITLE
Lock SPM minor version.

### DIFF
--- a/scripts/SPM/Package.swift
+++ b/scripts/SPM/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-package-manager.git",
-            .upToNextMajor(from: "0.3.0")
+            .upToNextMinor(from: "0.3.0")
         ),
     ],
     targets: [


### PR DESCRIPTION
Lock SPM minor version since I experienced issues building the project with SPM version 0.4.0.

scripts/SPM/swift build
'SPM' /Users/mac/github/xcode/ostelco-ios-client/scripts/SPM: error: product dependency 'Utility' not found
warning: dependency 'SwiftPM' is not used by any target