### PR TITLE
Ask for permissions Before Home.

### DIFF
--- a/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
@@ -27,7 +27,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
         )
         let context = Context(customer: CustomerModel(id: "xx", name: "xxx", email: "xxx", analyticsId: "xxx", referralId: "xxx"), regions: [region])
         
-        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .home)
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .locationPermissions)
     }
     
     func testUserKillsAppAfterCompletingOnboardingSuccessfullyButBeforeAwesomeScreen() {
@@ -48,7 +48,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
             ]
         )
         
-        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .home)
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .locationPermissions)
     }
     
     func testServerIsUnavailableOnStartUp() {
@@ -183,7 +183,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
             ]
         )
         
-        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .home)
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .locationPermissions)
     }
 
 }

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
@@ -66,7 +66,15 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
         let localContext = OnboardingContext()
         let context = Context(customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"), regions: noRegions)
         
-        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .home)
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .locationPermissions)
+    }
+    
+    func testUserHasAcceptedLocationPermissions() {
+        let decider = StageDecider()
+        let localContext = OnboardingContext(hasSeenLocationPermissions: true)
+        let context = Context(customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"), regions: noRegions)
+        
+        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .notificationPermissions)
     }
     
     func testUserHasSelectedACountryAndIsInThatCountry() {
@@ -149,28 +157,7 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
     
     func testUserHasInstalledESIMThenColdStart() {
         let decider = StageDecider()
-        let localContext = OnboardingContext(hasSeenLocationPermissions: true)
-        
-        let context = Context(
-            customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),
-            regions: [
-                RegionResponse(
-                    region: Region(id: "sg", name: "Singapore"),
-                    status: .APPROVED,
-                    simProfiles: [
-                        SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED)
-                    ],
-                    kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .APPROVED, nricFin: .PENDING, addressPhone: .PENDING)
-                )
-            ]
-        )
-        
-        XCTAssertEqual(decider.compute(context: context, localContext: localContext), .home)
-    }
-    
-    func testUserHasInstalledESIMAndSeenAwesome() {
-        let decider = StageDecider()
-        let localContext = OnboardingContext()
+        let localContext = OnboardingContext(hasSeenLocationPermissions: true, hasSeenNotificationPermissions: true)
         
         let context = Context(
             customer: CustomerModel(id: "xxx", name: "xxx", email: "xxxx@gmail.com", analyticsId: "xxxx", referralId: "xxxx"),

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -128,12 +128,7 @@ public struct StageDecider {
             return .ohNo(.serverUnreachable)
         }
         
-        if context?.customer != nil {
-            // This is a clue the user is an existing user, don't need to show legal stuff
-            return .home
-        }
-        
-        var stages: [Stage] = [.loginCarousel, .legalStuff, .nicknameEntry, .locationPermissions, .notificationPermissions, .notificationPermissions, .home]
+        var stages: [Stage] = [.loginCarousel, .legalStuff, .nicknameEntry, .locationPermissions, .notificationPermissions, .home]
         
         func remove(_ stage: Stage) {
             if let index = stages.firstIndex(of: stage) {
@@ -147,6 +142,13 @@ public struct StageDecider {
         if localContext.hasAgreedToTerms {
             remove(.legalStuff)
         }
+        if context?.customer != nil {
+            // This is a clue the user is an existing user, don't need to show legal stuff
+            remove(.loginCarousel)
+            remove(.legalStuff)
+            remove(.nicknameEntry)
+        }
+        
         if localContext.hasSeenLocationPermissions {
             remove(.locationPermissions)
         }

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -50,6 +50,10 @@ class OnboardingCoordinator {
             .done { (context) in
                 self.localContext.serverIsUnreachable = false
                 
+                let location = LocationController.shared
+                self.localContext.hasSeenLocationPermissions = location.authorizationStatus != .notDetermined
+                self.localContext.locationProblem = location.locationProblem
+                
                 UserManager.shared.customer = context.customer
                 let stage = self.stageDecider.compute(context: context.toLegacyModel(), localContext: self.localContext)
                 self.afterDismissing {

--- a/ostelco-ios-client/Extensions/UIViewController+SwiftUI.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+SwiftUI.swift
@@ -18,4 +18,3 @@ extension UIViewController {
         childView.didMove(toParent: self)
     }
 }
-

--- a/ostelco-ios-client/Stores/AppStore.swift
+++ b/ostelco-ios-client/Stores/AppStore.swift
@@ -9,7 +9,7 @@
 import ostelco_core
 
 final class AppStore: ObservableObject {
-    @Published var country: Country? = nil
+    @Published var country: Country?
     
     init() {
         // TODO: Feels like we can refactor this into something simpler

--- a/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
+++ b/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
@@ -40,3 +40,4 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
         self.onboarding = onboarding
     }
 }
+

--- a/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Home/HomeViewController.swift
@@ -75,10 +75,8 @@ class HomeViewController: ApplePayViewController {
         scrollView.addSubview(refreshControl)
         refreshBalance()
         
-        LocationController.shared.startUpdatingLocation()
         NotificationCenter.default.addObserver(self, selector: #selector(countryChanged(_:)), name: CurrentCountryChanged, object: nil)
         updateButtonFor(country: LocationController.shared.currentCountry)
-        
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Because users can now choose to only grant permissions one time, we'll
need to be able to ask even after onboarding is complete.