### PR TITLE
Handle being forced out better

### DIFF
--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -11,6 +11,7 @@ import Foundation
 import Apollo
 
 public typealias Long = Int64
+public let FailedToFetchCustomerCode = "FAILED_TO_FETCH_CUSTOMER"
 
 extension Int64: JSONDecodable, JSONEncodable {
     public init(jsonValue value: JSONValue) throws {
@@ -126,8 +127,8 @@ open class PrimeAPI: BasicNetwork {
                     if let data = result?.data {
                         seal.fulfill(data.context)
                     } else {
-                        // Note: RootCoordinator excepts an error of specific type to redirect user to signup when user is logged in but has not user in our server yet.
-                        seal.reject(APIHelper.Error.jsonError(JSONRequestError(errorCode: "FAILED_TO_FETCH_CUSTOMER", httpStatusCode: 404, message: "Failed to fetch customer.")))
+                        // Note: OnboardingCoordinator excepts an error of specific type to redirect user to signup when user is logged in but has not user in our server yet.
+                        seal.reject(APIHelper.Error.jsonError(JSONRequestError(errorCode: FailedToFetchCustomerCode, httpStatusCode: 404, message: "Failed to fetch customer.")))
                     }
                 }
                 

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -48,6 +48,8 @@ class OnboardingCoordinator {
     func advance() {
         primeAPI.loadContext()
             .done { (context) in
+                print(context.customer!)
+                
                 self.localContext.serverIsUnreachable = false
                 
                 let location = LocationController.shared
@@ -64,6 +66,10 @@ class OnboardingCoordinator {
                     }
                 }
         }.recover { error in
+            if case APIHelper.Error.jsonError(let innerError) = error, innerError.errorCode == FailedToFetchCustomerCode {
+                UserManager.shared.logOut()
+            }
+            
             self.localContext.serverIsUnreachable = (error as NSError).code == -1004
             let context: Context? = nil
             let stage = self.stageDecider.compute(context: context, localContext: self.localContext)


### PR DESCRIPTION
This handles the case where the app launches, thinks it is logged in
because it has a token from Firebase, but the server has decided it is
not logged in (like if a tester deletes their account).