### PR TITLE
Handle the case where user already started Jumio

### DIFF
--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithScanICStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithScanICStageDeciderTests.swift
@@ -33,7 +33,7 @@ class SingaporeUserHappyFlowWithScanICStageDeciderTests: XCTestCase {
                     region: Region(id: "sg", name: "Singapore"),
                     status: .PENDING,
                     simProfiles: nil,
-                    kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .PENDING)
+                    kycStatusMap: KYCStatusMap(jumio: .none, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .PENDING)
                 )
             ]
         )
@@ -52,7 +52,7 @@ class SingaporeUserHappyFlowWithScanICStageDeciderTests: XCTestCase {
                     region: Region(id: "sg", name: "Singapore"),
                     status: .PENDING,
                     simProfiles: nil,
-                    kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .PENDING)
+                    kycStatusMap: KYCStatusMap(jumio: .none, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .PENDING)
                 )
             ]
         )

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -227,17 +227,23 @@ public struct StageDecider {
         }
         
         if localContext.hasSeenVerifyIdentifyOnboarding {
-            if let kycStatusMap = context.getRegion()?.kycStatusMap {
+            if let kycStatusMap = context.getRegion()?.kycStatusMap {                
                 if kycStatusMap.nricFin == .approved {
                     remove(.nric)
                 }
                 
-                if kycStatusMap.jumio == .approved {
-                    remove(.jumio)
-                }
                 if kycStatusMap.addressAndPhoneNumber == .approved {
                     remove(.address)
                 }
+                
+                if kycStatusMap.jumio == .approved {
+                    remove(.pendingVerification)
+                    remove(.jumio)
+                }
+                if kycStatusMap.jumio == .pending {
+                    remove(.jumio)
+                }
+                
                 if kycStatusMap.jumio == .rejected && localContext.hasCompletedJumio {
                     remove(.pendingVerification)
                     remove(.jumio)


### PR DESCRIPTION
If the user has started Jumio and it is pending, we don't want them to
restart Jumio again, just wait until it's done.