### PR TITLE
Revert "Handle being forced out better"

### DIFF
--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -11,7 +11,6 @@ import Foundation
 import Apollo
 
 public typealias Long = Int64
-public let FailedToFetchCustomerCode = "FAILED_TO_FETCH_CUSTOMER"
 
 extension Int64: JSONDecodable, JSONEncodable {
     public init(jsonValue value: JSONValue) throws {
@@ -127,8 +126,8 @@ open class PrimeAPI: BasicNetwork {
                     if let data = result?.data {
                         seal.fulfill(data.context)
                     } else {
-                        // Note: OnboardingCoordinator excepts an error of specific type to redirect user to signup when user is logged in but has not user in our server yet.
-                        seal.reject(APIHelper.Error.jsonError(JSONRequestError(errorCode: FailedToFetchCustomerCode, httpStatusCode: 404, message: "Failed to fetch customer.")))
+                        // Note: RootCoordinator excepts an error of specific type to redirect user to signup when user is logged in but has not user in our server yet.
+                        seal.reject(APIHelper.Error.jsonError(JSONRequestError(errorCode: "FAILED_TO_FETCH_CUSTOMER", httpStatusCode: 404, message: "Failed to fetch customer.")))
                     }
                 }
                 

--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -48,8 +48,6 @@ class OnboardingCoordinator {
     func advance() {
         primeAPI.loadContext()
             .done { (context) in
-                print(context.customer!)
-                
                 self.localContext.serverIsUnreachable = false
                 
                 let location = LocationController.shared
@@ -66,10 +64,6 @@ class OnboardingCoordinator {
                     }
                 }
         }.recover { error in
-            if case APIHelper.Error.jsonError(let innerError) = error, innerError.errorCode == FailedToFetchCustomerCode {
-                UserManager.shared.logOut()
-            }
-            
             self.localContext.serverIsUnreachable = (error as NSError).code == -1004
             let context: Context? = nil
             let stage = self.stageDecider.compute(context: context, localContext: self.localContext)


### PR DESCRIPTION
Reverts ostelco/ostelco-ios-client#401

The PR prevents new users from using the app, when a new user logs in using sign in with apple, we don't have a user in our servers yet, thus the UserNotFound error is triggered and the app logs the user out.