### PR TITLE
Check permission when the app becomes active.

### DIFF
--- a/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
+++ b/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
@@ -22,6 +22,8 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
                 self.setupOnboarding()
             }
         }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(setupOnboarding), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     func onboardingComplete() {
@@ -31,7 +33,7 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
         embedFullViewChild(tabs!)
     }
     
-    func setupOnboarding() {
+    @objc func setupOnboarding() {
         let navigationController = UINavigationController()
         embedFullViewChild(navigationController)
         
@@ -40,4 +42,3 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
         self.onboarding = onboarding
     }
 }
-


### PR DESCRIPTION
Not just when it launches, but every time you come back. If we *do* have
permission this will result in a brief flicker. As discussed with Oisin,
we'll make this more pleasant later.