### PR TITLE
Fix visual issue with navigation bar on coverage view and sub views.

### DIFF
--- a/ostelco-ios-client/AppDelegate.swift
+++ b/ostelco-ios-client/AppDelegate.swift
@@ -42,8 +42,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         application.applicationSupportsShakeToEdit = true
         
         self.registerForNotifications()
-
+        self.configureAppearance()
+        
         return true
+    }
+    
+    private func configureAppearance() {
+        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
+        UINavigationBar.appearance().isTranslucent = true
     }
     
     private func registerForNotifications() {

--- a/ostelco-ios-client/Features/Coverage/CoverageView.swift
+++ b/ostelco-ios-client/Features/Coverage/CoverageView.swift
@@ -89,7 +89,9 @@ struct CoverageView: View {
                     ForEach(store.regionGroups.filter({ $0.isPreview || store.regions != nil && Set(store.allowedCountries()).intersection(Set($0.countries.map({ $0.countryCode }))).isNotEmpty }), id: \.id) { self.renderRegionGroup($0) }
                     
                 }.padding()
-            }.navigationBarTitle("", displayMode: .inline)
+            }.padding(.top, 50).navigationBarTitle("Coverage", displayMode: .inline)
+            .navigationBarHidden(true)
+            .statusBar(hidden: true)
         }.onAppear {
             self.store.loadRegions()
         }

--- a/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
@@ -33,16 +33,19 @@ struct RegionGroupView: View {
     }
     
     var body: some View {
-        VStack {
-            RegionGroupCardView(label: regionGroup.name, description: regionGroup.description, backgroundColor: regionGroup.backgroundColor.toColor)
-            List(store.allowedCountries(countries: regionGroup.countries).map({ Country($0) }), id: \.countryCode) { country in
-                Group {
-                    self.renderSimProfile(self.regionGroup, country: country)
-                }.frame(maxWidth: .infinity, minHeight: 94.0)
-            }.cornerRadius(28)
-            .padding([.leading, .trailing, .top ], 10)
-            .padding(.bottom, 30)
-        }.background(regionGroup.backgroundColor.toColor)
+        ZStack {
+            regionGroup.backgroundColor.toColor
+            VStack {
+                RegionGroupCardView(label: regionGroup.name, description: regionGroup.description, backgroundColor: regionGroup.backgroundColor.toColor)
+                List(store.allowedCountries(countries: regionGroup.countries).map({ Country($0) }), id: \.countryCode) { country in
+                    Group {
+                        self.renderSimProfile(self.regionGroup, country: country)
+                    }.frame(maxWidth: .infinity, minHeight: 94.0)
+                }.cornerRadius(28)
+                .padding([.leading, .trailing, .top ], 10)
+                .padding(.bottom, 30)
+            }.padding(.top, 25)
+            }.edgesIgnoringSafeArea(.top)
     }
 }
 struct RegionView_Previews: PreviewProvider {


### PR DESCRIPTION
- Made navigation bar transparent
- Moved RegionGroupView under navigation bar and set background color to the whole view to color behind the navigation bar
- Show coverage title in navigation bar for region group by adding a title on coverage view, hiding the navigation bar since we already have a title there, then adding some padding to make up for the space created by the now hidden navigation bar

Not perfect, status bar is still wrong color, but hey
<img width="417" alt="Screen Shot 2019-10-25 at 7 54 09 PM" src="https://user-images.githubusercontent.com/2212037/67592939-43080c00-f761-11e9-9797-48df38fd3bb0.png">
