### PR TITLE
Fix issues with using the one-time code too much.

### DIFF
--- a/dev-ostelco-ios-clientTests/LocalContextTests.swift
+++ b/dev-ostelco-ios-clientTests/LocalContextTests.swift
@@ -1,0 +1,36 @@
+//
+//  LocalContextTests.swift
+//  dev-ostelco-ios-clientTests
+//
+//  Created by Samuel Goodwin on 8/7/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import XCTest
+@testable import ostelco_core
+
+class LocalContextTests: XCTestCase {
+    
+    func testOneTimeAccessToMyInfoCode() {
+        
+        let context = LocalContext(myInfoCode: "xxxx")
+        
+        XCTAssertNotNil(context.myInfoCode)
+        XCTAssertNil(context.myInfoCode)
+    }
+    
+    func testOneTimeAccessToMyInfoCodeInsideAFunction() {
+        
+        let context = LocalContext(myInfoCode: "xxxx")
+        
+        func process(_ a: LocalContext) -> Bool {
+            if a.myInfoCode != nil {
+                return true
+            }
+            return false
+        }
+        
+        XCTAssert(process(context))
+        XCTAssertNil(context.myInfoCode)
+    }
+}

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct LocalContext {
+public class LocalContext {
     public var hasSeenLoginCarousel: Bool
     public var enteredEmailAddress: String? {
         get {
@@ -27,7 +27,18 @@ public struct LocalContext {
     public var locationProblem: LocationProblem?
     public var hasSeenVerifyIdentifyOnboarding: Bool
     public var selectedVerificationOption: IdentityVerificationOption?
-    public var myInfoCode: String? // Needs to be persisted
+    
+    private var _myInfoCode: String?
+    public var myInfoCode: String? {
+        get {
+            let code = _myInfoCode
+            _myInfoCode = nil
+            return code
+        }
+        set(value) {
+            _myInfoCode = value
+        }
+    }
     public var hasSeenESimOnboarding: Bool
     public var hasSeenESIMInstructions: Bool
     public var hasSeenAwesome: Bool
@@ -44,7 +55,6 @@ public struct LocalContext {
         self.regionVerified = regionVerified
         self.hasSeenVerifyIdentifyOnboarding = hasSeenVerifyIdentifyOnboarding
         self.selectedVerificationOption = selectedVerificationOption
-        self.myInfoCode = myInfoCode
         self.hasSeenESimOnboarding = hasSeenESimOnboarding
         self.hasSeenESIMInstructions = hasSeenESIMInstructions
         self.hasSeenAwesome = hasSeenAwesome
@@ -53,6 +63,7 @@ public struct LocalContext {
         self.serverIsUnreachable = serverIsUnreachable
         self.locationProblem = locationProblem
         self.hasSeenRegionOnboarding = hasSeenRegionOnboarding
+        self.myInfoCode = myInfoCode
     }
 }
 

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -389,6 +389,7 @@ extension OnboardingCoordinator: MyInfoSummaryDelegate {
         .catch { error in
             ApplicationErrors.log(error)
             controller.showGenericError(error: error) { [weak self] (_) in
+                self?.localContext.selectedVerificationOption = nil
                 self?.advance()
             }
         }
@@ -409,7 +410,6 @@ extension OnboardingCoordinator: MyInfoSummaryDelegate {
             ApplicationErrors.log(error)
             controller.showGenericError(error: error) { [weak self] (_) in
                 self?.localContext.selectedVerificationOption = nil
-                self?.localContext.myInfoCode = nil
                 self?.advance()
             }
         }


### PR DESCRIPTION
Since they myinfo code is only good for one use, this let's that show in
the code. Once the code is accessed, it will be cleared out. This should
help to make sure we don't forget to clean up anywhere and cause
behavioral errors.