### PR TITLE
Show welcome to country message if user changes country.

### DIFF
--- a/ostelco-core/ModelControllers/UserDefaultsWrapper.swift
+++ b/ostelco-core/ModelControllers/UserDefaultsWrapper.swift
@@ -13,6 +13,7 @@ public struct UserDefaultsWrapper {
     // Underlying keys for user defaults
     private enum Key: String, CaseIterable {
         case contactEmail = "ContactEmail"
+        case countryCode = "CountryCode"
     }
     
     private static var defaults: UserDefaults {
@@ -51,5 +52,17 @@ public struct UserDefaultsWrapper {
             }
         }
     }
-
+    
+    public static var countryCode: String? {
+        get {
+            return self.value(for: .countryCode)
+        }
+        set {
+            if let newCountry = newValue {
+                self.setValue(newCountry, for: .countryCode)
+            } else {
+                self.removeValue(for: .countryCode)
+            }
+        }
+    }
 }

--- a/ostelco-ios-client.xcodeproj/project.pbxproj
+++ b/ostelco-ios-client.xcodeproj/project.pbxproj
@@ -121,6 +121,10 @@
 		04BA349D222587F6000359C4 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349B222587F6000359C4 /* SplashViewController.swift */; };
 		04BA34A02226B8D9000359C4 /* EnableNotificationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349F2226B8D9000359C4 /* EnableNotificationsViewController.swift */; };
 		04BA34A12226B8D9000359C4 /* EnableNotificationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BA349F2226B8D9000359C4 /* EnableNotificationsViewController.swift */; };
+		04BBA8202362EA1200BFED03 /* MessageContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBA81F2362EA1200BFED03 /* MessageContainer.swift */; };
+		04BBA8212362EA1200BFED03 /* MessageContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBA81F2362EA1200BFED03 /* MessageContainer.swift */; };
+		04BBA8242362EAAA00BFED03 /* GlobalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBA8232362EAAA00BFED03 /* GlobalStore.swift */; };
+		04BBA8252362EAAA00BFED03 /* GlobalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBA8232362EAAA00BFED03 /* GlobalStore.swift */; };
 		04D6C9852276E32700AE13DD /* OstelcoAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */; };
 		04D6C9862276E32700AE13DD /* OstelcoAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */; };
 		04D6C9882276F7CB00AE13DD /* String+SnakeCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6C9872276F7CB00AE13DD /* String+SnakeCase.swift */; };
@@ -495,6 +499,8 @@
 		04B9AB5022CB9062009234B6 /* OhNoIssueType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhNoIssueType.swift; sourceTree = "<group>"; };
 		04BA349B222587F6000359C4 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		04BA349F2226B8D9000359C4 /* EnableNotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableNotificationsViewController.swift; sourceTree = "<group>"; };
+		04BBA81F2362EA1200BFED03 /* MessageContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageContainer.swift; sourceTree = "<group>"; };
+		04BBA8232362EAAA00BFED03 /* GlobalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalStore.swift; sourceTree = "<group>"; };
 		04D1D1362197D2FD00551B0E /* FreshchatCarthage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FreshchatCarthage.framework; path = Carthage/Build/iOS/FreshchatCarthage.framework; sourceTree = "<group>"; };
 		04D6C9842276E32700AE13DD /* OstelcoAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OstelcoAnalytics.swift; sourceTree = "<group>"; };
 		04D6C9872276F7CB00AE13DD /* String+SnakeCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SnakeCase.swift"; sourceTree = "<group>"; };
@@ -752,7 +758,6 @@
 			isa = PBXGroup;
 			children = (
 				04AB2CAF235A522D00C9A71B /* Features */,
-				04A80CCE234C829800ECEE84 /* Stores */,
 				04488169217924B700F59758 /* AppDelegate.swift */,
 				9BE2D45B225B634100B51999 /* TestAppDelegate.swift */,
 				9BE2D440225B5CB700B51999 /* Assets */,
@@ -894,16 +899,10 @@
 			path = Balance;
 			sourceTree = "<group>";
 		};
-		04A80CCE234C829800ECEE84 /* Stores */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Stores;
-			sourceTree = "<group>";
-		};
 		04AB2CAF235A522D00C9A71B /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				04BBA8222362EA9B00BFED03 /* App */,
 				0482E46E235A587C00DAC4D7 /* Balance */,
 				0482E46D235A56D200DAC4D7 /* Coverage */,
 				04AB2CB0235A523400C9A71B /* Account */,
