### PR TITLE
Update analytic events according to updated onboarding flow.

### DIFF
--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -62,7 +62,7 @@ public class RegionOnboardingContext {
     }
 }
 
-public enum IdentityVerificationOption: CaseIterable {
+public enum IdentityVerificationOption: String, CaseIterable {
     case singpass
     case scanIC
     case jumio

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -568,6 +568,11 @@ class RegionOnboardingCoordinator {
             verifyMyInfo.delegate = self
             navigationController.setViewControllers([verifyMyInfo], animated: true)
         case .eSimInstructions:
+            OstelcoAnalytics.logEvent(.identificationSuccessful(
+                regionCode: region.region.id,
+                countryCode: LocationController.shared.currentCountry?.countryCode ?? "",
+                ekycMethod: localContext.selectedVerificationOption?.rawValue ?? "")
+                )
             let instructions = ESIMInstructionsViewController.fromStoryboard()
             instructions.delegate = self
             navigationController.setViewControllers([instructions], animated: true)
@@ -593,6 +598,11 @@ class RegionOnboardingCoordinator {
             addressController.regionCode = region.region.id
             navigationController.setViewControllers([addressController], animated: true)
         case .pendingVerification:
+            OstelcoAnalytics.logEvent(.identificationPendingValidation(
+                regionCode: region.region.id,
+                countryCode: LocationController.shared.currentCountry?.countryCode ?? "",
+                ekycMethod: localContext.selectedVerificationOption?.rawValue ?? "")
+            )
             let pending = PendingVerificationViewController.fromStoryboard()
             pending.delegate = self
             navigationController.setViewControllers([pending], animated: true)
@@ -602,6 +612,17 @@ class RegionOnboardingCoordinator {
             navigationController.setViewControllers([cameraPermissions], animated: true)
         case .ohNo(let issue):
             let ohNo = OhNoViewController.fromStoryboard(type: issue)
+            switch issue {
+            case .ekycRejected:
+                OstelcoAnalytics.logEvent(.identificationFailed(
+                    regionCode: region.region.id,
+                    countryCode: LocationController.shared.currentCountry?.countryCode ?? "",
+                    ekycMethod: localContext.selectedVerificationOption?.rawValue ?? "",
+                    failureReason: issue.displayTitle)
+                )
+            default:
+                break
+            }
             ohNo.primaryButtonAction = { [weak self] in
                 switch issue {
                 case .ekycRejected:

--- a/ostelco-ios-client/Features/Account/AccountView.swift
+++ b/ostelco-ios-client/Features/Account/AccountView.swift
@@ -98,6 +98,8 @@ struct AccountView: View {
                     ]
                 )
             }
+        }.onAppear {
+            OstelcoAnalytics.setScreenName(name: "AccountView")
         }
     }
 }

--- a/ostelco-ios-client/Features/Account/PurchaseHistoryView.swift
+++ b/ostelco-ios-client/Features/Account/PurchaseHistoryView.swift
@@ -32,6 +32,9 @@ struct PurchaseHistoryView: View {
                 }.padding()
             }
         }.navigationBarTitle("Purchase History")
+        .onAppear {
+            OstelcoAnalytics.setScreenName(name: "PurchaseHistoryView")
+        }
     }
 }
 

--- a/ostelco-ios-client/Features/Balance/ApplePaySetupView.swift
+++ b/ostelco-ios-client/Features/Balance/ApplePaySetupView.swift
@@ -27,6 +27,7 @@ struct ApplePaySetupView: View {
             ApplePaySetupButton(paymentButtonType: .setUp)
                 .frame(height: 44)
                 .onTapGesture {
+                    OstelcoAnalytics.logEvent(.setupApplePay)
                     PKPassLibrary().openPaymentSetup()
             }
         }.padding(20)

--- a/ostelco-ios-client/Features/Balance/ApplePaySetupView.swift
+++ b/ostelco-ios-client/Features/Balance/ApplePaySetupView.swift
@@ -31,6 +31,9 @@ struct ApplePaySetupView: View {
                     PKPassLibrary().openPaymentSetup()
             }
         }.padding(20)
+        .onAppear {
+            OstelcoAnalytics.setScreenName(name: "ApplePaySetupView")
+        }
     }
 }
 

