### PR TITLE
Fix how the pending email is handled.

### DIFF
--- a/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
@@ -10,12 +10,19 @@ import XCTest
 @testable import ostelco_core
 
 class EdgeCasesInStageDeciderTests: XCTestCase {
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        UserDefaultsWrapper.pendingEmail = nil
+    }
 
     // Existing Singapore user who logs in to a new device but has completed the onboarding on a different device.
     
     func testUserSignsUpOnNewDeviceAfterCompletingOnboardingOnOtherDevice() {
         let decider = StageDecider()
-        let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@gmail.com", hasFirebaseToken: true)
+        UserDefaultsWrapper.pendingEmail = "xxxx@gmail.com"
+        let localContext = LocalContext(hasSeenLoginCarousel: true, hasFirebaseToken: true)
         
         let context = Context(
             customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),
@@ -36,7 +43,8 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
     
     func testUserSignsUpOnNewDeviceAndGivesNotificationPermissionsAfterCompletingOnboardingOnOtherDevice() {
         let decider = StageDecider()
-        let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@gmail.com", hasFirebaseToken: true, hasSeenNotificationPermissions: true)
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext(hasSeenLoginCarousel: true, hasFirebaseToken: true, hasSeenNotificationPermissions: true)
         
         let context = Context(
             customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
@@ -12,6 +12,11 @@ import XCTest
 class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     // Testing the flow of a singapore user who uses singpass and has no trouble:
     
+    override func tearDown() {
+        super.tearDown()
+        UserDefaultsWrapper.pendingEmail = nil
+    }
+    
     func testColdStartForAUser() {
         let decider = StageDecider()
         let context: Context? = nil
@@ -29,7 +34,8 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     func testUserHasEnteredEmail() {
         let decider = StageDecider()
         let context: Context? = nil
-        let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@xxxx.com")
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext(hasSeenLoginCarousel: true)
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .checkYourEmail(email: "xxxx@xxxx.com"))
     }
@@ -37,7 +43,8 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     func testUserHasEnteredEmailThenColdStart() {
         let decider = StageDecider()
         let context: Context? = nil
-        let localContext = LocalContext(enteredEmailAddress: "xxxx@xxxx.com")
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext()
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .checkYourEmail(email: "xxxx@xxxx.com"))
     }
@@ -45,7 +52,8 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     func testUserHasAFirebaseUserButNoContextYet() {
         let decider = StageDecider()
         let context: Context? = nil
-        let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true)
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext(hasSeenLoginCarousel: true, hasFirebaseToken: true)
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .legalStuff)
     }
@@ -53,7 +61,8 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     func testUserHasAgreedToLegalStuff() {
         let decider = StageDecider()
         let context: Context? = nil
-        let localContext = LocalContext(hasSeenLoginCarousel: true, enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true, hasAgreedToTerms: true)
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext(hasSeenLoginCarousel: true, hasFirebaseToken: true, hasAgreedToTerms: true)
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .nicknameEntry)
     }
@@ -61,7 +70,8 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     func testUserHasAgreedToLegalStuffThenColdStart() {
         let decider = StageDecider()
         let context: Context? = nil
-        let localContext = LocalContext(enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true)
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext(hasFirebaseToken: true)
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .legalStuff)
     }
@@ -69,7 +79,8 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     func testUserHasFirebasedThenColdStartedThenAgreedToLegalStuff() {
         let decider = StageDecider()
         let context: Context? = nil
-        let localContext = LocalContext(enteredEmailAddress: "xxxx@xxxx.com", hasFirebaseToken: true, hasAgreedToTerms: true)
+        UserDefaultsWrapper.pendingEmail = "xxxx@xxxx.com"
+        let localContext = LocalContext(hasFirebaseToken: true, hasAgreedToTerms: true)
         
         XCTAssertEqual(decider.compute(context: context, localContext: localContext), .nicknameEntry)
     }

