### PR TITLE
Move API usage out of controllers.

### DIFF
--- a/OstelcoStyles/LinkableText.swift
+++ b/OstelcoStyles/LinkableText.swift
@@ -8,6 +8,16 @@
 
 import Foundation
 
+public struct Link: Equatable {
+    public let text: String
+    public let url: URL
+    
+    public init(_ text: String, url: URL) {
+        self.text = text
+        self.url = url
+    }
+}
+
 /// A text structure for dealing with a large amount of text that potentially
 /// contains multiple links.
 public struct LinkableText {
@@ -16,7 +26,7 @@ public struct LinkableText {
     public let fullText: String
     
     /// [optional] The bits of text to link, or nil to link nothing.
-    public let linkedBits: [String]?
+    public let linkedBits: [Link]?
     
     /// Failable Initializer for text with a single linked portion.
     /// Fails when the `linkedPortion` is non-nil and is not contained within the full text.
@@ -24,8 +34,7 @@ public struct LinkableText {
     /// - Parameters:
     ///   - fullText: The text you can potentially add links to
     ///   - linkedPortion: [optional] The text which should be linked, or nil to link nothing.
-    public init?(fullText: String,
-                 linkedPortion: String?) {
+    public init?(fullText: String, linkedPortion: Link?) {
         if let singleLink = linkedPortion {
             self.init(fullText: fullText, linkedBits: [singleLink])
         } else {
@@ -40,13 +49,12 @@ public struct LinkableText {
     /// - Parameters:
     ///   - fullText: The text containing 0 or more links
     ///   - linkedBits: [optional] The bits of text to link, or nil to link nothing.
-    public init?(fullText: String,
-                 linkedBits: [String]?) {
+    public init?(fullText: String, linkedBits: [Link]?) {
         self.fullText = fullText
         
         if let bits = linkedBits {
             for bit in bits {
-                guard fullText.contains(bit) else {
+                guard fullText.contains(bit.text) else {
                     // The full text doesn't contain one of the things we're trying to link.
                     return nil
                 }
@@ -59,8 +67,8 @@ public struct LinkableText {
         }
     }
     
-    private func range(of bit: String) -> NSRange? {
-        let nsRange = (self.fullText as NSString).range(of: bit)
+    private func range(of bit: Link) -> NSRange? {
+        let nsRange = (self.fullText as NSString).range(of: bit.text)
         guard nsRange.location != NSNotFound else {
             return nil
         }
@@ -68,7 +76,7 @@ public struct LinkableText {
         return nsRange
     }
     
-    private func bit(_ bit: String, contains index: Int) -> Bool {
+    private func bit(_ bit: Link, contains index: Int) -> Bool {
         guard let range = self.range(of: bit) else {
             return false
         }
@@ -93,12 +101,12 @@ public struct LinkableText {
         return bits.contains(where: { self.bit($0, contains: index) })
     }
     
-    /// Returns the linked text at the given index
+    /// Returns the link at the given index
     ///
     /// - Parameter index: The index to check for linked text
     /// - Returns: [Optional] The linked text at the given index, or nil if the index
     ///            did not contain a link.
-    public func linkedText(at index: Int) -> String? {
+    public func linkedText(at index: Int) -> Link? {
         guard
             index < (self.fullText as NSString).length,
             let bits = self.linkedBits,

--- a/dev-ostelco-ios-clientTests/LinkableTextTests.swift
+++ b/dev-ostelco-ios-clientTests/LinkableTextTests.swift
@@ -13,19 +13,21 @@ import XCTest
 
 class LinkableTextTests: XCTestCase {
     
+    let dummyURL = URL(string: "https://google.com")!
+    
     // MARK: - Generic linkable text
     
     private let testText = "She sells seashells by the seashore"
     
     func testNilPassedToInitializersWorks() {
-        XCTAssertNotNil(LinkableText(fullText: self.testText, linkedBits: nil))
-        XCTAssertNotNil(LinkableText(fullText: self.testText, linkedPortion: nil))
+        XCTAssertNotNil(LinkableText(fullText: testText, linkedBits: nil))
+        XCTAssertNotNil(LinkableText(fullText: testText, linkedPortion: nil))
     }
     
     func testSingleLinkInitializerWorksWithIncludedText() {
-        let linkedPortion = "seashells"
+        let linkedPortion = Link("seashells", url: dummyURL)
         
-        guard let linkableText = LinkableText(fullText: self.testText, linkedPortion: linkedPortion) else {
+        guard let linkableText = LinkableText(fullText: testText, linkedPortion: linkedPortion) else {
             XCTFail("This should have worked!")
             return
         }
@@ -44,14 +46,14 @@ class LinkableTextTests: XCTestCase {
     }
     
     func testSingleLinkInitializerFailsWithNotIncludedText() {
-        let linkedPortion = "sea monsters"
-        XCTAssertNil(LinkableText(fullText: self.testText, linkedPortion: linkedPortion))
+        let linkedPortion = Link("sea monsters", url: dummyURL)
+        XCTAssertNil(LinkableText(fullText: testText, linkedPortion: linkedPortion))
     }
     
     func testMultipleLinkInitializerWorksWithAllIncludedText() {
-        let bits = ["seashells", "seashore"]
+        let bits = [Link("seashells", url: dummyURL), Link("seashore", url: dummyURL)]
         
-        guard let linkableText = LinkableText(fullText: self.testText, linkedBits: bits) else {
+        guard let linkableText = LinkableText(fullText: testText, linkedBits: bits) else {
             XCTFail("Both of these are contained, this should have worked!")
             return
         }
@@ -75,7 +77,7 @@ class LinkableTextTests: XCTestCase {
         XCTAssertEqual(linkableText.linkedText(at: 27), bits[1])
         
         // Second link should end at the end of the word
-        let length = (self.testText as NSString).length
+        let length = (testText as NSString).length
         let lastIndex = length - 1
         XCTAssertTrue(linkableText.isIndexLinked(lastIndex))
         XCTAssertEqual(linkableText.linkedText(at: lastIndex), bits[1])
@@ -86,9 +88,9 @@ class LinkableTextTests: XCTestCase {
     }
     
     func testMultipleLinkInitializerFailsWithSingleNotIncludedText() {
-        let bits = ["seashells", "sea lion"]
+        let bits = [Link("seashells", url: dummyURL), Link("sea lion", url: dummyURL)]
 
-        XCTAssertNil(LinkableText(fullText: self.testText, linkedBits: bits))
+        XCTAssertNil(LinkableText(fullText: testText, linkedBits: bits))
     }
     
     // MARK: - Individual instances of linkable text

--- a/ostelco-core/Models/Context.swift
+++ b/ostelco-core/Models/Context.swift
@@ -25,7 +25,7 @@ public struct Context {
     }
     
     public func toGraphQLModel() -> PrimeGQL.ContextQuery.Data.Context {
-        var gqlCustomer: PrimeGQL.ContextQuery.Data.Context.Customer? = nil
+        var gqlCustomer: PrimeGQL.ContextQuery.Data.Context.Customer?
         if let customer = customer {
             gqlCustomer = PrimeGQL.ContextQuery.Data.Context.Customer(legacyModel: customer)
         }
@@ -38,7 +38,7 @@ public struct Context {
 
 extension PrimeGQL.ContextQuery.Data.Context {
     public func toLegacyModel() -> Context {
-        var legacyCustomer: CustomerModel? = nil
+        var legacyCustomer: CustomerModel?
         if let customer = customer {
             legacyCustomer = CustomerModel(gqlCustomer: customer)
         }

--- a/ostelco-ios-client/Coordinators/EKYC/SingPassCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/EKYC/SingPassCoordinator.swift
@@ -31,7 +31,7 @@ class SingPassCoordinator: NSObject {
     }
     
     func startLogin(from viewController: UIViewController) {
-        let spinnerView = viewController.showSpinner(onView: viewController.view)
+        let spinnerView = viewController.showSpinner()
         // Fetch the configuration from prime
         APIManager.shared.primeAPI
             .loadMyInfoConfig()

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -218,8 +218,22 @@ extension OnboardingCoordinator: TheLegalStuffDelegate {
 }
 
 extension OnboardingCoordinator: GetStartedDelegate {
-    func nameEnteredSuccessfully() {
-        advance()
+    func enteredNickname(_ nickname: String) {
+        guard let email = UserManager.shared.currentUserEmail else {
+            navigationController.showAlert(title: "Error", msg: "Email is empty or missing in Firebase")
+            return
+        }
+        
+        let user = UserSetup(nickname: nickname, email: email)
+        
+        APIManager.shared.primeAPI.createCustomer(with: user)
+        .done { [weak self] customer in
+            OstelcoAnalytics.logEvent(.EnteredNickname)
+            UserManager.shared.customer = PrimeGQL.ContextQuery.Data.Context.Customer(legacyModel: customer)
+            self?.advance()
+        }
+        .cauterize()
+        // There is no catch. The only reason this could error is if the server is unreachable which we handle otherwise.
     }
 }
 

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -453,12 +453,7 @@ extension OnboardingCoordinator: ESIMPendingDownloadDelegate {
         .then { (context) -> PromiseKit.Promise<SimProfile> in
             let region = context.toLegacyModel().getRegion()!
             let profile = region.getSimProfile()!
-<<<<<<< HEAD
-            return APIManager.shared.primeAPI.resendEmailForSimProfileInRegion(code: region.region.id, iccId: profile.iccId)
-=======
-            
-            return self.primeAPI.resendEmailForSimProfileInRegion(code: region.region.country.countryCode, iccId: profile.iccId)
->>>>>>> Fixes linkable text.
+            return self.primeAPI.resendEmailForSimProfileInRegion(code: region.region.id, iccId: profile.iccId)
         }
         .done { [weak self] _ in
             self?.navigationController.showAlert(
@@ -529,15 +524,7 @@ extension OnboardingCoordinator: JumioCoordinatorDelegate {
 }
 
 extension OnboardingCoordinator: PendingVerificationDelegate {
-<<<<<<< HEAD
-    func waitingCompletedSuccessfully(for region: PrimeGQL.RegionDetailsFragment) {
-        advance()
-    }
-    
-    func waitingCompletedWithRejection() {
-=======
     func checkStatus() {
->>>>>>> Fixes linkable text.
         advance()
     }
 }

--- a/ostelco-ios-client/Extensions/UIViewController+UIActivityIndicator.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+UIActivityIndicator.swift
@@ -11,18 +11,18 @@ import UIKit
 // ref: https://github.com/vincechan/SwiftLoadingIndicator/blob/master/SwiftLoadingIndicator/LoadingIndicatorView.swift
 
 extension UIViewController {
-    @discardableResult func showSpinner(onView: UIView, loadingText: String? = nil) -> UIView {
+    @discardableResult func showSpinner(loadingText: String? = nil) -> UIView {
         
         // Create the overlay
         let overlay = UIView()
         overlay.alpha = 0
         overlay.backgroundColor = UIColor.white
         overlay.translatesAutoresizingMaskIntoConstraints = false
-        onView.addSubview(overlay)
-        onView.bringSubviewToFront(overlay)
+        view.addSubview(overlay)
+        view.bringSubviewToFront(overlay)
         
-        overlay.widthAnchor.constraint(equalTo: onView.widthAnchor).isActive = true
-        overlay.heightAnchor.constraint(equalTo: onView.heightAnchor).isActive = true
+        overlay.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
+        overlay.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
         
         // Create and animate the activity indicator
         let indicator = UIActivityIndicatorView(style: .whiteLarge)

--- a/ostelco-ios-client/ModelControllers/UserManager.swift
+++ b/ostelco-ios-client/ModelControllers/UserManager.swift
@@ -64,7 +64,7 @@ class UserManager: TokenProvider {
     }
     
     func deleteAccount(showingIn viewController: UIViewController) {
-        let spinnerView = viewController.showSpinner(onView: viewController.view)
+        let spinnerView = viewController.showSpinner()
         APIManager.shared.primeAPI.deleteCustomer()
             .ensure { [weak viewController] in
                 viewController?.removeSpinner(spinnerView)

--- a/ostelco-ios-client/Models/LocationProblem+UserFacingCopy.swift
+++ b/ostelco-ios-client/Models/LocationProblem+UserFacingCopy.swift
@@ -53,39 +53,37 @@ extension LocationProblem {
     
     /// The explanatory copy the user should see about the problem.
     var linkableCopy: LinkableText {
+        let link = Link(NSLocalizedString("by law", comment: "Location errors: linkable part"), url: ExternalLink.locationRequirement.url)
+        
         switch self {
         case .authorizedButWrongCountry(let expected, let actual):
-            return LinkableText(fullText: """
-            It seems like you're in \(actual).
-            
-            To give you mobile data, by law, we have to verify that you're in \(expected)
-            """, linkedPortion: "by law")!
-        case .disabledInSettings,
-             .deniedByUser,
-             .notDetermined:
-            return LinkableText(fullText: """
-            To give you mobile data, by law, we have to verify which country you're in.
-            
-            Please enable "Location Services" in Settings.
-            """, linkedPortion: "by law")!
+            let format = "It seems like you're in %@.\n\nTo give you mobile data, by law, we have to verify that you're in %@"
+            return LinkableText(
+                fullText: String(format: NSLocalizedString(format, comment: "Error message when user is in the wrong country"), expected, actual),
+                linkedPortion: link
+            )!
+        case .disabledInSettings, .deniedByUser, .notDetermined:
+            return LinkableText(
+                fullText: NSLocalizedString("To give you mobile data, by law, we have to verify which country you're in.\n\nPlease enable \"Location Services\" in Settings.", comment: "Error when user has disabled location access."),
+                linkedPortion: link
+            )!
         case .restrictedByParentalControls:
-            return LinkableText(fullText: """
-            To give you mobile data, by law, we have to verify which country you're in.
-            
-            "Location Services" are disabled due to Parental Control Settings on this device.
-            """, linkedPortion: "by law")!
+            return LinkableText(
+                fullText: NSLocalizedString("To give you mobile data, by law, we have to verify which country you're in.\n\n\"Location Services\" are disabled due to Parental Control Settings on this device.", comment: "Error when user is restricted by parental controls"),
+                linkedPortion: link
+            )!
         }
     }
     
-    /// [optional] The primary button title. If no title is returned, the button should be hidden.
+    /// The primary button title. If no title is returned, the button should be hidden.
     var primaryButtonTitle: String? {
         switch self {
         case .disabledInSettings,
              .deniedByUser:
-            return "Settings"
+            return NSLocalizedString("Settings", comment: "Title for primary action button when user needs to fix location settings")
         case .notDetermined,
              .authorizedButWrongCountry:
-            return "Retry"
+            return NSLocalizedString("Retry", comment: "Title for primary action button when user needs to retry selecting a country")
         case .restrictedByParentalControls:
             return nil
         }

--- a/ostelco-ios-client/Network/APIManager.swift
+++ b/ostelco-ios-client/Network/APIManager.swift
@@ -15,8 +15,10 @@ class APIManager {
     
     lazy var primeAPI: PrimeAPI = {
         let baseURLString = Environment().configuration(PlistKey.ServerURL)
-        return PrimeAPI(baseURLString: baseURLString,
-                           tokenProvider: self.tokenProvider)
+        return PrimeAPI(
+            baseURLString: baseURLString,
+            tokenProvider: self.tokenProvider
+        )
     }()
     
     var baseURLString: String {

--- a/ostelco-ios-client/Protocols/PushNotificationHandling.swift
+++ b/ostelco-ios-client/Protocols/PushNotificationHandling.swift
@@ -39,7 +39,7 @@ extension PushNotificationHandling {
                 guard let pushObject = self.convertToNotificationContainer(userInfo: notification.userInfo) else {
                     let error = ApplicationErrors.General.couldntConvertUserInfoToNotificaitonData(userInfo: notification.userInfo)
                     ApplicationErrors.assertAndLog(error)
-                        return
+                    return
                 }
                 
                 self.handlePushNotification(pushObject)

--- a/ostelco-ios-client/Storyboards/Base.lproj/Email.storyboard
+++ b/ostelco-ios-client/Storyboards/Base.lproj/Email.storyboard
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="your@email.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6Sg-FN-Gmq" customClass="TopBottomBorderedTextField" customModule="OstelcoStyles">
-                                <rect key="frame" x="0.0" y="191.33333333333334" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="142.33333333333334" width="375" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="JS7-WM-fll"/>
                                 </constraints>
@@ -31,20 +31,20 @@
                                 </connections>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What is your email address?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jp7-YK-ZEC" customClass="Heading2Label" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="88" width="327" height="69.333333333333314"/>
+                                <rect key="frame" x="24" y="88" width="327" height="20.333333333333329"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HwT-Hr-sTl" customClass="PrimaryButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="684" width="327" height="50"/>
+                                <rect key="frame" x="24" y="704" width="327" height="30"/>
                                 <state key="normal" title="Continue"/>
                                 <connections>
                                     <action selector="continueTapped" destination="8Sr-ot-cFb" eventType="touchUpInside" id="M5Z-N3-VY4"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Some kind of error occurred" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoL-c1-WZi" customClass="ErrorTextLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="251.33333333333337" width="327" height="21"/>
+                                <rect key="frame" x="24" y="202.33333333333334" width="327" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -106,15 +106,8 @@
                                     <action selector="needHelpTapped" destination="ejA-LR-l53" eventType="touchUpInside" id="Ek9-Rt-wX3"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BwW-Su-BCB" customClass="LinkTextButton" customModule="OstelcoStyles">
-                                <rect key="frame" x="75.666666666666686" y="572.33333333333337" width="224" height="20.666666666666629"/>
-                                <state key="normal" title="Submit Simulator Pasteboard"/>
-                                <connections>
-                                    <action selector="submitPasteboardTapped" destination="ejA-LR-l53" eventType="touchUpInside" id="dDO-7w-ORq"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="We need to confirm your email address. Please click the link in the email you received." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0cu-on-0rp" customClass="OnboardingLabel" customModule="OstelcoStyles">
-                                <rect key="frame" x="24" y="489.66666666666669" width="327" height="66.666666666666686"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="We need to confirm your email address. Please click the link in the email you received." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0cu-on-0rp" customClass="OnboardingLabel" customModule="OstelcoStyles">
+                                <rect key="frame" x="24" y="526.33333333333337" width="327" height="66.666666666666629"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -132,18 +125,16 @@
                             <constraint firstItem="YU5-UY-nx5" firstAttribute="leading" secondItem="CEv-8w-uyC" secondAttribute="leading" constant="24" id="1TM-96-cfB"/>
                             <constraint firstItem="0cu-on-0rp" firstAttribute="leading" secondItem="CEv-8w-uyC" secondAttribute="leading" constant="24" id="3oq-7O-aPj"/>
                             <constraint firstItem="KUH-L2-xfe" firstAttribute="leading" secondItem="CEv-8w-uyC" secondAttribute="leading" constant="24" id="3pH-jm-5aB"/>
-                            <constraint firstItem="BwW-Su-BCB" firstAttribute="top" secondItem="0cu-on-0rp" secondAttribute="bottom" constant="16" id="9jL-qU-wMR"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="YU5-UY-nx5" secondAttribute="trailing" constant="24" id="I0M-qB-7d4"/>
-                            <constraint firstItem="fn5-bY-n3l" firstAttribute="top" secondItem="BwW-Su-BCB" secondAttribute="bottom" constant="24" id="QdO-at-rJd"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="KUH-L2-xfe" secondAttribute="trailing" constant="24" id="QeG-eo-WbW"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="bottom" secondItem="cen-WM-H3N" secondAttribute="bottom" constant="44" id="Sez-Eo-l7S"/>
-                            <constraint firstItem="BwW-Su-BCB" firstAttribute="centerX" secondItem="vCx-56-Z2j" secondAttribute="centerX" id="UKg-Xf-6Sq"/>
                             <constraint firstItem="fn5-bY-n3l" firstAttribute="centerX" secondItem="vCx-56-Z2j" secondAttribute="centerX" id="UiD-Qv-sUK"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="cen-WM-H3N" secondAttribute="trailing" constant="24" id="UyX-h9-Apg"/>
                             <constraint firstItem="cen-WM-H3N" firstAttribute="leading" secondItem="CEv-8w-uyC" secondAttribute="leading" constant="24" id="cPz-uA-ck5"/>
                             <constraint firstItem="cen-WM-H3N" firstAttribute="top" secondItem="fn5-bY-n3l" secondAttribute="bottom" constant="34" id="hJX-je-wuB"/>
                             <constraint firstItem="KUH-L2-xfe" firstAttribute="top" secondItem="YU5-UY-nx5" secondAttribute="bottom" constant="20" id="kqV-jO-cXm"/>
                             <constraint firstItem="YU5-UY-nx5" firstAttribute="top" secondItem="CEv-8w-uyC" secondAttribute="top" constant="44" id="nVS-mn-Fov"/>
+                            <constraint firstItem="fn5-bY-n3l" firstAttribute="top" secondItem="0cu-on-0rp" secondAttribute="bottom" constant="24" id="oj3-ql-Lsc"/>
                             <constraint firstItem="CEv-8w-uyC" firstAttribute="trailing" secondItem="0cu-on-0rp" secondAttribute="trailing" constant="24" id="uuS-rP-IDo"/>
                             <constraint firstItem="0cu-on-0rp" firstAttribute="top" relation="greaterThanOrEqual" secondItem="KUH-L2-xfe" secondAttribute="bottom" constant="20" id="yHx-Zr-h0q"/>
                         </constraints>
@@ -151,7 +142,6 @@
                     </view>
                     <connections>
                         <outlet property="gifView" destination="KUH-L2-xfe" id="RGo-4g-f3X"/>
-                        <outlet property="submitPasteboardOnSimulatorButton" destination="BwW-Su-BCB" id="5bK-6s-39r"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="s9L-Rx-c69" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/ostelco-ios-client/ViewControllers/Country/ChooseCountryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/ChooseCountryViewController.swift
@@ -20,18 +20,20 @@ class ChooseCountryViewController: UIViewController {
     @IBOutlet private var continueButton: UIButton!
     
     private lazy var dataSource: CountryDataSource = {
-        return CountryDataSource(tableView: self.tableView,
-                                 countries: Country.defaultCountries,
-                                 delegate: self)
+        return CountryDataSource(
+            tableView: tableView,
+            countries: Country.defaultCountries,
+            delegate: self
+        )
     }()
     
     weak var delegate: ChooseCountryDelegate?
     private var currentSelectedCountry: Country? {
         didSet {
-            if self.currentSelectedCountry == nil {
-                self.continueButton.isEnabled = false
+            if currentSelectedCountry == nil {
+                continueButton.isEnabled = false
             } else {
-                self.continueButton.isEnabled = true
+                continueButton.isEnabled = true
             }
         }
     }
@@ -39,21 +41,21 @@ class ChooseCountryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.tableView.tintColor = OstelcoColor.oyaBlue.toUIColor
-        self.tableView.addEmptyFooter()
-        self.dataSource.reloadData()
+        tableView.tintColor = OstelcoColor.oyaBlue.toUIColor
+        tableView.addEmptyFooter()
+        dataSource.reloadData()
     }
     
     @IBAction private func needHelpTapped(_ sender: Any) {
-        self.showNeedHelpActionSheet()
+        showNeedHelpActionSheet()
     }
     
     @IBAction private func continueTapped(_ sender: Any) {
-        guard let country = self.currentSelectedCountry else {
+        guard let country = currentSelectedCountry else {
             return
         }
         
-        showSpinner(onView: self.view)
+        showSpinner()
         delegate?.selectedCountry(country)
     }
 }
@@ -61,7 +63,7 @@ class ChooseCountryViewController: UIViewController {
 extension ChooseCountryViewController: CountrySelectionDelegate {
     
     func selected(country: Country) {
-        self.currentSelectedCountry = country
+        currentSelectedCountry = country
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/LocationProblemViewController.swift
@@ -158,11 +158,7 @@ extension LocationProblemViewController: StoryboardLoadable {
 
 extension LocationProblemViewController: LabelTapDelegate {
     
-    func tappedAttributedLabel(_ label: UILabel, at characterIndex: Int) {
-        guard locationProblem!.linkableCopy.isIndexLinked(characterIndex) else {
-            return
-        }
-        
-        UIApplication.shared.open(ExternalLink.locationRequirement.url)
+    func tappedLink(_ link: Link) {
+        UIApplication.shared.open(link.url)
     }
 }

--- a/ostelco-ios-client/ViewControllers/Country/VerifyCountryOnBoardingViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/VerifyCountryOnBoardingViewController.swift
@@ -41,7 +41,7 @@ class VerifyCountryOnBoardingViewController: UIViewController {
     
     private func setTitle() {
         if let user = UserManager.shared.customer {
-            titleLabel.text = String(format: NSLocalizedString("Hi %@", comment: "User greeting during onboarding"), user.name)
+            titleLabel.text = String(format: NSLocalizedString("Hi %@", comment: "User greeting during onboarding"), user.nickname)
         }
     }
 }

--- a/ostelco-ios-client/ViewControllers/Country/VerifyCountryOnBoardingViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/VerifyCountryOnBoardingViewController.swift
@@ -23,12 +23,12 @@ class VerifyCountryOnBoardingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.selectedStepIcon.tintColor = OstelcoColor.oyaBlue.toUIColor
+        selectedStepIcon.tintColor = OstelcoColor.oyaBlue.toUIColor
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.setTitle()
+        setTitle()
     }
     
     @IBAction private func needHelpTapped(_ sender: UIButton) {
@@ -36,12 +36,12 @@ class VerifyCountryOnBoardingViewController: UIViewController {
     }
     
     @IBAction private func continueTapped(_ sender: UIButton) {
-        self.delegate?.finishedViewingCountryLandingScreen()
+        delegate?.finishedViewingCountryLandingScreen()
     }
     
     private func setTitle() {
         if let user = UserManager.shared.customer {
-            self.titleLabel.text = String(format: NSLocalizedString("Hi %@", comment: "User greeting during onboarding"), user.nickname)
+            titleLabel.text = String(format: NSLocalizedString("Hi %@", comment: "User greeting during onboarding"), user.name)
         }
     }
 }

--- a/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/AddressEditViewController.swift
@@ -150,7 +150,7 @@ class AddressEditViewController: UITableViewController {
         let countryCode = delegate?.countryCode()
         let address = self.buildAddress()
         
-        self.spinnerView = showSpinner(onView: self.view)
+        self.spinnerView = showSpinner()
 
         APIManager.shared.primeAPI
             .addAddress(address, forRegion: countryCode!)

--- a/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/MyInfoSummaryViewController.swift
@@ -44,7 +44,7 @@ class MyInfoSummaryViewController: UIViewController {
             return
         }
         
-        self.spinnerView = self.showSpinner(onView: self.view, loadingText: NSLocalizedString("Loading your data from SingPass...", comment: "Loading text after user approves SingPass"))
+        self.spinnerView = self.showSpinner(loadingText: NSLocalizedString("Loading your data from SingPass...", comment: "Loading text after user approves SingPass"))
         APIManager.shared.primeAPI
             .loadSingpassInfo(code: code)
             .ensure { [weak self] in
@@ -75,7 +75,7 @@ class MyInfoSummaryViewController: UIViewController {
                 return
         }
         
-        self.spinnerView = self.showSpinner(onView: self.view)
+        self.spinnerView = self.showSpinner()
         APIManager.shared.primeAPI.updateEKYCProfile(with: profileUpdate, forRegion: "sg")
             .ensure { [weak self] in
                 self?.removeSpinner(self?.spinnerView)

--- a/ostelco-ios-client/ViewControllers/EKYC/NRICVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRICVerifyViewController.swift
@@ -40,7 +40,7 @@ class NRICVerifyViewController: UIViewController {
         }
         
         self.nricErrorLabel.isHidden = true
-        self.spinnerView = self.showSpinner(onView: self.view)
+        self.spinnerView = self.showSpinner()
         APIManager.shared.primeAPI
             .validateNRIC(nric, forRegion: countryCode)
             .ensure { [weak self] in

--- a/ostelco-ios-client/ViewControllers/EKYC/NRICVerifyViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/NRICVerifyViewController.swift
@@ -12,8 +12,7 @@ import PromiseKit
 import UIKit
 
 protocol NRICVerifyDelegate: class {
-    func countryCode() -> String
-    func enteredNRICSuccessfully()
+    func enteredNRICS(_ controller: NRICVerifyViewController, nric: String)
 }
 
 class NRICVerifyViewController: UIViewController {
@@ -26,37 +25,25 @@ class NRICVerifyViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.hideKeyboardWhenTappedAround()
+        hideKeyboardWhenTappedAround()
     }
     
     @IBAction private func needHelpTapped(_ sender: Any) {
-        self.showNeedHelpActionSheet()
+        showNeedHelpActionSheet()
     }
     
     @IBAction private func continueTapped(_ sender: Any) {
-        guard let nric = self.nricTextField.text, nric.isNotEmpty, let countryCode = delegate?.countryCode() else {
-            self.showAlert(title: "Error", msg: "NRIC field can't be empty")
+        guard let nric = nricTextField.text, nric.isNotEmpty else {
+            showAlert(title: "Error", msg: "NRIC field can't be empty")
             return
         }
         
-        self.nricErrorLabel.isHidden = true
-        self.spinnerView = self.showSpinner()
-        APIManager.shared.primeAPI
-            .validateNRIC(nric, forRegion: countryCode)
-            .ensure { [weak self] in
-                self?.removeSpinner(self?.spinnerView)
-            }
-            .done { [weak self] isValid in
-                if isValid {
-                    self?.delegate?.enteredNRICSuccessfully()
-                } else {
-                    self?.nricErrorLabel.isHidden = false
-                }
-            }
-            .catch { [weak self] error in
-                ApplicationErrors.log(error)
-                self?.showGenericError(error: error)
-            }
+        nricErrorLabel.isHidden = true
+        delegate?.enteredNRICS(self, nric: nric)
+    }
+    
+    func showError() {
+        nricErrorLabel.isHidden = false
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -11,9 +11,7 @@ import OstelcoStyles
 import UIKit
 
 protocol PendingVerificationDelegate: class {
-    func waitingCompletedSuccessfully(for region: PrimeGQL.RegionDetailsFragment)
-    func countryCode() -> String
-    func waitingCompletedWithRejection()
+    func checkStatus()
 }
 
 class PendingVerificationViewController: UIViewController {
@@ -25,6 +23,7 @@ class PendingVerificationViewController: UIViewController {
     var didBecomeActiveObserver: NSObjectProtocol?
     
     @IBOutlet private var gifView: LoopingVideoView!
+    var spinnerView: UIView?
 
     weak var delegate: PendingVerificationDelegate?
     
@@ -33,97 +32,34 @@ class PendingVerificationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.gifView.videoURL = GifVideo.time.url
-        self.gifView.play()
+        gifView.videoURL = GifVideo.time.url
+        gifView.play()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(true, animated: animated)
-        self.addPushNotificationListener()
-        self.addDidBecomeActiveObserver()
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+        
+        addPushNotificationListener()
+        addDidBecomeActiveObserver()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        self.removePushNotificationListener()
-        self.removeDidBecomeActiveObserver()
+        
+        removePushNotificationListener()
+        removeDidBecomeActiveObserver()
     }
     
     // MARK: - IBActions
     
     @IBAction private func needHelpTapped(_ sender: Any) {
-        self.showNeedHelpActionSheet()
+        showNeedHelpActionSheet()
     }
     
     @IBAction private func `continue`(_ sender: Any) {
-        self.checkVerificationStatus()
-    }
-    
-    func checkVerificationStatus(silentCheck: Bool = false) {
-        guard let countryCode = delegate?.countryCode() else {
-            fatalError("Missing country code!")
-        }
-        
-        let spinnerView = showSpinner()
-        APIManager.shared.primeAPI
-            .loadRegion(code: countryCode)
-            .ensure { [weak self] in
-                self?.removeSpinner(spinnerView)
-            }
-            .done { [weak self] regionResponse in
-                switch regionResponse.status {
-                case .approved:
-                    self?.delegate?.waitingCompletedSuccessfully(for: regionResponse)
-                default:
-                    self?.handleRegionPendingOrRejected(silentCheck: silentCheck, regionResponse: regionResponse)
-                }
-            }
-            .catch { [weak self] error in
-                ApplicationErrors.log(error)
-                self?.showGenericError(error: error)
-            }
-    }
-    
-    func handleRegionPending(silentCheck: Bool = false) {
-        if !silentCheck {
-            showAlert(title: "Status", msg: "Please hold on! We are still checking your docs.")
-        }
-    }
-    
-    func handleRegionPendingOrRejected(silentCheck: Bool = false, regionResponse: PrimeGQL.RegionDetailsFragment) {
-        if
-            let jumioStatus = regionResponse.kycStatusMap.jumio,
-            let nricStatus = regionResponse.kycStatusMap.nricFin,
-            let addressStatus = regionResponse.kycStatusMap.addressAndPhoneNumber {
-            switch (jumioStatus, nricStatus, addressStatus) {
-            case (.rejected, _, _), (_, .rejected, _), (_, _, .rejected):
-                self.delegate?.waitingCompletedWithRejection()
-            case (.approved, .approved, .approved):
-                self.delegate?.waitingCompletedSuccessfully(for: regionResponse)
-            case (.pending, _, _), (_, .pending, _), (_, _, .pending):
-                self.handleRegionPending(silentCheck: silentCheck)
-            default:
-                // This case means any of the above is pending, thus user has to wait
-                if !silentCheck {
-                    self.showAlert(title: "Status", msg: regionResponse.status.rawValue)
-                }
-            }
-        } else {
-            // If none of the variables above are set in the kycStatusMap, something weird has happened, send user to generic contact support screen
-            // TODO: Need to figure out what error code we should pass to generic error screen here
-            showGenericOhNo()
-        }
-    }
-    
-    func showGenericOhNo() {
-        let ohNo = OhNoViewController.fromStoryboard(type: .generic(code: nil))
-        ohNo.primaryButtonAction = {
-            ohNo.dismiss(animated: true, completion: { [weak self] in
-                self?.checkVerificationStatus()
-            })
-        }
-        self.present(ohNo, animated: true)
+        spinnerView = showSpinner()
+        delegate?.checkStatus()
     }
 }
 
@@ -145,19 +81,7 @@ extension PendingVerificationViewController: StoryboardLoadable {
 extension PendingVerificationViewController: PushNotificationHandling {
     
     func handlePushNotification(_ notification: PushNotificationContainer) {
-        guard let scanInfo = notification.scanInfo else {
-            // This is some other kind of notification
-            return
-        }
-        
-        switch scanInfo.status {
-        case .APPROVED:
-            self.checkVerificationStatus()
-        case .REJECTED:
-            self.delegate?.waitingCompletedWithRejection()
-        case .PENDING:
-            self.handleRegionPending(silentCheck: true)
-        }
+        delegate?.checkStatus()
     }
 }
 
@@ -166,6 +90,6 @@ extension PendingVerificationViewController: PushNotificationHandling {
 extension PendingVerificationViewController: DidBecomeActiveHandling {
     
     func handleDidBecomeActive() {
-        self.checkVerificationStatus(silentCheck: true)
+        delegate?.checkStatus()
     }
 }

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -65,7 +65,7 @@ class PendingVerificationViewController: UIViewController {
             fatalError("Missing country code!")
         }
         
-        let spinnerView = showSpinner(onView: self.view)
+        let spinnerView = showSpinner()
         APIManager.shared.primeAPI
             .loadRegion(code: countryCode)
             .ensure { [weak self] in

--- a/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
@@ -54,7 +54,7 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
     }
     
     @IBAction private func continueTapped() {
-        spinnerView = showSpinner(onView: self.view)
+        spinnerView = showSpinner()
         
         if self.singPassRadioButton.isCurrentSelected {
             OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "singpass"))

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMInstructionsViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMInstructionsViewController.swift
@@ -50,7 +50,7 @@ class ESIMInstructionsViewController: UIViewController {
             primaryButton.setTitle(NSLocalizedString("Send me the QR code", comment: "Last action button in eSim Carousel"), for: .normal)
             lastPageLabel.isHidden = false
         } else {
-            primaryButton.setTitle(NSLocalizedString("Next", comment: "Action button in eSim Carousel"), for: .normal)
+            primaryButton.setTitle(NSLocalizedString("Next", comment: "Action button in Carousel"), for: .normal)
             lastPageLabel.isHidden = true
         }
     }

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -23,7 +23,7 @@ class ESIMPendingDownloadViewController: UIViewController {
     @IBOutlet private weak var continueButton: UIButton!
 
     @IBAction private func sendAgainTapped(_ sender: Any) {
-        spinnerView = showSpinner(onView: self.view)
+        spinnerView = showSpinner()
         delegate?.resendEmail()
     }
     

--- a/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Email/CheckEmailViewController.swift
@@ -9,80 +9,28 @@
 import OstelcoStyles
 import UIKit
 
+protocol CheckEmailDelegate: class {
+    func resendLoginEmail()
+}
+
 class CheckEmailViewController: UIViewController {
-    
-    @IBOutlet private var submitPasteboardOnSimulatorButton: UIButton!
     @IBOutlet private var gifView: LoopingVideoView!
+    
+    weak var delegate: CheckEmailDelegate!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.configureSubmitPasteboardButton()
         
-        self.gifView.videoURL = GifVideo.mail.url
-        self.gifView.play()
-    }
-    
-    private func configureSubmitPasteboardButton() {
-        #if targetEnvironment(simulator)
-            self.submitPasteboardOnSimulatorButton.isHidden = false
-        #else
-            self.submitPasteboardOnSimulatorButton.isHidden = true
-        #endif
+        gifView.videoURL = GifVideo.mail.url
+        gifView.play()
     }
     
     @IBAction private func needHelpTapped() {
-        self.showNeedHelpActionSheet()
+        showNeedHelpActionSheet()
     }
     
     @IBAction private func resendTapped() {
-        guard let email = UserDefaultsWrapper.pendingEmail else {
-            ApplicationErrors.assertAndLog("No pending email?!")
-            return
-        }
-        
-        let spinnerView = self.showSpinner(onView: self.view)
-        EmailLinkManager.linkEmail(email)
-            .ensure { [weak self] in
-                self?.removeSpinner(spinnerView)
-            }
-            .done { [weak self] in
-                self?.showAlert(title: "Resent!", msg: "We've resent your email to \(email). If you're still having issues, please contact support.")
-            }
-            .catch { [weak self] error in
-                ApplicationErrors.log(error)
-                self?.showGenericError(error: error)
-            }
-    }
-    
-    @IBAction private func submitPasteboardTapped() {
-        #if targetEnvironment(simulator)
-            guard let pasteboardString = UIPasteboard.general.string else {
-                self.showAlert(title: "Pasteboard was empty!", msg: "Remember to copy the link to the pasteboard first")
-                return
-            }
-            
-            guard let url = URL(string: pasteboardString) else {
-                self.showAlert(title: "Can't Create URL", msg: "Couldn't create a URL from pasteboard contents:\n\n\(pasteboardString)")
-                return
-            }
-            
-            guard EmailLinkManager.isSignInLink(url) else {
-                self.showAlert(title: "Not a sign in link!", msg: "The URL passed in is not a sign-in link!\n\n\(url.absoluteString)")
-                return
-            }
-            
-            let spinner = self.showSpinner(onView: self.view)
-            EmailLinkManager.signInWithLink(url)
-                .ensure { [weak self] in
-                    self?.removeSpinner(spinner)
-                }
-                .catch { [weak self] error in
-                    ApplicationErrors.log(error)
-                    self?.showGenericError(error: error)
-                }
-        #else
-            fatalError("Submit pasteboard was somehow used when not on the simulator!")
-        #endif
+       delegate.resendLoginEmail()
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/Email/EmailEntryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Email/EmailEntryViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol EmailEntryDelegate: class {
-    func emailLinkSent(email: String)
+    func sendEmailLink(email: String)
 }
 
 class EmailEntryViewController: UIViewController {
@@ -34,18 +34,7 @@ class EmailEntryViewController: UIViewController {
             return
         }
         
-        let spinnerView = self.showSpinner(onView: self.view)
-        EmailLinkManager.linkEmail(email)
-            .ensure { [weak self] in
-                self?.removeSpinner(spinnerView)
-            }
-            .done { [weak self] in
-                self?.delegate?.emailLinkSent(email: email)
-            }
-            .catch { [weak self] error in
-                ApplicationErrors.log(error)
-                self?.showGenericError(error: error)
-            }
+        delegate?.sendEmailLink(email: email)
     }
     
     private func configureForValidationState() {

--- a/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
@@ -21,19 +21,18 @@ class BecomeAMemberViewController: ApplePayViewController {
     var membership: Product?
     
     lazy var linkableCopy: LinkableText = {
-        return LinkableText(fullText: """
-To buy data you need to become an OYA member.
-
-As an OYA member you keep your data forever.
-
-$1 = 1 year of membership.
-
-Read about our current prices
-""",
-                            linkedBits: [
-                                "As an OYA member",
-                                "Read about our current prices",
-                            ])!
+        return LinkableText(
+            fullText: NSLocalizedString("To buy data you need to become an OYA member.\n\nAs an OYA member you keep your data forever.\n\n$1 = 1 year of membership.\n\nRead about our current prices", comment: "Explanation for why a user needs to become a member"),
+            linkedBits: [
+                Link(
+                    NSLocalizedString("As an OYA member", comment: "Explanation for why a user needs to become a member: linkable part: oya member"),
+                    url: ExternalLink.aboutMembership.url
+                ),
+                Link(
+                    NSLocalizedString("Read about our current prices", comment: "Explanation for why a user needs to become a member: linkable part: current prices"),
+                    url: ExternalLink.currentPricing.url
+                ),
+            ])!
     }()
 
     override func viewDidLoad() {
@@ -174,25 +173,7 @@ extension BecomeAMemberViewController: StoryboardLoadable {
 
 extension BecomeAMemberViewController: LabelTapDelegate {
     
-    func tappedAttributedLabel(_ label: UILabel, at characterIndex: Int) {
-        guard let tappedLink = self.linkableCopy.linkedText(at: characterIndex) else {
-            // No link was tapped
-            return
-        }
-        
-        guard let bits = self.linkableCopy.linkedBits, bits.count == 2, bits.contains(tappedLink) else {
-                ApplicationErrors.assertAndLog("Unexpected link copy \(tappedLink)")
-                return
-        }
-        
-        // TODO: Update these to switch on localized strings
-        switch tappedLink {
-        case "As an OYA member":
-            UIApplication.shared.open(ExternalLink.aboutMembership.url)
-        case "Read about our current prices":
-            UIApplication.shared.open(ExternalLink.currentPricing.url)
-        default:
-            fatalError("This should have been caught in the guard stement above!")
-        }
+    func tappedLink(_ link: Link) {
+        UIApplication.shared.open(link.url)
     }
 }

--- a/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
@@ -27,19 +27,21 @@ class LoginViewController: UIViewController {
     
     private lazy var dataSource: PageControllerDataSource = {
         let pages = OnboardingPage.allCases.map { $0.viewController }
-        return PageControllerDataSource(pageController: self.pageController,
-                                        viewControllers: pages,
-                                        pageIndicatorTintColor: OstelcoColor.paleGrey.toUIColor,
-                                        currentPageIndicatorTintColor: OstelcoColor.oyaBlue.toUIColor,
-                                        delegate: self)
+        return PageControllerDataSource(
+            pageController: pageController,
+            viewControllers: pages,
+            pageIndicatorTintColor: OstelcoColor.paleGrey.toUIColor,
+            currentPageIndicatorTintColor: OstelcoColor.oyaBlue.toUIColor,
+            delegate: self
+        )
     }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let index = self.dataSource.currentIndex
-        self.configureButtonTitle(for: index)
-        self.logoImageView.tintColor = OstelcoColor.oyaBlue.toUIColor
+        let index = dataSource.currentIndex
+        configureButtonTitle(for: index)
+        logoImageView.tintColor = OstelcoColor.oyaBlue.toUIColor
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -51,22 +53,22 @@ class LoginViewController: UIViewController {
     private func configureButtonTitle(for index: Int) {
         if index == (OnboardingPage.allCases.count - 1) {
             // This is the last page.
-            self.primaryButton.setTitle("Sign In", for: .normal)
+            primaryButton.setTitle(NSLocalizedString("Sign In", comment: "Title for sign in button."), for: .normal)
         } else {
-            self.primaryButton.setTitle("Next", for: .normal)
+            primaryButton.setTitle(NSLocalizedString("Next", comment: "Action button in Carousel"), for: .normal)
         }
     }
     
     @IBAction private func primaryButtonTapped(_ sender: UIButton) {
         Analytics.logEvent("button_tapped", parameters: [
             "newValue": sender.title(for: .normal)!
-            ])
+        ])
         
-        let index = self.dataSource.currentIndex
+        let index = dataSource.currentIndex
         if index == (OnboardingPage.allCases.count - 1) {
-            self.signInTapped()
+            signInTapped()
         } else {
-            self.dataSource.goToNextPage()
+            dataSource.goToNextPage()
         }
     }
     
@@ -78,7 +80,7 @@ class LoginViewController: UIViewController {
 extension LoginViewController: PageControllerDataSourceDelegate {
  
     func pageChanged(to index: Int) {
-        self.configureButtonTitle(for: index)
+        configureButtonTitle(for: index)
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/Login/OnboardingPageViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/OnboardingPageViewController.swift
@@ -42,7 +42,10 @@ enum OnboardingPage: Int, CaseIterable {
         case .fullyDigital:
             return LinkableText(
                 fullText: NSLocalizedString("OYA is fully digital\n\nNo need to wait for a SIM card in the mail\n\nTry it now! With 1GB free data", comment: "Login onboarding step 3 text"),
-                linkedPortion: NSLocalizedString("fully digital", comment: "Login onboarding step 3 linkable part")
+                linkedPortion: Link(
+                    NSLocalizedString("fully digital", comment: "Login onboarding step 3 linkable part"),
+                    url: ExternalLink.fullyDigital.url
+                )
             )
         }
     }
@@ -108,17 +111,7 @@ extension OnboardingPageViewController: StoryboardLoadable {
 
 extension OnboardingPageViewController: LabelTapDelegate {
     
-    func tappedAttributedLabel(_ label: UILabel, at index: Int) {
-        guard onboardingPage.linkableText!.isIndexLinked(index) else {
-            // Did not actually tap a link
-            return
-        }
-        
-        switch onboardingPage! {
-        case .fullyDigital:
-            UIApplication.shared.open(ExternalLink.fullyDigital.url)
-        default:
-            break
-        }
+    func tappedLink(_ link: Link) {
+        UIApplication.shared.open(link.url)
     }
 }

--- a/ostelco-ios-client/ViewControllers/Login/OnboardingPageViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/OnboardingPageViewController.swift
@@ -30,29 +30,20 @@ enum OnboardingPage: Int, CaseIterable {
     var linkableText: LinkableText? {
         switch self {
         case .whatIsOya:
-            return LinkableText(fullText: """
-            OYA is a simple way to get extra mobile data
-            
-            No monthly fees
-            
-            Just extra data when you need it!
-            """, linkedPortion: nil)
+            return LinkableText(
+                fullText: NSLocalizedString("OYA is a simple way to get extra mobile data\n\nNo monthly fees\n\nJust extra data when you need it!", comment: "Login onboarding step 1 text"),
+                linkedPortion: nil
+            )
         case .noNeedToChange:
-            return LinkableText(fullText: """
-            No need to change telco!
-            
-            When you’re running low on data, get some extra from OYA
-            
-            OYA data never expires, so it’s there when you need it!
-            """, linkedPortion: nil)
+            return LinkableText(
+                fullText: NSLocalizedString("No need to change telco!\n\nWhen you’re running low on data, get some extra from OYA\n\nOYA data never expires, so it’s there when you need it!", comment: "Login onboarding step 2 text"),
+                linkedPortion: nil
+            )
         case .fullyDigital:
-            return LinkableText(fullText: """
-            OYA is fully digital
-            
-            No need to wait for a SIM card in the mail
-            
-            Try it now! With 1GB free data
-            """, linkedPortion: "fully digital")
+            return LinkableText(
+                fullText: NSLocalizedString("OYA is fully digital\n\nNo need to wait for a SIM card in the mail\n\nTry it now! With 1GB free data", comment: "Login onboarding step 3 text"),
+                linkedPortion: NSLocalizedString("fully digital", comment: "Login onboarding step 3 linkable part")
+            )
         }
     }
     
@@ -74,7 +65,7 @@ class OnboardingPageViewController: UIViewController {
     ///
     /// - Parameter page: The page you wish to display.
     static func fromStoryboard(with page: OnboardingPage) -> OnboardingPageViewController {
-        let vc = self.fromStoryboard()
+        let vc = fromStoryboard()
         vc.onboardingPage = page
         
         return vc
@@ -83,24 +74,24 @@ class OnboardingPageViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.gifView.videoURL = self.onboardingPage.gifVideo.url
-        guard let linkableText = self.onboardingPage.linkableText else {
-            ApplicationErrors.assertAndLog("Couldn't instantiate onboarding page linkable text for page \(self.onboardingPage!)")
+        gifView.videoURL = onboardingPage.gifVideo.url
+        guard let linkableText = onboardingPage.linkableText else {
+            ApplicationErrors.assertAndLog("Couldn't instantiate onboarding page linkable text for page \(onboardingPage!)")
             return
         }
         
-        self.copyLabel.tapDelegate = self
-        self.copyLabel.setLinkableText(linkableText)
+        copyLabel.tapDelegate = self
+        copyLabel.setLinkableText(linkableText)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.gifView.play()
+        gifView.play()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        self.gifView.pause()
+        gifView.pause()
     }
 }
 
@@ -118,12 +109,12 @@ extension OnboardingPageViewController: StoryboardLoadable {
 extension OnboardingPageViewController: LabelTapDelegate {
     
     func tappedAttributedLabel(_ label: UILabel, at index: Int) {
-        guard self.onboardingPage.linkableText!.isIndexLinked(index) else {
+        guard onboardingPage.linkableText!.isIndexLinked(index) else {
             // Did not actually tap a link
             return
         }
         
-        switch self.onboardingPage! {
+        switch onboardingPage! {
         case .fullyDigital:
             UIApplication.shared.open(ExternalLink.fullyDigital.url)
         default:

--- a/ostelco-ios-client/ViewControllers/OhNoViewController.swift
+++ b/ostelco-ios-client/ViewControllers/OhNoViewController.swift
@@ -166,12 +166,13 @@ extension OhNoIssueType {
     
     var linkableText: LinkableText? {
         if case .noInternet = self {
-            return LinkableText(fullText: """
-Try again in a while or contact support
-
-support@oya.world
-""",
-                                linkedBits: ["support@oya.world"])
+            return LinkableText(
+                fullText: NSLocalizedString("Try again in a while or contact support\n\nsupport@oya.world", comment: "Error message when user has no connection"),
+                linkedPortion: Link(
+                    NSLocalizedString("support@oya.world", comment: "Error message when user has no connection: linkable part"),
+                    url: URL(string: "mailto:support@oya.world")!
+                )
+            )
         }
         return nil
     }

--- a/ostelco-ios-client/ViewControllers/SignUp/EnableNotificationsViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/EnableNotificationsViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import UserNotifications
 
 protocol EnableNotificationsDelegate: class {
-    func pushAgreedOrDenied()
+    func requestPermission()
 }
 
 class EnableNotificationsViewController: UIViewController {
@@ -18,28 +18,15 @@ class EnableNotificationsViewController: UIViewController {
     weak var delegate: EnableNotificationsDelegate?
     
     @IBAction private func continueTapped() {
-        self.requestNotificationAuthorization()
+        requestNotificationAuthorization()
     }
     
     @IBAction private func needHelpTapped() {
-        self.showNeedHelpActionSheet()
+        showNeedHelpActionSheet()
     }
 
     private func requestNotificationAuthorization() {
-        PushNotificationController.shared.checkSettingsThenRegisterForNotifications(authorizeIfNotDetermined: true)
-            .done { [weak self] _ in
-                self?.delegate?.pushAgreedOrDenied()
-            }
-            .catch { [weak self] error in
-                switch error {
-                case PushNotificationController.Error.notAuthorized:
-                    // The user declined push notifications. Oh well. Let's move on.
-                    self?.delegate?.pushAgreedOrDenied()
-                default:
-                    ApplicationErrors.log(error)
-                    self?.showGenericError(error: error)
-                }
-            }
+        delegate?.requestPermission()
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import ostelco_core
 
 protocol GetStartedDelegate: class {
-    func nameEnteredSuccessfully()
+    func enteredNickname(_ nickname: String)
 }
 
 class GetStartedViewController: UIViewController {
@@ -34,33 +34,13 @@ class GetStartedViewController: UIViewController {
     }
     
     @IBAction private func continueTapped(_ sender: Any) {
-        guard let email = UserManager.shared.currentUserEmail else {
-            self.showAlert(title: "Error", msg: "Email is empty or missing in Firebase")
-            return
-        }
-        
-        guard let nickname = self.nameTextField.text else {
+        guard let nickname = nameTextField.text else {
             ApplicationErrors.assertAndLog("No nickname but passed validation?!")
             return
         }
-        
-        self.spinnerView = self.showSpinner(onView: self.view)
-        let user = UserSetup(nickname: nickname, email: email)
 
-        APIManager.shared.primeAPI.createCustomer(with: user)
-            .ensure { [weak self] in
-                self?.removeSpinner(self?.spinnerView)
-                self?.spinnerView = nil
-            }
-            .done { [weak self] customer in
-                OstelcoAnalytics.logEvent(.EnteredNickname)
-                UserManager.shared.customer = PrimeGQL.ContextQuery.Data.Context.Customer(legacyModel: customer)
-                self?.delegate?.nameEnteredSuccessfully()
-            }
-            .catch { [weak self] error in
-                ApplicationErrors.log(error)
-                self?.showGenericError(error: error)
-            }
+        spinnerView = showSpinner(onView: view)
+        delegate?.enteredNickname(nickname)
     }
 }
 

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -39,7 +39,7 @@ class GetStartedViewController: UIViewController {
             return
         }
 
-        spinnerView = showSpinner(onView: view)
+        spinnerView = showSpinner()
         delegate?.enteredNickname(nickname)
     }
 }

--- a/ostelco-ios-client/ViewControllers/SignUp/TheLegalStuffViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/TheLegalStuffViewController.swift
@@ -17,25 +17,29 @@ enum LegalLink: CaseIterable {
     var linkableText: LinkableText {
         switch self {
         case .termsAndConditions:
-            return LinkableText(fullText: "I hereby agree to the Terms & Conditions",
-                                linkedPortion: "Terms & Conditions")!
+            return LinkableText(
+                fullText: NSLocalizedString("I hereby agree to the Terms & Conditions", comment: "Label for agreeing to the terms"),
+                linkedPortion: Link(
+                    NSLocalizedString("Terms & Conditions", comment: "Label for agreeing to the terms: linkable part"),
+                    url: ExternalLink.termsAndConditions.url
+                )
+            )!
         case .privacyPolicy:
-            return LinkableText(fullText: "I agree to the Privacy Policy",
-                                linkedPortion: "Privacy Policy")!
+            return LinkableText(
+                fullText: NSLocalizedString("I agree to the Privacy Policy", comment: "Label for agreeing to the privacy policy"),
+                linkedPortion: Link(
+                    NSLocalizedString("Privacy Policy", comment: "Label for agreeing to the privacy policy: linkable part"),
+                    url: ExternalLink.privacyPolicy.url
+                )
+            )!
         case .minimumAge:
-            return LinkableText(fullText: "I am at least 18 years of age",
-                                linkedPortion: "18 years")!
-        }
-    }
-    
-    var linkToOpen: ExternalLink {
-        switch self {
-        case .termsAndConditions:
-            return .termsAndConditions
-        case .privacyPolicy:
-            return .privacyPolicy
-        case .minimumAge:
-            return .minimumAgeDetails
+            return LinkableText(
+                fullText: NSLocalizedString("I am at least 18 years of age", comment: "Label for being at least 18"),
+                linkedPortion: Link(
+                    NSLocalizedString("18 years", comment: "Label for being at least 18: linkable part"),
+                    url: ExternalLink.minimumAgeDetails.url
+                )
+            )!
         }
     }
 }
@@ -60,47 +64,47 @@ class TheLegalStuffViewController: UIViewController {
  
     private var allChecks: [CheckButton] {
         return [
-            self.termsAndConditionsCheck,
-            self.privacyPolicyCheck,
-            self.ageCheck
+            termsAndConditionsCheck,
+            privacyPolicyCheck,
+            ageCheck
         ]
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.termsAndConditionsLabel.tapDelegate = self
-        self.termsAndConditionsLabel.setLinkableText(LegalLink.termsAndConditions.linkableText)
-        self.privacyPolicyLabel.tapDelegate = self
-        self.privacyPolicyLabel.setLinkableText(LegalLink.privacyPolicy.linkableText)
-        self.ageLabel.tapDelegate = self
-        self.ageLabel.setLinkableText(LegalLink.minimumAge.linkableText)
+        termsAndConditionsLabel.tapDelegate = self
+        termsAndConditionsLabel.setLinkableText(LegalLink.termsAndConditions.linkableText)
+        privacyPolicyLabel.tapDelegate = self
+        privacyPolicyLabel.setLinkableText(LegalLink.privacyPolicy.linkableText)
+        ageLabel.tapDelegate = self
+        ageLabel.setLinkableText(LegalLink.minimumAge.linkableText)
         
-        self.updateContinueButtonState()
+        updateContinueButtonState()
     }
 
     @IBAction private func needHelpTapped() {
-        self.showNeedHelpActionSheet()
+        showNeedHelpActionSheet()
     }
     
     @IBAction private func checkButtonTapped(_ check: CheckButton) {
         check.isChecked.toggle()
-        self.updateContinueButtonState()
+        updateContinueButtonState()
     }
     
     private func updateContinueButtonState() {
-        if self.allChecks.contains(where: { !$0.isChecked }) {
+        if allChecks.contains(where: { !$0.isChecked }) {
             // At least one item is not checked.
-            self.continueButton.isEnabled = false
+            continueButton.isEnabled = false
         } else {
             // Everything is checked!
-            self.continueButton.isEnabled = true
+            continueButton.isEnabled = true
         }
     }
     
     @IBAction private func continueTapped() {
         OstelcoAnalytics.logEvent(.LegalStuffAgreed)
-        self.delegate?.legaleseAgreed()
+        delegate?.legaleseAgreed()
     }
 }
 
@@ -117,25 +121,7 @@ extension TheLegalStuffViewController: StoryboardLoadable {
 
 extension TheLegalStuffViewController: LabelTapDelegate {
     
-    func tappedAttributedLabel(_ label: UILabel, at characterIndex: Int) {
-        
-        let legalLink: LegalLink
-        switch label {
-        case self.termsAndConditionsLabel:
-            legalLink = .termsAndConditions
-        case self.privacyPolicyLabel:
-            legalLink = .privacyPolicy
-        case self.ageLabel:
-            legalLink = .minimumAge
-        default:
-            fatalError("Tapped an unhandled label!")
-        }
-        
-        guard legalLink.linkableText.isIndexLinked(characterIndex) else {
-            // Did not actually tap the link
-            return
-        }
-        
-        UIApplication.shared.open(legalLink.linkToOpen.url)
+    func tappedLink(_ link: Link) {
+        UIApplication.shared.open(link.url)
     }
 }


### PR DESCRIPTION
The dumber controllers are, the easier they are to be used in different places. When to talk to the server is also more of a question of business policy and business policy shouldn't be in the controllers if we can help it. This allowed some simplification too as some of the logic as a result of network requests resulted in navigation, which is the coordinator's job.

Also found some places where I missed localization and so I fixed those.