### PR TITLE
Fix issue with parsing incoming push notifications

### DIFF
--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -537,6 +537,7 @@ class RegionOnboardingCoordinator {
     }
     
     func navigateTo(_ stage: StageDecider.RegionStage) {
+        print(stage)
         switch stage {
         case .selectIdentityVerificationMethod(let options):
             let selectEKYCMethod = SelectIdentityVerificationMethodViewController.fromStoryboard()
@@ -584,7 +585,12 @@ class RegionOnboardingCoordinator {
         case .ohNo(let issue):
             let ohNo = OhNoViewController.fromStoryboard(type: issue)
             ohNo.primaryButtonAction = { [weak self] in
-                self?.advance()
+                switch issue {
+                case .ekycRejected:
+                    self?.delegate?.onboardingCancelled()
+                default:
+                    self?.advance()
+                }
             }
             navigationController.present(ohNo, animated: true, completion: nil)
         case .done:


### PR DESCRIPTION
I think because of an iOS change, push notification data can come in
slightly differently. This would result in the app crashing, so we need
to account for this. This will make the app check both and not get
confused as easily if the payload is formatted differently.