### PR TITLE
Make sure new jumio replaces old one.

### DIFF
--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -155,9 +155,10 @@ class OnboardingCoordinator {
             navigationController.setViewControllers([nric], animated: true)
         case .jumio:
             if let country = localContext.selectedRegion?.country, let jumio = try? JumioCoordinator(country: country, primeAPI: primeAPI) {
+                self.jumioCoordinator = jumio
+                
                 jumio.delegate = self
                 jumio.startScan(from: navigationController)
-                self.jumioCoordinator = jumio
             }
         case .address:
             let addressController = AddressEditViewController.fromStoryboard()


### PR DESCRIPTION
This lets the old Jumio Coordinator kill it's Netverify instance so that
it does not complain when we try to make the new one.