### PR TITLE
Fix logout issues.

### DIFF
--- a/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
+++ b/ostelco-ios-client/Coordinators/OnboardingCoordinator.swift
@@ -16,7 +16,7 @@ import AVFoundation
 import CoreTelephony
 
 protocol OnboardingCoordinatorDelegate: class {
-    func onboardingComplete(force: Bool)
+    func onboardingComplete()
 }
 
 class OnboardingCoordinator {
@@ -57,7 +57,7 @@ class OnboardingCoordinator {
                 UserManager.shared.customer = context.customer
                 let stage = self.stageDecider.compute(context: context.toLegacyModel(), localContext: self.localContext)
                 if stage == .home {
-                    self.delegate?.onboardingComplete(force: false)
+                    self.delegate?.onboardingComplete()
                 } else {
                     self.afterDismissing {
                         self.navigateTo(stage)
@@ -96,7 +96,7 @@ class OnboardingCoordinator {
             nicknameEntry.delegate = self
             navigationController.setViewControllers([nicknameEntry], animated: true)
         case .home:
-            delegate?.onboardingComplete(force: false)
+            delegate?.onboardingComplete()
         case .ohNo(let issue):
             let ohNo = OhNoViewController.fromStoryboard(type: issue)
             ohNo.primaryButtonAction = { [weak self] in
@@ -111,7 +111,7 @@ class OnboardingCoordinator {
             let locationProblem = LocationProblemViewController.fromStoryboard()
             locationProblem.delegate = self
             locationProblem.locationProblem = problem
-            navigationController.present(locationProblem, animated: true, completion: nil)
+            navigationController.setViewControllers([locationProblem], animated: true)
         case .notificationPermissions:
             let notificationPermissions = EnableNotificationsViewController.fromStoryboard()
             notificationPermissions.delegate = self

--- a/ostelco-ios-client/Features/App/TabBarView.swift
+++ b/ostelco-ios-client/Features/App/TabBarView.swift
@@ -33,6 +33,10 @@ struct TabBarView: View {
         UINavigationBar.appearance().shadowImage = UIImage()
     }
     
+    func resetTabs() {
+        currentTab = .balance
+    }
+    
     var body: some View {
         TabView(selection: $currentTab) {
             // TODO: This seems like a hacky way to be able to change current tab from a child view. (this = passing the state variable from the tabbar view to the corresponding views, it feels like we should be able to control this through some other kind of mechanism)

--- a/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
+++ b/ostelco-ios-client/ViewControllers/AuthParentViewController.swift
@@ -21,6 +21,7 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
         
         Auth.auth().addStateDidChangeListener { (_, user) in
             if user == nil {
+                self.killMainApp()
                 self.setupOnboarding()
             } else {
                 OstelcoAnalytics.logEvent(.signIn)
@@ -30,14 +31,21 @@ class AuthParentViewController: UIViewController, OnboardingCoordinatorDelegate 
         NotificationCenter.default.addObserver(self, selector: #selector(setupOnboarding), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
-    func onboardingComplete(force: Bool = false) {
+    func onboardingComplete() {
         killOldOnboarding()
         
-        if force || mainRoot == nil {
+        if mainRoot == nil {
             let tabs = UIStoryboard(name: "TabController", bundle: nil).instantiateInitialViewController()
             mainRoot = tabs
             embedFullViewChild(tabs!)
         }
+    }
+    
+    private func killMainApp() {
+        mainRoot?.willMove(toParent: nil)
+        mainRoot?.view.removeFromSuperview()
+        mainRoot?.removeFromParent()
+        mainRoot = nil
     }
     
     private func killOldOnboarding() {

--- a/ostelco-ios-client/ViewControllers/TabBarViewController.swift
+++ b/ostelco-ios-client/ViewControllers/TabBarViewController.swift
@@ -15,10 +15,13 @@ class TabBarViewController: ApplePayViewController {
     var currentCoordinator: RegionOnboardingCoordinator?
     let primeAPI = APIManager.shared.primeAPI
     
+    var tabBar: TabBarView?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        embedSwiftUI(TabBarView(controller: self))
+        tabBar = TabBarView(controller: self)
+        embedSwiftUI(tabBar!)
     }
     
     func showFreshchat() {
@@ -26,6 +29,8 @@ class TabBarViewController: ApplePayViewController {
     }
     
     func startOnboardingForRegion(_ region: PrimeGQL.RegionDetailsFragment) {
+        currentCoordinator = nil
+        
         let navigationController = UINavigationController()
         let coordinator = RegionOnboardingCoordinator(region: region, localContext: RegionOnboardingContext(), navigationController: navigationController, primeAPI: primeAPI)
         coordinator.delegate = self
@@ -37,18 +42,14 @@ class TabBarViewController: ApplePayViewController {
         if let product = product {
             OstelcoAnalytics.logEvent(.ecommercePurchase(currency: product.currency, value: product.stripeAmount, tax: product.stripeTax))
         }
-        if let parent = self.parent as? AuthParentViewController {
-            parent.onboardingComplete(force: true)
-        }
+        tabBar?.resetTabs()
     }
 }
 
 extension TabBarViewController: RegionOnboardingDelegate {
     func onboardingCompleteForRegion(_ regionID: String) {
         dismiss(animated: true, completion: nil)
-        if let parent = self.parent as? AuthParentViewController {
-            parent.onboardingComplete(force: true)
-        }
+        tabBar?.resetTabs()
     }
     
     func onboardingCancelled() {


### PR DESCRIPTION
1. Make sure the app shows the balance tab once the user logs back in.

Resolved this by making sure the main app is rebuilt when a user logs
in.
2. Make sure the app shows the location problem properly.

It was incorrectly presented when it should be left to the navigation
controller.