### PR TITLE
Fix jittering issues when becoming active.

### DIFF
--- a/ostelco-core/ModelControllers/LocationController.swift
+++ b/ostelco-core/ModelControllers/LocationController.swift
@@ -40,6 +40,7 @@ open class LocationController: NSObject, CLLocationManagerDelegate {
         
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
+        checkPermissions()
     }
     
     public func startUpdatingLocation() {
@@ -97,8 +98,19 @@ open class LocationController: NSObject, CLLocationManagerDelegate {
     
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         assert(Thread.isMainThread)
+        checkPermissions()
         DispatchQueue.main.async {
             self.authChangeCallback?(status)
+        }
+    }
+    
+    func checkPermissions() {
+        if authorizationStatus == .restricted {
+            locationProblem = .restrictedByParentalControls
+        } else if authorizationStatus == .denied {
+            locationProblem = .deniedByUser
+        } else {
+            locationProblem = nil
         }
     }
 }

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -56,8 +56,12 @@ class OnboardingCoordinator {
                 
                 UserManager.shared.customer = context.customer
                 let stage = self.stageDecider.compute(context: context.toLegacyModel(), localContext: self.localContext)
-                self.afterDismissing {
-                    self.navigateTo(stage)
+                if stage == .home {
+                    self.delegate?.onboardingComplete()
+                } else {
+                    self.afterDismissing {
+                        self.navigateTo(stage)
+                    }
                 }
         }.recover { error in
             self.localContext.serverIsUnreachable = (error as NSError).code == -1004

--- a/ostelco-ios-client/Extensions/UIViewController+EmbedFullViewChild.swift
+++ b/ostelco-ios-client/Extensions/UIViewController+EmbedFullViewChild.swift
@@ -9,17 +9,22 @@
 import UIKit
 
 extension UIViewController {
-    func embedFullViewChild(_ controller: UIViewController) {
-        for child in children {
-            child.willMove(toParent: nil)
-            child.view.removeFromSuperview()
-            child.removeFromParent()
+    func embedFullViewChild(_ controller: UIViewController, removePrevious: Bool = true) {
+        if removePrevious {
+            for child in children {
+                child.willMove(toParent: nil)
+                child.view.removeFromSuperview()
+                child.removeFromParent()
+            }
         }
-        let newView = controller.view
-        view.addSubview(newView!)
-        newView?.translatesAutoresizingMaskIntoConstraints = false
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-(0)-[newView]-(0)-|", options: [], metrics: nil, views: ["newView": newView!]))
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(0)-[newView]-(0)-|", options: [], metrics: nil, views: ["newView": newView!]))
+        guard let newView = controller.view else {
+            return
+        }
+        view.addSubview(newView)
+        newView.translatesAutoresizingMaskIntoConstraints = false
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-(0)-[newView]-(0)-|", options: [], metrics: nil, views: ["newView": newView]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(0)-[newView]-(0)-|", options: [], metrics: nil, views: ["newView": newView]))
+        view.bringSubviewToFront(newView)
         
         addChild(controller)
         controller.didMove(toParent: self)

--- a/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
+++ b/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
@@ -11,6 +11,8 @@ import FirebaseAuth
 
 class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate {
     var onboarding: OnboardingCoordinator?
+    var onboardingRoot: UIViewController?
+    var mainRoot: UIViewController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,13 +31,22 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
     func onboardingComplete() {
         onboarding = nil
         
-        let tabs = UIStoryboard(name: "TabController", bundle: nil).instantiateInitialViewController()
-        embedFullViewChild(tabs!)
+        onboardingRoot?.willMove(toParent: nil)
+        onboardingRoot?.view.removeFromSuperview()
+        onboardingRoot?.removeFromParent()
+        onboardingRoot = nil
+        
+        if mainRoot == nil {
+            let tabs = UIStoryboard(name: "TabController", bundle: nil).instantiateInitialViewController()
+            mainRoot = tabs
+            embedFullViewChild(tabs!)
+        }
     }
     
     @objc func setupOnboarding() {
         let navigationController = UINavigationController()
-        embedFullViewChild(navigationController)
+        onboardingRoot = navigationController
+        embedFullViewChild(navigationController, removePrevious: false)
         
         let onboarding = OnboardingCoordinator(navigationController: navigationController)
         onboarding.delegate = self


### PR DESCRIPTION
This prevents the tab bar jumping if the app is paused at all, this also
prevents the in-progress EKYC from being dismissed when the app is
paused as well. This doesn't completely eliminate the mild visual
flickering when the app is un-paused.