### PR TITLE
Warnings are now errors.

### DIFF
--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -2474,6 +2474,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 			};
 			name = Debug;
 		};
@@ -2527,6 +2528,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Forgot to enable this before. We now have 0 warnings and we want to keep
it this way, so warnings are now errors.