@@ -919,6 +918,16 @@
 				045A4BCA2355B2A600873410 /* PurchaseHistoryView.swift */,
 			);
 			path = Account;
+			sourceTree = "<group>";
+		};
+		04BBA8222362EA9B00BFED03 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				04AB2CA6235A412E00C9A71B /* TabBarView.swift */,
+				04BBA81F2362EA1200BFED03 /* MessageContainer.swift */,
+				04BBA8232362EAAA00BFED03 /* GlobalStore.swift */,
+			);
+			path = App;
 			sourceTree = "<group>";
 		};
 		9B3FA95622649DBE0001641A /* Protocols */ = {
@@ -1172,7 +1181,6 @@
 			isa = PBXGroup;
 			children = (
 				9BBF705B2265F03600E4B9B4 /* Cells */,
-				04AB2CA6235A412E00C9A71B /* TabBarView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1963,6 +1971,7 @@
 				042928F2223D0BE700806438 /* NRICVerifyViewController.swift in Sources */,
 				041216AF22281CE000455278 /* AllowLocationAccessViewController.swift in Sources */,
 				C2D2EAE922785C0C00010586 /* AppErrors.swift in Sources */,
+				04BBA8242362EAAA00BFED03 /* GlobalStore.swift in Sources */,
 				9B305F98229693EA00B89FCB /* GifVideo.swift in Sources */,
 				9B3FA68F22896510001E4D60 /* UIAlertAction+Convenience.swift in Sources */,
 				9BBEEE0C228D88F600EED7F5 /* PushNotificationHandling.swift in Sources */,
@@ -1987,6 +1996,7 @@
 				04BA34A02226B8D9000359C4 /* EnableNotificationsViewController.swift in Sources */,
 				9B6A928122833242007F5EC9 /* STPAPIClient+PromiseKit.swift in Sources */,
 				0494336E22BB9E2400E5BB24 /* FreshchatManager.swift in Sources */,
+				04BBA8202362EA1200BFED03 /* MessageContainer.swift in Sources */,
 				04A80CD5234C969400ECEE84 /* ESimCountryView.swift in Sources */,
 				04D6C9882276F7CB00AE13DD /* String+SnakeCase.swift in Sources */,
 				9B560A9922731E57004473E1 /* OnboardingPageViewController.swift in Sources */,
@@ -2177,6 +2187,7 @@
 				C2D2EAEA22785C0C00010586 /* AppErrors.swift in Sources */,
 				9B305F99229694F700B89FCB /* GifVideo.swift in Sources */,
 				0412BF8A2355EEE8003D485B /* BalanceView.swift in Sources */,
+				04BBA8252362EAAA00BFED03 /* GlobalStore.swift in Sources */,
 				043E710F2239F17200E01993 /* main.swift in Sources */,
 				9BE2D458225B61CF00B51999 /* Storyboard.swift in Sources */,
 				9B5CBF542281888A00D83D7B /* FirebaseAuthUser+PromiseKit.swift in Sources */,
@@ -2201,6 +2212,7 @@
 				0412BF892355EED9003D485B /* BalanceStore.swift in Sources */,
 				9BE2D464225B698E00B51999 /* StoryboardLoadable.swift in Sources */,
 				C29802B12181EDA800FBC5C3 /* AppDelegate.swift in Sources */,
+				04BBA8212362EA1200BFED03 /* MessageContainer.swift in Sources */,
 				0494336F22BB9FF700E5BB24 /* FreshchatManager.swift in Sources */,
 				04A80CD6234C969400ECEE84 /* ESimCountryView.swift in Sources */,
 				04834D7F2237D53700A01500 /* UserManager.swift in Sources */,

--- a/ostelco-ios-client/Features/App/GlobalStore.swift
+++ b/ostelco-ios-client/Features/App/GlobalStore.swift
@@ -61,4 +61,33 @@ final class GlobalStore: ObservableObject {
         }
         return nil
     }
+    
+    func allowedCountries() -> [String] {
+        let countryCodeToRegionCodeMap = RemoteConfigManager.shared.countryCodeAndRegionCodes.reduce(into: [:], { (result, value) in
+            result[value.countryCode] = value.regionCodes
+        })
+        
+        if let regionDetailslist = regions {
+            let regionCodes = Set(
+                regionDetailslist.map({ $0.region.id })
+            )
+            
+            let allowedCountryCodes = Array(
+                countryCodeToRegionCodeMap
+                    .filter({ (_, value) in Set(value).intersection(regionCodes).isNotEmpty })
+                    .keys
+                )
+            
+            return allowedCountryCodes
+        }
+        
+        return []
+    }
+    
+    func showCountryNotSupportedMessage() -> Bool {
+        if let country = country, allowedCountries().contains(country.countryCode) {
+            return false
+        }
+        return true
+    }
 }