--- a/ostelco-ios-client/Features/Balance/ApplePayViewController.swift
+++ b/ostelco-ios-client/Features/Balance/ApplePayViewController.swift
@@ -38,6 +38,7 @@ class ApplePayViewController: UIViewController, ApplePayDelegate {
     #endif
 
     func paymentError(_ error: Error) {
+        OstelcoAnalytics.logEvent(.ecommercePurchaseFailed(failureReason: error.localizedDescription))
         if let applePayError = error as? ApplePayError {
             switch applePayError {
             case .unsupportedDevice, .noSupportedCards, .otherRestrictions:

--- a/ostelco-ios-client/Features/Balance/BalanceView.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceView.swift
@@ -114,6 +114,7 @@ struct BalanceView: View {
         }.sheet(isPresented: $presentApplePaySetup) {
             ApplePaySetupView()
         }.onAppear {
+            OstelcoAnalytics.setScreenName(name: "BalanceView")
             if !self.store.hasAtLeastOneInstalledSimProfile {
                 self.store.loadSimProfiles()
             }

--- a/ostelco-ios-client/Features/Balance/BalanceView.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceView.swift
@@ -13,6 +13,7 @@ import Stripe
 import ostelco_core
 import PromiseKit
 import UIKit
+import FirebaseAnalytics
 
 // TODO: Missing pull to refresh balance
 // TODO: Only loading products once, not on view did appear as original VC did (does this matter?)
@@ -93,7 +94,7 @@ struct BalanceView: View {
                     .font(.system(size: 21))
                     .foregroundColor(OstelcoColor.primaryButtonBackground.toColor)
                 Button(action: {
-                    OstelcoAnalytics.logEvent(.BuyDataClicked)
+                    OstelcoAnalytics.logEvent(.buyDataFlowStarted)
                     self.showProductsSheet.toggle()
                 }) {
                     Text("Buy more Data")

--- a/ostelco-ios-client/Features/Coverage/CoverageView.swift
+++ b/ostelco-ios-client/Features/Coverage/CoverageView.swift
@@ -93,6 +93,7 @@ struct CoverageView: View {
             }.navigationBarTitle("", displayMode: .inline)
         }.onAppear {
             self.store.loadRegions()
+            OstelcoAnalytics.setScreenName(name: "CoverageView")
         }
     }
 }

--- a/ostelco-ios-client/Features/Coverage/CoverageView.swift
+++ b/ostelco-ios-client/Features/Coverage/CoverageView.swift
@@ -62,8 +62,9 @@ struct CoverageView: View {
         } else {
             return AnyView(
                 NavigationLink(destination: RegionGroupView(regionGroup: regionGroup, countrySelected: { country in
-                   // TODO: Change RegionView presentation from modal to either animation or navigation, then we can remove the below hack
-                    self.store.startOnboardingForRegion(self.store.getRegionFromCountry(country))
+                    let regionDetails = self.store.getRegionFromCountry(country)
+                     OstelcoAnalytics.logEvent(.getNewRegionFlowStarted(regionCode: regionDetails.region.id, countryCode: country.countryCode))
+                    self.store.startOnboardingForRegion(regionDetails)
             }).environmentObject(self.store)) {
                 RegionGroupCardView(label: regionGroup.name, description: regionGroup.description, backgroundColor: regionGroup.backgroundColor.toColor)
                }.cornerRadius(28)

--- a/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
@@ -26,7 +26,6 @@ struct RegionGroupView: View {
         }
         return AnyView(
             ESimCountryView(image: country.image, country: country.nameOrPlaceholder, action: {
-                // TODO: Refactor this so isnt dependent on CoverageViewController
                 self.countrySelected(country)
             })
         )

--- a/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
@@ -42,6 +42,9 @@ struct RegionGroupView: View {
             .padding([.leading, .trailing, .top ], 10)
             .padding(.bottom, 30)
         }.background(regionGroup.backgroundColor.toColor)
+            .onAppear {
+                OstelcoAnalytics.setScreenName(name: "RegionGroupView")
+        }
     }
 }
 struct RegionView_Previews: PreviewProvider {

--- a/ostelco-ios-client/Features/Coverage/RegionListByLocation.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionListByLocation.swift
@@ -30,7 +30,7 @@ struct RegionListByLocation: View {
         return AnyView(
             OstelcoContainer {
                 ESimCountryView(image: country.image, country: regionDetails.region.name, heading: "BASED ON LOCATION", action: {
-                    // TODO: Refactor this to not be dependent on CoverageViewController
+                     OstelcoAnalytics.logEvent(.getNewRegionFlowStarted(regionCode: regionDetails.region.id, countryCode: country.countryCode))
                     self.store.startOnboardingForRegion(regionDetails)
                 })
             }

--- a/ostelco-ios-client/ModelControllers/PushNotificationController.swift
+++ b/ostelco-ios-client/ModelControllers/PushNotificationController.swift
@@ -71,9 +71,9 @@ class PushNotificationController: NSObject {
                     seal.reject(error)
                 } else {
                     if granted {
-                        OstelcoAnalytics.logEvent(.PushNotificationsAccepted)
+                        OstelcoAnalytics.logEvent(.permissionNotificationsGranted)
                     } else {
-                        OstelcoAnalytics.logEvent(.PushNotificationsDeclined)
+                        OstelcoAnalytics.logEvent(.permissionNotificationsDenied)
                     }
                     
                     seal.fulfill(granted)

--- a/ostelco-ios-client/ModelControllers/UserManager.swift
+++ b/ostelco-ios-client/ModelControllers/UserManager.swift
@@ -54,6 +54,7 @@ class UserManager: TokenProvider {
     }
         
     func logOut() {
+        OstelcoAnalytics.logEvent(.logout)
         do {
             try Auth.auth().signOut()
         } catch let error {

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -74,7 +74,7 @@ enum AnalyticsEvent {
         case .ecommercePurchaseFailed:
             return "purchase_failed"
         default:
-            return String(describing: self).snakeCased() ?? ""
+            return String(describing: self).components(separatedBy: "(")[0].snakeCased() ?? ""
         }
     }
     

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -71,6 +71,8 @@ enum AnalyticsEvent {
             return AnalyticsEventAddToCart
         case .ecommercePurchase:
             return AnalyticsEventEcommercePurchase
+        case .ecommercePurchaseFailed:
+            return "purchase_failed"
         default:
             return String(describing: self).snakeCased() ?? ""
         }

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -38,6 +38,10 @@ public class OstelcoAnalytics {
     static func setUserId(_ id: String) {
         Analytics.setUserID(id)
     }
+    
+    static func setScreenName(name: String, screenClass: String? = nil) {
+        Analytics.setScreenName(name, screenClass: screenClass)
+    }
 }
 
 enum AnalyticsEvent {

--- a/ostelco-ios-client/Network/OstelcoAnalytics.swift
+++ b/ostelco-ios-client/Network/OstelcoAnalytics.swift
@@ -11,7 +11,7 @@ import ostelco_core
 import FirebaseAnalytics
 import Crashlytics
 
-class OstelcoAnalytics {
+public class OstelcoAnalytics {
     
     enum AnalyticsError: Swift.Error, LocalizedError {
         case eventNameIsEmpty
@@ -41,37 +41,77 @@ class OstelcoAnalytics {
 }
 
 enum AnalyticsEvent {
-    case LegalStuffAgreed
-    case EnteredNickname
-    case ChosenCountry(country: Country)
-    case ChosenIDMethod(idMethod: String)
-    case ESimOnboardingIntro
-    case ESimOnboardingIntroCompleted
-    case ESimOnboardingPending
-    case SignUpCompleted
-    case UnlockMoreData
-    case BecomeMemberClicked
-    case BuyDataClicked
-    case PushNotificationsAccepted
-    case PushNotificationsDeclined
-
+    
+    case signInFlowStarted
+    case signIn
+    case legalStuffAgreed
+    case nicknameEntered
+    case signup
+    case permissionLocationGranted
+    case permissionLocationDenied
+    case permissionNotificationsGranted
+    case permissionNotificationsDenied
+    case getNewRegionFlowStarted(regionCode: String, countryCode: String)
+    case identificationMethodChosen(regionCode: String, countryCode: String, ekycMethod: String)
+    case identificationPendingValidation(regionCode: String, countryCode: String, ekycMethod: String)
+    case identificationSuccessful(regionCode: String, countryCode: String, ekycMethod: String)
+    case identificationFailed(regionCode: String, countryCode: String, ekycMethod: String, failureReason: String)
+    case esimSetupStarted(regionCode: String, countryCode: String)
+    case esimSetupCompleted(regionCode: String, countryCode: String)
+    case logout
+    case buyDataFlowStarted
+    case setupApplePay
+    case addToCart(name: String, sku: String, countryCode: String, amount: Decimal, currency: String)
+    case ecommercePurchase(currency: String, value: Decimal, tax: Decimal)
+    case ecommercePurchaseFailed(failureReason: String)
+    
     var name: String {
         switch self {
-        case .ChosenCountry:
-            return "chosen_country"
-        case .ChosenIDMethod:
-            return "chosen_id_method"
+        case .addToCart:
+            return AnalyticsEventAddToCart
+        case .ecommercePurchase:
+            return AnalyticsEventEcommercePurchase
         default:
             return String(describing: self).snakeCased() ?? ""
         }
     }
     
-    var metadata: [String: NSObject] {
+    var metadata: [String: Any] {
         switch self {
-        case .ChosenCountry(let country):
-            return ["country": country.countryCode as NSObject]
-        case .ChosenIDMethod(let idMethod):
-            return ["id_method": idMethod as NSObject]
+        case .getNewRegionFlowStarted(let regionCode, let countryCode):
+            return ["region_code": regionCode, "country_code": countryCode]
+        case .identificationMethodChosen(let regionCode, let countryCode, let ekycMethod):
+            return ["region_code": regionCode, "country_code": countryCode, "ekyc_method": ekycMethod]
+        case .identificationPendingValidation(let regionCode, let countryCode, let ekycMethod):
+            return ["region_code": regionCode, "country_code": countryCode, "ekyc_method": ekycMethod]
+        case .identificationSuccessful(let regionCode, let countryCode, let ekycMethod):
+            return ["region_code": regionCode, "country_code": countryCode, "ekyc_method": ekycMethod]
+        case .identificationFailed(let regionCode, let countryCode, let ekycMethod, let failureReason):
+            return ["region_code": regionCode, "country_code": countryCode, "ekyc_method": ekycMethod, "failure_reaon": failureReason]
+        case .esimSetupStarted(let regionCode, let countryCode):
+            return ["region_code": regionCode, "country_code": countryCode]
+        case .esimSetupCompleted(let regionCode, let countryCode):
+            return ["region_code": regionCode, "country_code": countryCode]
+        case .addToCart(let name, let sku, let countryCode, let amount, let currency):
+            return [
+                "quantity": "1",
+                "item_categgory":
+                "one-time-purchase",
+                "item_name": name,
+                "item_sku": sku,
+                "item_location": countryCode,
+                "value": NSDecimalNumber(decimal: amount).stringValue,
+                "price": NSDecimalNumber(decimal: amount).stringValue,
+                "currency": currency
+            ]
+        case .ecommercePurchase(let currency, let value, let tax):
+            return [
+                "currency": currency,
+                "value": Double(truncating: value as NSNumber),
+                "tax": Double(truncating: tax as NSNumber)
+            ]
+        case .ecommercePurchaseFailed(let failureReason):
+            return ["failure_reason": failureReason]
         default:
             return [:]
         }

--- a/ostelco-ios-client/Protocols/ApplePayDelegate.swift
+++ b/ostelco-ios-client/Protocols/ApplePayDelegate.swift
@@ -107,6 +107,7 @@ extension ApplePayDelegate where Self: PKPaymentAuthorizationViewControllerDeleg
     // MARK: - Helpers for starting Apple Pay.
 
     func startApplePay(product: Product) {
+        OstelcoAnalytics.logEvent(.addToCart(name: product.name, sku: product.sku, countryCode: product.country, amount: product.amount, currency: product.currency))
         shownApplePay = false
         authorizedApplePay = false
         purchasingProduct = product

--- a/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
+++ b/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
@@ -22,6 +22,8 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
         Auth.auth().addStateDidChangeListener { (_, user) in
             if user == nil {
                 self.setupOnboarding()
+            } else {
+                OstelcoAnalytics.logEvent(.signIn)
             }
         }
         

--- a/ostelco-ios-client/ViewControllers/Country/AllowLocationAccessViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Country/AllowLocationAccessViewController.swift
@@ -64,9 +64,11 @@ class AllowLocationAccessViewController: UIViewController {
         case .restricted:
             delegate.handleLocationProblem(.restrictedByParentalControls)
         case .denied:
+            OstelcoAnalytics.logEvent(.permissionLocationDenied)
             delegate.handleLocationProblem(.deniedByUser)
         case .authorizedAlways,
              .authorizedWhenInUse:
+            OstelcoAnalytics.logEvent(.permissionLocationGranted)
             delegate.locationUsageAuthorized()
         @unknown default:
             ApplicationErrors.assertAndLog("Apple added another case to this! You should update your handling.")

--- a/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/PendingVerificationViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 
 protocol PendingVerificationDelegate: class {
     func checkStatus()
+    func viewDidAppear()
 }
 
 class PendingVerificationViewController: UIViewController {
@@ -28,6 +29,11 @@ class PendingVerificationViewController: UIViewController {
     weak var delegate: PendingVerificationDelegate?
     
     // MARK: - View Lifecycle
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        delegate?.viewDidAppear()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
+++ b/ostelco-ios-client/ViewControllers/EKYC/SelectIdentityVerificationMethodViewController.swift
@@ -61,13 +61,10 @@ class SelectIdentityVerificationMethodViewController: UIViewController {
         spinnerView = showSpinner()
         
         if self.singPassRadioButton.isCurrentSelected {
-            OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "singpass"))
             self.delegate?.selected(option: .singpass)
         } else if self.scanICRadioButton.isCurrentSelected {
-            OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "jumio"))
             self.delegate?.selected(option: .scanIC)
         } else if self.jumioRadioButton.isCurrentSelected {
-            OstelcoAnalytics.logEvent(.ChosenIDMethod(idMethod: "jumio"))
             self.delegate?.selected(option: .jumio)
         } else {
             ApplicationErrors.assertAndLog("At least one of these should be checked if continue is enabled!")

--- a/ostelco-ios-client/ViewControllers/ESim/ESIMInstructionsViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/ESIMInstructionsViewController.swift
@@ -55,7 +55,6 @@ class ESIMInstructionsViewController: UIViewController {
     @IBAction private func primaryButtonTapped(_ sender: UIButton) {
         let index = dataSource.currentIndex
         if index == (ESIMPage.allCases.count - 1) {
-            OstelcoAnalytics.logEvent(.ESimOnboardingIntroCompleted)
             self.delegate?.completedInstructions(self)
         } else {
             self.dataSource.goToNextPage()

--- a/ostelco-ios-client/ViewControllers/ESim/SignUpCompletedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/ESim/SignUpCompletedViewController.swift
@@ -25,8 +25,6 @@ class SignUpCompletedViewController: UIViewController {
         
         gifView.videoURL = GifVideo.rocket.url(for: traitCollection.userInterfaceStyle)
         gifView.play()
-        
-        OstelcoAnalytics.logEvent(.SignUpCompleted)
     }
     
     @IBAction private func continueTapped(_ sender: Any) {

--- a/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
+++ b/ostelco-ios-client/ViewControllers/Login/LoginViewController.swift
@@ -76,6 +76,7 @@ class LoginViewController: UIViewController {
 
     @objc
     func handleAuthorizationAppleIDButtonPress() {
+        OstelcoAnalytics.logEvent(.signInFlowStarted)
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]

--- a/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/GetStartedViewController.swift
@@ -36,6 +36,8 @@ class GetStartedViewController: UIViewController {
             ApplicationErrors.assertAndLog("No nickname but passed validation?!")
             return
         }
+        
+        OstelcoAnalytics.logEvent(.nicknameEntered)
 
         delegate?.enteredNickname(controller: self, nickname: nickname)
     }

--- a/ostelco-ios-client/ViewControllers/SignUp/TheLegalStuffViewController.swift
+++ b/ostelco-ios-client/ViewControllers/SignUp/TheLegalStuffViewController.swift
@@ -103,7 +103,7 @@ class TheLegalStuffViewController: UIViewController {
     }
     
     @IBAction private func continueTapped() {
-        OstelcoAnalytics.logEvent(.LegalStuffAgreed)
+        OstelcoAnalytics.logEvent(.legalStuffAgreed)
         delegate?.legaleseAgreed()
     }
 }

--- a/ostelco-ios-client/ViewControllers/TabBarViewController.swift
+++ b/ostelco-ios-client/ViewControllers/TabBarViewController.swift
@@ -34,7 +34,9 @@ class TabBarViewController: ApplePayViewController {
     }
     
     override func paymentSuccessful(_ product: Product?) {
-        
+        if let product = product {
+            OstelcoAnalytics.logEvent(.ecommercePurchase(currency: product.currency, value: product.amount, tax: product.tax))
+        }
     }
 }
 


### PR DESCRIPTION
Added FA events based on our doc "Analytics - Overview of events and requirements" describing which events we want.

Added code to manually set screen name for SwiftUI views since FA does not report them automatically.

Confirmed that the following events are sent
- [x] sign_in_flow_started
- [x] sign_in
- [x] legal_stuff_agreed
- [x] nickname_entered
- [x] signup
- [x] permission_location_granted
- [x] permission_location_denied
- [x] permission_notifications_granted
- [x] permission_notifications_denied
- [x] logout
- [x] buy_data_flow_started
- [x] setup_apple_pay
- [x] add_to_cart
- [x] ecommerce_purchase
- [x] ecommerce_purchase_failed
- [x] get_new_region_flow_started
- [x] identification_method_chosen
- [ ] identification_pending_validation (verify with jumio)
- [ ] identification_successful (works with singpass, verify with jumio)
- [ ] identification_failed (verify with jumio)
- [x] esim_setup_started
- [x] esim_setup_completed



