### PR TITLE
Display proper purchase history dates.

### DIFF
--- a/ostelco-ios-client/Features/Account/AccountStore.swift
+++ b/ostelco-ios-client/Features/Account/AccountStore.swift
@@ -10,9 +10,9 @@ final class AccountStore: ObservableObject {
     @Published var purchaseRecords: [PurchaseRecord] = []
     @Published var unreadMessages: Int = 0
     
-    private let controller: TabBarViewController
+    private let controller: UIViewController
     
-    init(controller: TabBarViewController) {
+    init(controller: UIViewController) {
         self.controller = controller
         
         updateUnreadMessagesCount()
@@ -23,7 +23,9 @@ final class AccountStore: ObservableObject {
             let sortedPurchases = purchaseModels.sorted { $0.timestamp > $1.timestamp }
             return sortedPurchases.map { PurchaseRecord(from: $0) }
         }
-        .done { self.purchaseRecords = $0 }
+        .done {
+            self.purchaseRecords = $0
+        }
         .catch { error in
             ApplicationErrors.log(error)
             // TODO: Notify user about this error.

--- a/ostelco-ios-client/Features/Account/PurchaseHistoryView.swift
+++ b/ostelco-ios-client/Features/Account/PurchaseHistoryView.swift
@@ -8,13 +8,14 @@
 
 import SwiftUI
 import OstelcoStyles
+import ostelco_core
 
 struct PurchaseHistoryView: View {
     
     @EnvironmentObject var store: AccountStore
     
     var body: some View {
-        List(store.purchaseRecords, id: \.name) { record in
+        List(store.purchaseRecords, id: \.id) { record in
             RecordRow(record: record)
         }
         .navigationBarTitle("Purchase History")
@@ -27,17 +28,21 @@ struct PurchaseHistoryView: View {
 struct RecordRow: View {
     let record: PurchaseRecord
     
+    init(record: PurchaseRecord) {
+        self.record = record
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(record.date)
+            Text(verbatim: record.date)
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(OstelcoColor.inputLabel.toColor)
             HStack {
-                Text(record.name)
+                Text(verbatim: record.name)
                     .font(.system(size: 17))
                     .foregroundColor(OstelcoColor.inputLabel.toColor)
                 Spacer()
-                Text(record.amount)
+                Text(verbatim: record.amount)
                     .font(.system(size: 17))
                     .foregroundColor(OstelcoColor.inputLabel.toColor)
             }
@@ -47,7 +52,18 @@ struct RecordRow: View {
 
 struct PurchaseHistoryView_Previews: PreviewProvider {
 
+    static var store: AccountStore = {
+        let store = AccountStore(controller: UIViewController())
+        store.purchaseRecords = [
+            PurchaseRecord(name: "first", amount: "10x", date: "01/01/01", id: "1"),
+            PurchaseRecord(name: "second", amount: "20x", date: "01/01/02", id: "2"),
+            PurchaseRecord(name: "third", amount: "30x", date: "01/01/03", id: "3")
+        ]
+        
+        return store
+    }()
+    
     static var previews: some View {
-        PurchaseHistoryView()
+        PurchaseHistoryView().environmentObject(store)
     }
 }

--- a/ostelco-ios-client/Models/PurchaseRecord.swift
+++ b/ostelco-ios-client/Models/PurchaseRecord.swift
@@ -9,10 +9,11 @@
 import Foundation
 import ostelco_core
 
-class PurchaseRecord {
+struct PurchaseRecord {
     let name: String
     let amount: String
     let date: String
+    let id: String
 
     private static var  dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -20,11 +21,12 @@ class PurchaseRecord {
         formatter.timeStyle = .none
         return formatter
     }()
-
-    init(name: String, amount: String, date: String) {
+    
+    init(name: String, amount: String, date: String, id: String) {
         self.name = name
         self.amount = amount
         self.date = date
+        self.id = id
     }
 
     init(from: PrimeGQL.PurchasesQuery.Data.Context.Purchase) {
@@ -34,5 +36,6 @@ class PurchaseRecord {
         name = from.product.fragments.productFragment.presentation.productLabel
         amount = from.product.fragments.productFragment.presentation.priceLabel
         date = strDate
+        id = from.id
     }
 }


### PR DESCRIPTION
If you use the name of a purchase as the identifier, this tells SwiftUI
to use the same exact row view for each item, even if they have
different dates. This re-use makes it display incorrect dates, so I
added ID's and used that as the identifier.