### PR TITLE
Fixes crash when parsing new region status available in onboarding flow

### DIFF
--- a/ostelco-core/Models/EKYCStatus.swift
+++ b/ostelco-core/Models/EKYCStatus.swift
@@ -12,6 +12,7 @@ public enum EKYCStatus: String, Codable, CaseIterable {
     case APPROVED
     case REJECTED
     case PENDING
+    case AVAILABLE
     
     func getGraphQLModel() -> PrimeGQL.KycStatus {
         return PrimeGQL.KycStatus(rawValue: self.rawValue)!


### PR DESCRIPTION
This fix should have been part of PR #368 where we updated graphql schema.