### PR TITLE
Remove NRIC

### DIFF
--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithScanICStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithScanICStageDeciderTests.swift
@@ -19,7 +19,7 @@ class SingaporeUserHappyFlowWithScanICStageDeciderTests: XCTestCase {
         let regions: [PrimeGQL.RegionDetailsFragment] = []
         let context = Context(customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"), regions: regions)
         
-        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .nric)
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .jumio)
     }
 
     func testUserHasCompletedNRIC() {

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -214,7 +214,7 @@ public struct StageDecider {
         case .singpass:
             midStages.append(.singpass)
         case .scanIC:
-            midStages.append(contentsOf: [.nric, .jumio, .address, .pendingVerification])
+            midStages.append(contentsOf: [.jumio, .address, .pendingVerification])
         }
         
         if let code = localContext.myInfoCode {

--- a/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
@@ -128,7 +128,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
             guard let authCodeData = appleIDCredential.authorizationCode else {
                 print("No authorization code received at Sign In, cannot procced.")
                 return
-            }            
+            }
             if let authCode = String(data: authCodeData, encoding: .utf8) {
                 delegate?.signedIn(controller: self, authCode: authCode, contactEmail: contactEmail)
             }


### PR DESCRIPTION
Singapore people no longer need the nric screens. They're not mandatory
in the server and we don't need to waste user time with it.