### PR TITLE
Add more firebase analytic events.

### DIFF
--- a/ostelco-ios-client/ModelControllers/UserManager.swift
+++ b/ostelco-ios-client/ModelControllers/UserManager.swift
@@ -37,6 +37,8 @@ class UserManager: TokenProvider {
             Crashlytics.sharedInstance().setUserIdentifier(customer.id)
             Crashlytics.sharedInstance().setUserName(customer.nickname)
             Crashlytics.sharedInstance().setUserEmail(customer.contactEmail)
+            
+            OstelcoAnalytics.setUserId(customer.analyticsId)
         }
     }
     

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -27,8 +27,8 @@ class OstelcoAnalytics {
     static func logEvent(_ event: AnalyticsEvent) {
         if event.name.isEmpty {
             var meta = event.metadata
-            meta["name"] = event.name
-            meta["className"] = String(describing: event)
+            meta["name"] = event.name as NSObject
+            meta["className"] = String(describing: event) as NSObject
             ApplicationErrors.log(AnalyticsError.eventNameIsEmpty, withAdditionalUserInfo: meta)
         } else {
             Analytics.logEvent(event.name, parameters: event.metadata)
@@ -41,7 +41,13 @@ enum AnalyticsEvent {
     case EnteredNickname
     case ChosenCountry(country: Country)
     case ChosenIDMethod(idMethod: String)
-    case DownloadingESIM
+    case ESimOnboardingIntro
+    case ESimOnboardingIntroCompleted
+    case ESimOnboardingPending
+    case SignUpCompleted
+    case UnlockMoreData
+    case BecomeMemberClicked
+    case BuyDataClicked
     case PushNotificationsAccepted
     case PushNotificationsDeclined
 
@@ -56,12 +62,12 @@ enum AnalyticsEvent {
         }
     }
     
-    var metadata: [String: String] {
+    var metadata: [String: NSObject] {
         switch self {
         case .ChosenCountry(let country):
-            return ["country": country.countryCode]
+            return ["country": country.countryCode as NSObject]
         case .ChosenIDMethod(let idMethod):
-            return ["id_method": idMethod]
+            return ["id_method": idMethod as NSObject]
         default:
             return [:]
         }

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -34,6 +34,10 @@ class OstelcoAnalytics {
             Analytics.logEvent(event.name, parameters: event.metadata)
         }
     }
+    
+    static func setUserId(_ id: String) {
+        Analytics.setUserID(id)
+    }
 }
 
 enum AnalyticsEvent {

--- a/ostelco-ios-client/ViewControllers/Country/ChooseCountryViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/ChooseCountryViewController.swift
@@ -56,6 +56,7 @@ class ChooseCountryViewController: UIViewController {
         }
         
         showSpinner()
+        OstelcoAnalytics.logEvent(.ChosenCountry(country: country))
         delegate?.selectedCountry(country)
     }
 }

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMInstructionsViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMInstructionsViewController.swift
@@ -58,6 +58,7 @@ class ESIMInstructionsViewController: UIViewController {
     @IBAction private func primaryButtonTapped(_ sender: UIButton) {
         let index = dataSource.currentIndex
         if index == (ESIMPage.allCases.count - 1) {
+            OstelcoAnalytics.logEvent(.ESimOnboardingIntroCompleted)
             self.delegate?.completedInstructions(self)
         } else {
             self.dataSource.goToNextPage()

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMOnBoardingViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMOnBoardingViewController.swift
@@ -32,7 +32,7 @@ class ESIMOnBoardingViewController: UIViewController {
     }
     
     @IBAction private func continueTapped(_ sender: Any) {
-        OstelcoAnalytics.logEvent(.DownloadingESIM)
+        OstelcoAnalytics.logEvent(.ESimOnboardingIntro)
         self.delegate?.completedLanding()
     }
     

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMPendingDownloadViewController.swift
@@ -28,6 +28,7 @@ class ESIMPendingDownloadViewController: UIViewController {
     }
     
     @IBAction private func continueTapped(_ sender: Any) {
+        OstelcoAnalytics.logEvent(.ESimOnboardingPending)
         delegate?.checkAgain()
     }
     

--- a/ostelco-ios-client/ViewControllers/ESim/SignUpCompletedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/SignUpCompletedViewController.swift
@@ -25,6 +25,8 @@ class SignUpCompletedViewController: UIViewController {
         
         gifView.videoURL = GifVideo.rocket.url
         gifView.play()
+        
+        OstelcoAnalytics.logEvent(.SignUpCompleted)
     }
     
     @IBAction private func continueTapped(_ sender: Any) {

--- a/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/BecomeAMemberViewController.swift
@@ -113,6 +113,7 @@ class BecomeAMemberViewController: ApplePayViewController {
     }
 
     @objc func buyButtonTapped() {
+        OstelcoAnalytics.logEvent(.BecomeMemberClicked)
         if let membership = membership {
             #if STRIPE_PAYMENT
                 showStripePaymentActionSheet(membership: membership)

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -165,8 +165,10 @@ class HomeViewController: ApplePayViewController {
     @IBAction private func buyDataTapped(_ sender: Any) {
         if hasSubscription {
             // TODO: Should we show the plans here ?
+            OstelcoAnalytics.logEvent(.BuyDataClicked)
             showProductListActionSheet(products: self.availableProducts)
         } else {
+            OstelcoAnalytics.logEvent(.UnlockMoreData)
             performSegue(withIdentifier: "becomeMember", sender: self)
         }
     }


### PR DESCRIPTION
Added the following events:
- chosen_country
- eSIM_onboarding_intro_completed
- eSIM_onboarding_intro
- eSIM_onboarding_pending
- signup_completed
- become_member_clicked
- buy_data_clicked
- unlock_more_data

Note: Had to convert value of parameters when logging analytics event to NSObject for it to show up in the firebase dashboard.