--- a/ostelco-ios-client/Features/App/GlobalStore.swift
+++ b/ostelco-ios-client/Features/App/GlobalStore.swift
@@ -1,0 +1,64 @@
+//
+//  GlobalStore.swift
+//  ostelco-ios-client
+//
+//  Created by mac on 10/25/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import ostelco_core
+
+final class GlobalStore: ObservableObject {
+    @Published var country: Country?
+    @Published var previousCountry: Country?
+    @Published var regions: [PrimeGQL.RegionDetailsFragment]?
+    @Published var countryCodeToRegionCodeMap = [:] as [String: [String]]
+    
+    init() {
+        
+        country = LocationController.shared.currentCountry
+
+        if let countryCode = UserDefaultsWrapper.countryCode {
+            previousCountry = Country(countryCode)
+        }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(countryChanged(_:)), name: CurrentCountryChanged, object: nil)
+        
+        loadRegions()
+    }
+    
+    func loadRegions() {
+        APIManager.shared.primeAPI.loadRegions()
+        .done { self.regions = $0 }.cauterize()
+    }
+    
+    @objc func countryChanged(_ notification: NSNotification) {
+        guard let controller = notification.object as? LocationController else {
+            fatalError("Something other than the location controller is posting this notification!")
+        }
+        country = controller.currentCountry
+        UserDefaultsWrapper.countryCode = country?.countryCode
+    }
+    
+    func simProfilesForCountry(country: Country) -> [PrimeGQL.SimProfileFields] {
+        if let regionDetailsList = regions, let regionCodes = countryCodeToRegionCodeMap[country.countryCode] {
+            return regionDetailsList
+                .filter({ regionCodes.contains($0.region.id) })
+                .filter({ $0.simProfiles != nil })
+                .map({ $0.simProfiles!.map({ $0.fragments.simProfileFields }) })
+                .reduce([], +)
+        }
+        return []
+    }
+    
+    func showCountryChangedMessage() -> Country? {
+        if let previousCountry = previousCountry, let country = country {
+            
+            if previousCountry.countryCode != country.countryCode && simProfilesForCountry(country: country).filter({ $0.status == .installed }).isEmpty
+            {
+                return country
+            }
+        }
+        return nil
+    }
+}