--- a/ostelco-core/ModelControllers/UserDefaultsWrapper.swift
+++ b/ostelco-core/ModelControllers/UserDefaultsWrapper.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UserDefaultsWrapper {
+public struct UserDefaultsWrapper {
     
     // Underlying keys for user defaults
     private enum Key: String, CaseIterable {
@@ -33,14 +33,14 @@ struct UserDefaultsWrapper {
     }
     
     /// Remove every default stored through this wrapper
-    static func clearAll() {
+    public static func clearAll() {
         for key in Key.allCases {
             self.removeValue(for: key)
         }
     }
     
     /// What is the email we are waiting to confirm?
-    static var pendingEmail: String? {
+    public static var pendingEmail: String? {
         get {
             return self.value(for: .pendingEmail)
         }
@@ -53,7 +53,7 @@ struct UserDefaultsWrapper {
         }
     }
     
-    static var pendingSingPass: [URLQueryItem]? {
+    public static var pendingSingPass: [URLQueryItem]? {
         get {
             guard let dict: [String: String?] = self.value(for: .pendingSingPassQueryItems) else {
                 return nil

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -10,7 +10,14 @@ import Foundation
 
 public struct LocalContext {
     public var hasSeenLoginCarousel: Bool
-    public var enteredEmailAddress: String?
+    public var enteredEmailAddress: String? {
+        get {
+            return UserDefaultsWrapper.pendingEmail
+        }
+        set(value) {
+            UserDefaultsWrapper.pendingEmail = value
+        }
+    }
     public var hasFirebaseToken: Bool
     public var hasAgreedToTerms: Bool
     public var hasSeenNotificationPermissions: Bool
@@ -28,10 +35,9 @@ public struct LocalContext {
     public var hasCompletedAddress: Bool
     public var serverIsUnreachable: Bool
     
-    public init(selectedRegion: Region? = nil, hasSeenLoginCarousel: Bool = false, enteredEmailAddress: String? = nil, hasFirebaseToken: Bool = false, hasAgreedToTerms: Bool = false, hasSeenNotificationPermissions: Bool = false, regionVerified: Bool = false, hasSeenVerifyIdentifyOnboarding: Bool = false, selectedVerificationOption: IdentityVerificationOption? = nil, myInfoCode: String? = nil, hasSeenESimOnboarding: Bool = false, hasSeenESIMInstructions: Bool = false, hasSeenAwesome: Bool = false, hasCompletedJumio: Bool = false, hasCompletedAddress: Bool = false, serverIsUnreachable: Bool = false, locationProblem: LocationProblem? = nil, hasSeenRegionOnboarding: Bool = false) {
+    public init(selectedRegion: Region? = nil, hasSeenLoginCarousel: Bool = false, hasFirebaseToken: Bool = false, hasAgreedToTerms: Bool = false, hasSeenNotificationPermissions: Bool = false, regionVerified: Bool = false, hasSeenVerifyIdentifyOnboarding: Bool = false, selectedVerificationOption: IdentityVerificationOption? = nil, myInfoCode: String? = nil, hasSeenESimOnboarding: Bool = false, hasSeenESIMInstructions: Bool = false, hasSeenAwesome: Bool = false, hasCompletedJumio: Bool = false, hasCompletedAddress: Bool = false, serverIsUnreachable: Bool = false, locationProblem: LocationProblem? = nil, hasSeenRegionOnboarding: Bool = false) {
         self.selectedRegion = selectedRegion
         self.hasSeenLoginCarousel = hasSeenLoginCarousel
-        self.enteredEmailAddress = enteredEmailAddress
         self.hasFirebaseToken = hasFirebaseToken
         self.hasAgreedToTerms = hasAgreedToTerms
         self.hasSeenNotificationPermissions = hasSeenNotificationPermissions

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		9B2576E02296C54600676D97 /* BackgroundRoundedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2576DE2296C53F00676D97 /* BackgroundRoundedImageView.swift */; };
 		9B305F98229693EA00B89FCB /* GifVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B305F97229693EA00B89FCB /* GifVideo.swift */; };
 		9B305F99229694F700B89FCB /* GifVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B305F97229693EA00B89FCB /* GifVideo.swift */; };
+		9B3D906B22F18341007A362D /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B3FA68F22896510001E4D60 /* UIAlertAction+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3FA68E22896510001E4D60 /* UIAlertAction+Convenience.swift */; };
 		9B3FA69022896640001E4D60 /* UIAlertAction+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3FA68E22896510001E4D60 /* UIAlertAction+Convenience.swift */; };
 		9B3FA6922289B485001E4D60 /* BasicNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3FA6912289B485001E4D60 /* BasicNetworkTests.swift */; };
@@ -235,8 +236,6 @@
 		9B8E926522A9368F00A1E35E /* MockPlacemarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8E926422A9368F00A1E35E /* MockPlacemarks.swift */; };
 		9B8E926722A93F5E00A1E35E /* CountryDeterminablePlacemark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8E926622A93F5E00A1E35E /* CountryDeterminablePlacemark.swift */; };
 		9B920F5F225B8AF0001EF9CD /* VerifyIdentityOnBoardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04834D47222EE97A00A01500 /* VerifyIdentityOnBoardingViewController.swift */; };
-		9B920F62225B8C70001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
-		9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */; };
 		9B9B3243225E3B7B00227EA3 /* PrimeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9B3242225E3B7B00227EA3 /* PrimeAPI.swift */; };
 		9B9B3248225E3D3900227EA3 /* PurchaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044881A7217BA32B00F59758 /* PurchaseModel.swift */; };
 		9B9B3249225E3D3900227EA3 /* BundleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0448819D217B4E4E00F59758 /* BundleModel.swift */; };
