### PR TITLE
Fix apple pay dialog does not close.

### DIFF
--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		046E05F722CA3461008D81F4 /* NorwayUserHappyFlowWithJumioStageDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046E05F622CA3461008D81F4 /* NorwayUserHappyFlowWithJumioStageDeciderTests.swift */; };
 		047F29032224460B00FC6A8F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F29022224460B00FC6A8F /* LoginViewController.swift */; };
 		047F29042224460B00FC6A8F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047F29022224460B00FC6A8F /* LoginViewController.swift */; };
+		0482E470235A679B00DAC4D7 /* ApplePayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0482E46F235A679B00DAC4D7 /* ApplePayViewController.swift */; };
+		0482E471235A679B00DAC4D7 /* ApplePayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0482E46F235A679B00DAC4D7 /* ApplePayViewController.swift */; };
 		04834D32222EAA7D00A01500 /* Singapore.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 04834D31222EAA7D00A01500 /* Singapore.gpx */; };
 		04834D33222EAA7D00A01500 /* Singapore.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 04834D31222EAA7D00A01500 /* Singapore.gpx */; };
 		04834D35222EAB5900A01500 /* Norway.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 04834D34222EAB4E00A01500 /* Norway.gpx */; };
@@ -463,6 +465,7 @@
 		046FE92E22DF0A5200CF57E4 /* regions.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = regions.graphql; sourceTree = "<group>"; };
 		046FE93822E136AA00CF57E4 /* simProfilesForRegion.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = simProfilesForRegion.graphql; sourceTree = "<group>"; };
 		047F29022224460B00FC6A8F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		0482E46F235A679B00DAC4D7 /* ApplePayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayViewController.swift; sourceTree = "<group>"; };
 		04834D31222EAA7D00A01500 /* Singapore.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Singapore.gpx; sourceTree = "<group>"; };
 		04834D34222EAB4E00A01500 /* Norway.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Norway.gpx; sourceTree = "<group>"; };
 		04834D3B222EC7DC00A01500 /* UIViewController+DismissKeyboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+DismissKeyboard.swift"; sourceTree = "<group>"; };
@@ -886,6 +889,7 @@
 				0412BF8B235701A3003D485B /* BalanceLabel.swift */,
 				0412BF8E235701E1003D485B /* ApplePaySetupView.swift */,
 				0412BF912357020D003D485B /* ApplePaySetupButton.swift */,
+				0482E46F235A679B00DAC4D7 /* ApplePayViewController.swift */,
 			);
 			path = Balance;
 			sourceTree = "<group>";
@@ -1943,6 +1947,7 @@
 				9B17457A2276F6E900CF321B /* AddressEditDataSource.swift in Sources */,
 				045A4BC52354790000873410 /* RemoteConfigManager.swift in Sources */,
 				9BBF705A2265F02200E4B9B4 /* CountryDataSource.swift in Sources */,
+				0482E470235A679B00DAC4D7 /* ApplePayViewController.swift in Sources */,
 				04834D782237BF0C00A01500 /* UIViewController+Alerts.swift in Sources */,
 				043E710E2239F17200E01993 /* main.swift in Sources */,
 				045A4BCB2355B2A600873410 /* PurchaseHistoryView.swift in Sources */,
@@ -2156,6 +2161,7 @@
 				9BC4653D2271AE0F001951BF /* LocationProblem+UserFacingCopy.swift in Sources */,
 				045A4BC62354790000873410 /* RemoteConfigManager.swift in Sources */,
 				042928F9223D4D8800806438 /* SignUpCompletedViewController.swift in Sources */,
+				0482E471235A679B00DAC4D7 /* ApplePayViewController.swift in Sources */,
 				042CA82F22C21A1D000F0622 /* ShakeToHelpViewController.swift in Sources */,
 				04D6C9862276E32700AE13DD /* OstelcoAnalytics.swift in Sources */,
 				045A4BCC2355B2A600873410 /* PurchaseHistoryView.swift in Sources */,