--- a/ostelco-ios-client/Features/App/MessageContainer.swift
+++ b/ostelco-ios-client/Features/App/MessageContainer.swift
@@ -1,0 +1,139 @@
+//
+//  MessageContainer.swift
+//  ostelco-ios-client
+//
+//  Created by mac on 10/25/19.
+//  Copyright © 2019 mac. All rights reserved.
+//
+
+import SwiftUI
+import OstelcoStyles
+import ostelco_core
+
+enum MessageType {
+    case welcomeNewUser(action: () -> Void)
+    case welcomeToCountry(action: () -> Void, country: Country)
+}
+
+struct MessageContainer: View {
+    let messageType: MessageType
+    let action: (() -> Void)?
+    
+    init(messageType: MessageType, action: (() -> Void)? = nil) {
+        self.messageType = messageType
+        self.action = action
+    }
+    
+    var body: some View {
+        Group {
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                }
+            }.background(OstelcoColor.fog.toColor)
+            ZStack {
+                MessageView(messageType: messageType)
+                // Lazy way to hide the bottom rounded corners from the above container, a better solution would be to configure the corners in the container itself.
+                VStack {
+                    Spacer()
+                    Rectangle()
+                        .fill(OstelcoColor.foreground.toColor)
+                        .frame(maxWidth: .infinity, maxHeight: 25)
+                }
+            }
+        }
+    }
+}
+
+struct MessageView: View {
+    
+    
+    let messageType: MessageType
+    let action: (() -> Void)?
+    
+    init(messageType: MessageType, action: (() -> Void)? = nil) {
+        self.messageType = messageType
+        self.action = action
+    }
+    
+    func renderTitle() -> OstelcoTitle {
+        switch messageType {
+            case .welcomeNewUser:
+                return OstelcoTitle(label: "Welcome to OYA!")
+        case .welcomeToCountry( _, let country):
+                return OstelcoTitle(label: "Welcome to \(country.nameOrPlaceholder)!")
+        }
+    }
+    
+    func renderDescription() -> Text {
+        switch messageType {
+            case .welcomeNewUser:
+                return Text("Where would you like to start using your first 1GB of OYA data?")
+            case .welcomeToCountry:
+                return Text("You can continue to use your OYA data here with a few simple steps")
+        }
+    }
+    
+    func renderButtonImage() -> AnyView {
+        switch messageType {
+        case .welcomeNewUser:
+            return AnyView(Image(systemName: "globe")
+            .font(.system(size: 30, weight: .light))
+            .foregroundColor(OstelcoColor.primaryButtonLabel.toColor))
+        default:
+            return AnyView(EmptyView())
+        }
+    }
+    
+    func renderButtonLabel() -> Text {
+        switch messageType {
+        case .welcomeNewUser:
+            return Text("See Available Countries")
+        case .welcomeToCountry:
+            return Text("Continue to use your OYA data here")
+        }
+    }
+    
+    func renderButton() -> AnyView {
+        
+        switch messageType {
+        case .welcomeNewUser(let action), .welcomeToCountry(let action, _):
+            return AnyView(Button(action: action) {
+                ZStack {
+                    HStack {
+                        renderButtonImage()
+                        Spacer()
+                    }.padding(.leading, 10)
+                    renderButtonLabel()
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(OstelcoColor.primaryButtonLabel.toColor)
+                }
+            })
+        }
+    }
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            OstelcoContainer {
+                VStack(spacing: 20) {
+                    self.renderTitle()
+                    self.renderDescription()
+                        .font(.system(size: 21))
+                        .foregroundColor(OstelcoColor.inputLabel.toColor)
+                        .multilineTextAlignment(.center )
+                    self.renderButton()
+                    .frame(maxWidth: .infinity, minHeight: 50)
+                    .background(OstelcoColor.primaryButtonBackground.toColor)
+                    .cornerRadius(27.5)
+                }.padding(25)
+            }
+        }
+    }
+}
+struct MessageContainer_Previews: PreviewProvider {
+    static var previews: some View {
+        MessageContainer(messageType: .welcomeNewUser(action: {}))
+    }
+}

--- a/ostelco-ios-client/Features/App/MessageContainer.swift
+++ b/ostelco-ios-client/Features/App/MessageContainer.swift
@@ -13,6 +13,7 @@ import ostelco_core
 enum MessageType {
     case welcomeNewUser(action: () -> Void)
     case welcomeToCountry(action: () -> Void, country: Country)
+    case countryNotSupported(country: Country)
 }
 
 struct MessageContainer: View {
@@ -61,7 +62,7 @@ struct MessageView: View {
         switch messageType {
             case .welcomeNewUser:
                 return OstelcoTitle(label: "Welcome to OYA!")
-        case .welcomeToCountry( _, let country):
+        case .welcomeToCountry( _, let country), .countryNotSupported(let country):
                 return OstelcoTitle(label: "Welcome to \(country.nameOrPlaceholder)!")
         }
     }
@@ -72,6 +73,8 @@ struct MessageView: View {
                 return Text("Where would you like to start using your first 1GB of OYA data?")
             case .welcomeToCountry:
                 return Text("You can continue to use your OYA data here with a few simple steps")
+            case .countryNotSupported:
+                return Text("Unfortunately you cannot use your OYA data here at this point")
         }
     }
     
@@ -92,6 +95,8 @@ struct MessageView: View {
             return Text("See Available Countries")
         case .welcomeToCountry:
             return Text("Continue to use your OYA data here")
+        default:
+            return Text("")
         }
     }
     
@@ -110,6 +115,8 @@ struct MessageView: View {
                         .foregroundColor(OstelcoColor.primaryButtonLabel.toColor)
                 }
             })
+        default:
+            return AnyView(EmptyView())
         }
     }
     