@@ -1008,6 +1007,7 @@
 		9B851ADF225E331D0076ABF3 /* ModelControllers */ = {
 			isa = PBXGroup;
 			children = (
+				9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */,
 				9BBF7068226613C400E4B9B4 /* GenericDataSource.swift */,
 				9BBF704C2265DD8A00E4B9B4 /* GenericTableViewDataSource.swift */,
 				9BC465352270AD49001951BF /* LocationController.swift */,
@@ -1039,7 +1039,6 @@
 				9B4DAD9A2281ADEA003810BE /* EmailValidator.swift */,
 				9BBEEE05228D6E6A00EED7F5 /* PushNotificationController.swift */,
 				04834D7D2237D53700A01500 /* UserManager.swift */,
-				9B920F61225B8C70001EF9CD /* UserDefaultsWrapper.swift */,
 				0494336D22BB9E2400E5BB24 /* FreshchatManager.swift */,
 			);
 			path = ModelControllers;
@@ -2013,7 +2012,6 @@
 				042CA83422C21F10000F0622 /* UIViewController+EmbedFullViewChild.swift in Sources */,
 				041216AC2228195600455278 /* ChooseCountryViewController.swift in Sources */,
 				040A6A3222955E05002EE6BA /* ESIMInstructionsViewController.swift in Sources */,
-				9B920F62225B8C70001EF9CD /* UserDefaultsWrapper.swift in Sources */,
 				9B1745742276F64B00CF321B /* TextEditCell.swift in Sources */,
 				9BE2D45C225B634100B51999 /* TestAppDelegate.swift in Sources */,
 				9BBF70662265FA3100E4B9B4 /* UITableView+Footer.swift in Sources */,
@@ -2085,6 +2083,7 @@
 				9B9B3243225E3B7B00227EA3 /* PrimeAPI.swift in Sources */,
 				9B6A92892284209A007F5EC9 /* PushToken.swift in Sources */,
 				9B821594227ADA1000DC6B64 /* Request.swift in Sources */,
+				9B3D906B22F18341007A362D /* UserDefaultsWrapper.swift in Sources */,
 				9B560A9C2273289D004473E1 /* PageControllerDataSource.swift in Sources */,
 				9BBF7069226613C400E4B9B4 /* GenericDataSource.swift in Sources */,
 				9B8E926722A93F5E00A1E35E /* CountryDeterminablePlacemark.swift in Sources */,
@@ -2222,7 +2221,6 @@
 				9BBF70622265F43800E4B9B4 /* CountryCell.swift in Sources */,
 				042928F3223D0BE700806438 /* NRICVerifyViewController.swift in Sources */,
 				9B1E07472282F5E500EBFCDC /* EmailEntryViewController.swift in Sources */,
-				9B920F63225B8EAD001EF9CD /* UserDefaultsWrapper.swift in Sources */,
 				9B1745752276F64B00CF321B /* TextEditCell.swift in Sources */,
 				9BE2D460225B651A00B51999 /* TestAppDelegate.swift in Sources */,
 				9B6E3A26227093DA0063EBAA /* LocationProblemViewController.swift in Sources */,

--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -99,17 +99,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return false
     }
     