--- a/ostelco-ios-client/Features/Balance/ApplePayViewController.swift
+++ b/ostelco-ios-client/Features/Balance/ApplePayViewController.swift
@@ -1,0 +1,187 @@
+//
+//  ApplePayViewController.swift
+//  ostelco-ios-client
+//
+//  Created by Prasanth Ullattil on 26/04/2019.
+//  Copyright © 2019 mac. All rights reserved.
+//
+import UIKit
+import PassKit
+import PromiseKit
+import Stripe
+import ostelco_core
+
+// This is the base class for both HomeViewController and SetupApplePayViewController
+// 1) Adds properties defined by the ApplePayDelegate protocol
+// 2) Adds @objc methods for PKPaymentAuthorizationViewControllerDelegate
+// This class couldn't be avoided due to the issue described in the following link.
+// TL;DR: @objc functions may not currently be in protocol extensions.
+// You could create a base class instead, though that's not an ideal solution.
+// https://stackoverflow.com/questions/39487168/non-objc-method-does-not-satisfy-optional-requirement-of-objc-protocol
+class ApplePayViewController: UIViewController, ApplePayDelegate {
+
+    // MARK: - Properties for ApplePayDelegate.
+    var shownApplePay = false
+    var authorizedApplePay = false
+    var purchasingProduct: Product?
+    var applePayError: ApplePayError?
+
+    // MARK: - Properties for Stripe Payment.
+    #if STRIPE_PAYMENT
+        lazy var paymentContext: STPPaymentContext = {
+            let customerContext = STPCustomerContext(keyProvider: self)
+            let paymentContext = STPPaymentContext(customerContext: customerContext)
+            paymentContext.delegate = self
+            paymentContext.hostViewController = self
+            return paymentContext
+        }()
+    #endif
+
+    func paymentError(_ error: Error) {
+        if let applePayError = error as? ApplePayError {
+            switch applePayError {
+            case .unsupportedDevice, .noSupportedCards, .otherRestrictions:
+                self.showAlert(title: "Payment Error", msg: error.localizedDescription)
+            case .userCancelled:
+                debugPrint(error.localizedDescription, "Payment was cancelled after showing Apple Pay screen")
+            case .paymentDeclined:
+                debugPrint(error.localizedDescription, "Payment was declined")
+                showOhNo(type: .paymentFailedCardDeclined)
+            case .primeAPIError(let requestError):
+                debugPrint(requestError.localizedDescription, "Payment failed")
+                showOhNo(type: .paymentFailedGeneric)
+            case .invalidConfiguration:
+                debugPrint(error.localizedDescription, "Invalid configuration")
+                showOhNo(type: .paymentFailedGeneric)
+            }
+        } else {
+            showAlert(title: "Payment Error", msg: error.localizedDescription)
+        }
+    }
+
+    func showOhNo(type: OhNoIssueType) {
+        let ohNo = OhNoViewController.fromStoryboard(type: type)
+        ohNo.primaryButtonAction = {
+            ohNo.dismiss(animated: true, completion: nil)
+        }
+        present(ohNo, animated: true)
+    }
+
+    func paymentSuccessful(_ product: Product?) {
+        self.showAlert(title: "Yay!", msg: "Imaginary confetti, and lots of it! \(String(describing: product?.name))")
+    }
+
+    func getProducts() -> Promise<[Product]> {
+        return APIManager.shared.primeAPI
+            .loadProducts()
+            .map { productModels in
+                productModels.map { Product(from: $0, countryCode: "SG") }
+            }
+    }
+}
+
+extension ApplePayViewController: PKPaymentAuthorizationViewControllerDelegate {
+
+    // MARK: - Default implementaion of PKPaymentAuthorizationViewControllerDelegate.
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController,
+                                            didAuthorizePayment payment: PKPayment,
+                                            handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {
+        handlePaymentAuthorized(controller, didAuthorizePayment: payment, handler: completion)
+    }
+
+    func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+        handlePaymentFinished(controller)
+    }
+}
+
+#if STRIPE_PAYMENT
+// This extension supports payment through Stripe Standard UI components.
+// Mainly used for testing prime payment APIs with different types of cards avaiable in Stripe.
+// https://stripe.com/docs/testing
+extension ApplePayViewController: STPPaymentContextDelegate, STPCustomerEphemeralKeyProvider {
+
+    // This shows various payment options avaiable through stripe.
+    // You can add new cards using  the presented UI
+    func showPaymentOptions() {
+        let paymentOptionsViewController = STPPaymentOptionsViewController(paymentContext: paymentContext)
+        let navigationController = UINavigationController(rootViewController: paymentOptionsViewController)
+        present(navigationController, animated: true)
+    }
+
+    // Do actual payment using  Stripe.
+    // Payment is done using the default card you have selected using the showPaymentOptions API
+    // If no card is present, this will show the payment options UI
+    func startStripePay(product: Product) {
+        purchasingProduct = product
+        paymentContext.paymentAmount = Int(truncating: NSDecimalNumber(decimal: product.amount))
+        paymentContext.paymentCurrency = product.currency
+        paymentContext.requestPayment()
+    }
+
+    // Stripe is ready with a payment source, call Prime API to purchase the product
+    func handleDidCreatePaymentResult(paymentResult: STPPaymentResult, completion: @escaping STPErrorBlock) {
+        guard let product = purchasingProduct else {
+            debugPrint("No product to buy")
+            return
+        }
+        // Call Prime API to buy the product.
+        let payment = PaymentInfo(sourceID: paymentResult.source.stripeID)
+        APIManager.shared.primeAPI.purchaseProduct(with: product.sku, payment: payment)
+            .done {
+                debugPrint("Successfully bought product \(product.sku)")
+                completion(nil)
+            }
+            .catch { error in
+                ApplicationErrors.log(error)
+                debugPrint("Failed to buy product with sku %{public}@, got error: %{public}@", "123", "\(error)")
+                completion(self.createPaymentError(error))
+            }
+    }
+
+    // MARK: - STPPaymentContextDelegate methods
+    func paymentContext(_ paymentContext: STPPaymentContext, didFailToLoadWithError error: Error) {
+        debugPrint(#function, error)
+        paymentError(error)
+    }
+
+    func paymentContextDidChange(_ paymentContext: STPPaymentContext) {
+        debugPrint(#function)
+    }
+
+    func paymentContext(_ paymentContext: STPPaymentContext, didCreatePaymentResult paymentResult: STPPaymentResult, completion: @escaping STPErrorBlock) {
+        debugPrint(#function)
+        handleDidCreatePaymentResult(paymentResult: paymentResult, completion: completion)
+    }
+
+    func paymentContext(_ paymentContext: STPPaymentContext, didFinishWith status: STPPaymentStatus, error: Error?) {
+        switch status {
+        case .error:
+            debugPrint("Error while processing the payment: \(String(describing: error)))")
+            if let error = error {
+                paymentError(error)
+            }
+        case .success:
+            debugPrint("Payment was successful")
+            paymentSuccessful(purchasingProduct)
+        case .userCancellation:
+            debugPrint("User cancelled the payment")
+        @unknown default:
+            debugPrint("Payment finished with unknown status \(status)")
+        }
+    }
+
+    // MARK: - STPCustomerEphemeralKeyProvider method
+    // Called automatically by Stripe through the STPCustomerContext object
+    func createCustomerKey(withAPIVersion apiVersion: String, completion: @escaping STPJSONResponseCompletionBlock) {
+        let request = StripeEphemeralKeyRequest(apiVersion: apiVersion)
+        APIManager.shared.primeAPI.stripeEphemeralKey(with: request)
+            .done { key in
+                completion(key, nil)
+            }
+            .catch { error in
+                ApplicationErrors.log(error)
+                completion(nil, error)
+            }
+    }
+}
+#endif

--- a/ostelco-ios-client/Features/Balance/BalanceStore.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceStore.swift
@@ -14,13 +14,17 @@ final class BalanceStore: ObservableObject {
     @Published var selectedProduct: Product? = nil
     @Published var balance: String?
     
+    let controller: TabBarViewController
+    
     private lazy var byteCountFormatter: ByteCountFormatter = {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .binary
         return formatter
     }()
         
-    init() {
+    init(controller: TabBarViewController) {
+        self.controller = controller
+        
         loadProducts()
         fetchBalance()
     }

--- a/ostelco-ios-client/Features/Balance/BalanceView.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceView.swift
@@ -41,13 +41,14 @@ struct BalanceView: View {
             buttons.append(
                 .default(Text(product.label), action: {
                     #if STRIPE_PAYMENT
-                    // TODO: Start stripe pay
+                    self.store.controller.startStripePay(product: product)
                     #else
-                    // TODO: Test apple pay setup
-                    if (!self.showApplePaySetup()) {
-                        self.store.selectedProduct = product
+                    // Before we start payment, check if Apple pay is setup correctly.
+                    if !self.showApplePaySetup() {
+                        self.store.controller.startApplePay(product: product)
                     }
                     #endif
+
                 })
             )
         }

--- a/ostelco-ios-client/ViewControllers/TabBarViewController.swift
+++ b/ostelco-ios-client/ViewControllers/TabBarViewController.swift
@@ -8,8 +8,9 @@
 
 import UIKit
 import ostelco_core
+import Stripe
 
-class TabBarViewController: UITabBarController {
+class TabBarViewController: ApplePayViewController {
     
     var currentCoordinator: RegionOnboardingCoordinator?
     let primeAPI = APIManager.shared.primeAPI

--- a/ostelco-ios-client/Views/TabBarView.swift
+++ b/ostelco-ios-client/Views/TabBarView.swift
@@ -23,7 +23,7 @@ struct TabBarView: View {
     
     var body: some View {
         TabView {
-            BalanceView().environmentObject(BalanceStore())
+            BalanceView().environmentObject(BalanceStore(controller: controller))
                 .tabItem {
                     Image(systemName: "house.fill")
                         .font(.system(size: 24))


### PR DESCRIPTION
- After converting Apple Pay logic to swiftUI the apple pay dialog did not close after success / failure or when user clicked cancel. Since we now have a common controller we use for other stuff, the TabBarViewController, we can use that to bring back the ApplePayViewController.

Note: Requires som more clean up of the apple pay SwiftUI logic