--- a/ostelco-ios-client/Features/App/TabBarView.swift
+++ b/ostelco-ios-client/Features/App/TabBarView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import OstelcoStyles
+import ostelco_core
 
 enum Tabs {
     case balance
@@ -18,6 +19,7 @@ enum Tabs {
 struct TabBarView: View {
     
     private let controller: TabBarViewController
+    private let global = GlobalStore()
     @State private var currentTab: Tabs = .balance
     
     init(controller: TabBarViewController) {
@@ -33,15 +35,15 @@ struct TabBarView: View {
     
     var body: some View {
         TabView(selection: $currentTab) {
-            // TODO: This seems like a hacky way to be able to change current tab from a child view.
-            BalanceView(currentTab: $currentTab).environmentObject(BalanceStore(controller: controller))
+            // TODO: This seems like a hacky way to be able to change current tab from a child view. (this = passing the state variable from the tabbar view to the corresponding views, it feels like we should be able to control this through some other kind of mechanism)
+            BalanceView(currentTab: $currentTab).environmentObject(BalanceStore(controller: controller)).environmentObject(global)
                 .tabItem {
                     Image(systemName: "house")
                         .font(.system(size: 24))
                     Text("Balance")
                         .font(.system(size: 10))
             }.tag(Tabs.balance)
-            CoverageView().environmentObject(CoverageStore(controller: controller))
+            CoverageView().environmentObject(CoverageStore(controller: controller)).environmentObject(global)
                 .tabItem {
                     Image(systemName: "globe")
                         .font(.system(size: 24))
@@ -57,6 +59,7 @@ struct TabBarView: View {
                 }.tag(Tabs.account)
         }
         .accentColor(OstelcoColor.azul.toColor)
+        .onDisappear()
     }
 }
 

--- a/ostelco-ios-client/Features/Balance/BalanceView.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceView.swift
@@ -120,7 +120,13 @@ struct BalanceView: View {
     }
     
     func renderOverlay() -> AnyView {
-        if store.hasAtLeastOneInstalledSimProfile {
+        if let country = global.country, global.showCountryNotSupportedMessage() {
+                return AnyView(
+                    MessageContainer(
+                        messageType: .countryNotSupported(country: country)
+                    )
+                )
+        } else if store.hasAtLeastOneInstalledSimProfile {
             if let country = global.showCountryChangedMessage() {
                 return AnyView(
                     MessageContainer(messageType: .welcomeToCountry(action: { self.currentTab = .coverage }, country: country))

--- a/ostelco-ios-client/Features/Balance/BalanceView.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceView.swift
@@ -14,12 +14,11 @@ import ostelco_core
 import PromiseKit
 import UIKit
 
-// TODO: Missing pull to refresh balance
 // TODO: Only loading products once, not on view did appear as original VC did (does this matter?)
-// TODO: Original VC registered for PN for some reason, not sure why
 struct BalanceView: View {
     
     @EnvironmentObject var store: BalanceStore
+    @EnvironmentObject var global: GlobalStore
     @State private var showProductsSheet = false
     @State private var presentApplePaySetup = false
     @Binding private var currentTab: Tabs
@@ -122,57 +121,16 @@ struct BalanceView: View {
     
     func renderOverlay() -> AnyView {
         if store.hasAtLeastOneInstalledSimProfile {
-            return AnyView(EmptyView())
+            if let country = global.showCountryChangedMessage() {
+                return AnyView(
+                    MessageContainer(messageType: .welcomeToCountry(action: { self.currentTab = .coverage }, country: country))
+                )
+            } else {
+                return AnyView(EmptyView())
+            }
         } else {
             return AnyView(
-                Group {
-                    VStack {
-                        Spacer()
-                        HStack {
-                            Spacer()
-                        }
-                    }.background(OstelcoColor.fog.toColor)
-                    ZStack {
-                        VStack {
-                            Spacer()
-                            OstelcoContainer {
-                                VStack(spacing: 20) {
-                                    OstelcoTitle(label: "Welcome to OYA!")
-                                    Text("Where would you like to start using your first 1GB of OYA data?")
-                                        .font(.system(size: 21))
-                                        .foregroundColor(OstelcoColor.inputLabel.toColor)
-                                        .multilineTextAlignment(.center )
-                                    Button(action: {
-                                        self.currentTab = .coverage
-                                    }) {
-                                        ZStack {
-                                            HStack {
-                                                Image(systemName: "globe")
-                                                    .font(.system(size: 30, weight: .light))
-                                                    .foregroundColor(OstelcoColor.primaryButtonLabel.toColor)
-                                                Spacer()
-                                            }.padding(.leading, 10)
-                                            Text("See Available Countries")
-                                                .font(.system(size: 18, weight: .semibold))
-                                                .foregroundColor(OstelcoColor.primaryButtonLabel.toColor)
-                                        }
-                                    }
-                                    .frame(maxWidth: .infinity, minHeight: 50)
-                                    .background(OstelcoColor.primaryButtonBackground.toColor)
-                                    .cornerRadius(27.5)
-                                }.padding(25)
-                            }
-                        }
-                        
-                        // Lazy way to hide the bottom rounded corners from the above container, a better solution would be to configure the corners in the container itself.
-                        VStack {
-                            Spacer()
-                            Rectangle()
-                                .fill(OstelcoColor.foreground.toColor)
-                                .frame(maxWidth: .infinity, maxHeight: 25)
-                        }
-                    }
-                }
+                MessageContainer(messageType: .welcomeNewUser(action: { self.currentTab = .coverage }))
             )
         }
     }

--- a/ostelco-ios-client/Features/Coverage/CoverageStore.swift
+++ b/ostelco-ios-client/Features/Coverage/CoverageStore.swift
@@ -9,7 +9,6 @@
 import ostelco_core
 
 final class CoverageStore: ObservableObject {
-    @Published var country: Country?
     @Published var regions: [PrimeGQL.RegionDetailsFragment]?
     @Published var countryCodeToRegionCodeMap = [:] as [String: [String]]
     @Published var regionGroups: [RegionGroupViewModel] = []
@@ -20,9 +19,6 @@ final class CoverageStore: ObservableObject {
     
     init(controller: TabBarViewController) {
         self.controller = controller
-        country = LocationController.shared.currentCountry
-        NotificationCenter.default.addObserver(self, selector: #selector(countryChanged(_:)), name: CurrentCountryChanged, object: nil)
-        
         loadRegions()
         
         countryCodeToRegionCodeMap = RemoteConfigManager.shared.countryCodeAndRegionCodes.reduce(into: [:], { (result, value) in
@@ -42,13 +38,6 @@ final class CoverageStore: ObservableObject {
     func loadRegions() {
         APIManager.shared.primeAPI.loadRegions()
         .done { self.regions = $0 }.cauterize()
-    }
-    
-    @objc func countryChanged(_ notification: NSNotification) {
-        guard let controller = notification.object as? LocationController else {
-            fatalError("Something other than the location controller is posting this notification!")
-        }
-        country = controller.currentCountry
     }
     
     func allowedCountries() -> [String] {

--- a/ostelco-ios-client/Features/Coverage/CoverageView.swift
+++ b/ostelco-ios-client/Features/Coverage/CoverageView.swift
@@ -48,6 +48,7 @@ struct RegionGroupViewModel: Identifiable {
 struct CoverageView: View {
     
     @EnvironmentObject var store: CoverageStore
+    @EnvironmentObject var global: GlobalStore
     @State private var selectedRegionGroup: RegionGroupViewModel?
     @State private var showModal: Bool = false
         
@@ -78,7 +79,7 @@ struct CoverageView: View {
             ScrollView {
                 VStack(spacing: 20) {
                     
-                    OstelcoTitle(label: store.country?.nameOrPlaceholder ?? "Unknown", image: "location.fill")
+                    OstelcoTitle(label: global.country?.nameOrPlaceholder ?? "Unknown", image: "location.fill")
                     
                     RegionListByLocation()
                     

--- a/ostelco-ios-client/Features/Coverage/RegionListByLocation.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionListByLocation.swift
@@ -13,6 +13,7 @@ import ostelco_core
 struct RegionListByLocation: View {
     
     @EnvironmentObject var store: CoverageStore
+    @EnvironmentObject var global: GlobalStore
     
     var body: some View {
         renderListOrUnavailable()
@@ -39,7 +40,7 @@ struct RegionListByLocation: View {
     
     private func renderListOrUnavailable() -> AnyView {
         
-        if let country = store.country {
+        if let country = global.country {
             // regions can be nil if its not loaded or we failed to fetch them from server, we present these errors as if there are no available regions.
             if let regionCodes = store.countryCodeToRegionCodeMap[country.countryCode], let regionDetailsList = store.regions?.filter({ regionCodes.contains($0.region.id.lowercased()) }), regionDetailsList.isNotEmpty {
                 


### PR DESCRIPTION
- Create a GlobalStore with the purpose of sharing common store logic accross views
- Move current country from CoverageStore to GlobalStore since it's now needed for both BalanceView and CoverageView
- Add logic to cache current country so we can use it to compare if user changes country
- Create a component out of the message view so it can be reused for different types of balance screen messages