-    func application(_ application: UIApplication,
-                     continue userActivity: NSUserActivity,
-                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        guard let incomingURL = userActivity.webpageURL else {
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        guard let incomingURL = userActivity.webpageURL, let email = UserDefaultsWrapper.pendingEmail else {
             return false
         }
         
         debugPrint("Incoming URL is \(incomingURL)")
         
         if EmailLinkManager.isSignInLink(incomingURL) {
-            EmailLinkManager.signInWithLink(incomingURL)
+            EmailLinkManager.signInWithLink(incomingURL, email: email)
                 .catch { error in
                     ApplicationErrors.log(error)
                     debugPrint("ERROR SIGNING IN: \(error)")

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -36,7 +36,6 @@ class OnboardingCoordinator {
         }
         
         Auth.auth().addStateDidChangeListener { (_, user) in
-            self.localContext.enteredEmailAddress = UserDefaultsWrapper.pendingEmail
             self.localContext.hasFirebaseToken = user != nil
             self.advance()
         }
@@ -213,7 +212,6 @@ extension OnboardingCoordinator: EmailEntryDelegate {
         }
         .done { [weak self] (_) in
             self?.localContext.enteredEmailAddress = email
-            UserDefaultsWrapper.pendingEmail = email
             self?.advance()
         }
         .catch { [weak self] error in
@@ -225,7 +223,7 @@ extension OnboardingCoordinator: EmailEntryDelegate {
 
 extension OnboardingCoordinator: CheckEmailDelegate {
     func resendLoginEmail() {
-        guard let email = UserDefaultsWrapper.pendingEmail else {
+        guard let email = localContext.enteredEmailAddress else {
             ApplicationErrors.assertAndLog("No pending email?!")
             return
         }

--- a/ostelco-ios-client/Network/EmailLinkManager.swift
+++ b/ostelco-ios-client/Network/EmailLinkManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 import FirebaseAuth
 import PromiseKit
+import ostelco_core
 
 struct EmailLinkManager {
     
@@ -40,7 +41,6 @@ struct EmailLinkManager {
         settings.url = url
         settings.handleCodeInApp = true
         settings.setIOSBundleID(Bundle.main.bundleIdentifier!)
-        UserDefaultsWrapper.pendingEmail = emailAddress
         
         return Promise { seal in
             Auth.auth().sendSignInLink(
@@ -59,11 +59,7 @@ struct EmailLinkManager {
         return Auth.auth().isSignIn(withEmailLink: link.absoluteString)
     }
     
-    static func signInWithLink(_ link: URL) -> Promise<Void> {
-        guard let email = UserDefaultsWrapper.pendingEmail else {
-            return Promise(error: Error.noPendingEmailStored)
-        }
-        
+    static func signInWithLink(_ link: URL, email: String) -> Promise<Void> {
         return Promise { seal in
             // We are going to login with this email, clear it now, so if it fails you start over
             UserDefaultsWrapper.pendingEmail = nil


### PR DESCRIPTION
This way should result in less confusion about which email to use. The
coordinator always uses the email from the local context.