### PR TITLE
Fix the issue with showing welcome message late.

### DIFF
--- a/ostelco-ios-client/Features/Balance/BalanceStore.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceStore.swift
@@ -14,7 +14,7 @@ final class BalanceStore: ObservableObject {
     @Published var products: [Product] = []
     @Published var selectedProduct: Product?
     @Published var balance: String?
-    @Published var hasAtLeastOneInstalledSimProfile: Bool = false
+    @Published var hasAtLeastOneApprovedCountry: Bool = false
     
     let controller: TabBarViewController
     
@@ -28,7 +28,7 @@ final class BalanceStore: ObservableObject {
         self.controller = controller
         loadProducts()
         fetchBalance()
-        loadSimProfiles()
+        checkRegions()
     }
     
     func loadProducts() {
@@ -51,11 +51,13 @@ final class BalanceStore: ObservableObject {
         }
     }
     
-    func loadSimProfiles() {
+    func checkRegions() {
         APIManager.shared.primeAPI.loadRegions()
-            .map { $0.map { $0.simProfiles?.filter({ $0.fragments.simProfileFields.status == .installed }) ?? [] } }
-            .done { tmp in
-                self.hasAtLeastOneInstalledSimProfile = tmp.contains(where: { $0.isNotEmpty })
+            .filterValues({ (region) -> Bool in
+                return region.status == .approved
+            })
+            .done { result in
+                self.hasAtLeastOneApprovedCountry = result.isNotEmpty
             }.catch { error in
                 ApplicationErrors.log(error)
         }

--- a/ostelco-ios-client/Features/Balance/BalanceView.swift
+++ b/ostelco-ios-client/Features/Balance/BalanceView.swift
@@ -120,8 +120,8 @@ struct BalanceView: View {
             ApplePaySetupView()
         }.onAppear {
             OstelcoAnalytics.setScreenName(name: "BalanceView")
-            if !self.store.hasAtLeastOneInstalledSimProfile {
-                self.store.loadSimProfiles()
+            if !self.store.hasAtLeastOneApprovedCountry {
+                self.store.checkRegions()
             }
             
             self.store.loadProducts()
@@ -136,7 +136,7 @@ struct BalanceView: View {
                         messageType: .countryNotSupported(country: country)
                     )
                 )
-        } else if store.hasAtLeastOneInstalledSimProfile {
+        } else if store.hasAtLeastOneApprovedCountry {
             if let country = global.showCountryChangedMessage() {
                 return AnyView(
                     MessageContainer(messageType: .welcomeToCountry(action: { self.currentTab = .coverage }, country: country))


### PR DESCRIPTION
Since we don't know on the server end that a sim is installed right away
(which backend is working on), it makes more sense to stop showing the
welcome message once the user has finished eKYC instead. By that time,
they likely know what's going on and can re-download the sim if they
need to.