### PR TITLE
Report successfully installing eSims

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 3
 jobs:
   beta:
     macos:
-      xcode: "11.3.0"
+      xcode: "11.2.1"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output
@@ -39,7 +39,7 @@ jobs:
           path: output
   build-and-test:
     macos:
-      xcode: "11.3.0"
+      xcode: "11.2.1"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output

--- a/dev-ostelco-ios-clientTests/ContextTests.swift
+++ b/dev-ostelco-ios-clientTests/ContextTests.swift
@@ -30,5 +30,13 @@ class ContextTests: XCTestCase {
         
         XCTAssert(profiles!.isNotEmpty)
     }
+    
+    func testSimProfilesCountAsInstalledWhenRightPropertiesAreSet() {
+        let first = SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .AVAILABLE_FOR_DOWNLOAD, installedReportedByAppOn: "someDateThatIsGoodWeDontCare")
+        XCTAssert(first.isInstalled)
+        
+        let second = SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED, installedReportedByAppOn: nil)
+        XCTAssert(second.isInstalled)
+    }
 
 }

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/EdgeCasesInStageDeciderTests.swift
@@ -21,7 +21,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
             region: Region(id: "sg", name: "Singapore"),
             status: .APPROVED,
             simProfiles: [
-                SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED)
+                SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED, installedReportedByAppOn: "xxx")
             ],
             kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .APPROVED, nricFin: .PENDING, addressPhone: .PENDING)
         )
@@ -41,7 +41,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
                     region: Region(id: "sg", name: "Singapore"),
                     status: .APPROVED,
                     simProfiles: [
-                        SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED)
+                        SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED, installedReportedByAppOn: "xxx")
                     ],
                     kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .APPROVED, nricFin: .PENDING, addressPhone: .PENDING)
                 )
@@ -176,7 +176,7 @@ class EdgeCasesInStageDeciderTests: XCTestCase {
                     region: Region(id: "no", name: "Norway"),
                     status: .APPROVED,
                     simProfiles: [
-                        SimProfile(eSimActivationCode: "xxx", alias: "xxxx", iccId: "xxxx", status: .INSTALLED)
+                        SimProfile(eSimActivationCode: "xxx", alias: "xxxx", iccId: "xxxx", status: .INSTALLED, installedReportedByAppOn: "xxx")
                     ],
                     kycStatusMap: KYCStatusMap(jumio: .APPROVED, myInfo: .PENDING, nricFin: .APPROVED, addressPhone: .APPROVED)
                 )

--- a/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
+++ b/dev-ostelco-ios-clientTests/CoordinatorTests/SingaporeUserHappyFlowWithSingPassStageDeciderTests.swift
@@ -153,7 +153,7 @@ class SingaporeUserHappyFlowWithSingPassStageDeciderTests: XCTestCase {
                     region: Region(id: "sg", name: "Singapore"),
                     status: .APPROVED,
                     simProfiles: [
-                        SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED)
+                        SimProfile(eSimActivationCode: "xxx", alias: "xxx", iccId: "xxx", status: .INSTALLED, installedReportedByAppOn: "xxx")
                     ],
                     kycStatusMap: KYCStatusMap(jumio: .PENDING, myInfo: .APPROVED, nricFin: .PENDING, addressPhone: .PENDING)
                 )

--- a/ostelco-core/API.swift
+++ b/ostelco-core/API.swift
@@ -506,8 +506,8 @@ public enum PrimeGQL {
               self.resultMap = unsafeResultMap
             }
 
-            public init(eSimActivationCode: String, alias: String, iccId: String, status: SimProfileStatus) {
-              self.init(unsafeResultMap: ["__typename": "SimProfile", "eSimActivationCode": eSimActivationCode, "alias": alias, "iccId": iccId, "status": status])
+            public init(eSimActivationCode: String, alias: String, iccId: String, status: SimProfileStatus, installedReportedByAppOn: String? = nil) {
+              self.init(unsafeResultMap: ["__typename": "SimProfile", "eSimActivationCode": eSimActivationCode, "alias": alias, "iccId": iccId, "status": status, "installedReportedByAppOn": installedReportedByAppOn])
             }
 
             public var __typename: String {
@@ -1314,7 +1314,7 @@ public enum PrimeGQL {
 
   public struct SimProfileFields: GraphQLFragment {
     public static let fragmentDefinition =
-      "fragment simProfileFields on SimProfile {\n  __typename\n  eSimActivationCode\n  alias\n  iccId\n  status\n}"
+      "fragment simProfileFields on SimProfile {\n  __typename\n  eSimActivationCode\n  alias\n  iccId\n  status\n  installedReportedByAppOn\n}"
 
     public static let possibleTypes = ["SimProfile"]
 
@@ -1324,6 +1324,7 @@ public enum PrimeGQL {
       GraphQLField("alias", type: .nonNull(.scalar(String.self))),
       GraphQLField("iccId", type: .nonNull(.scalar(String.self))),
       GraphQLField("status", type: .nonNull(.scalar(SimProfileStatus.self))),
+      GraphQLField("installedReportedByAppOn", type: .scalar(String.self)),
     ]
 
     public private(set) var resultMap: ResultMap
@@ -1332,8 +1333,8 @@ public enum PrimeGQL {
       self.resultMap = unsafeResultMap
     }
 
-    public init(eSimActivationCode: String, alias: String, iccId: String, status: SimProfileStatus) {
-      self.init(unsafeResultMap: ["__typename": "SimProfile", "eSimActivationCode": eSimActivationCode, "alias": alias, "iccId": iccId, "status": status])
+    public init(eSimActivationCode: String, alias: String, iccId: String, status: SimProfileStatus, installedReportedByAppOn: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "SimProfile", "eSimActivationCode": eSimActivationCode, "alias": alias, "iccId": iccId, "status": status, "installedReportedByAppOn": installedReportedByAppOn])
     }
 
     public var __typename: String {
@@ -1378,6 +1379,15 @@ public enum PrimeGQL {
       }
       set {
         resultMap.updateValue(newValue, forKey: "status")
+      }
+    }
+
+    public var installedReportedByAppOn: String? {
+      get {
+        return resultMap["installedReportedByAppOn"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "installedReportedByAppOn")
       }
     }
   }
@@ -1579,8 +1589,8 @@ public enum PrimeGQL {
         self.resultMap = unsafeResultMap
       }
 
-      public init(eSimActivationCode: String, alias: String, iccId: String, status: SimProfileStatus) {
-        self.init(unsafeResultMap: ["__typename": "SimProfile", "eSimActivationCode": eSimActivationCode, "alias": alias, "iccId": iccId, "status": status])
+      public init(eSimActivationCode: String, alias: String, iccId: String, status: SimProfileStatus, installedReportedByAppOn: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "SimProfile", "eSimActivationCode": eSimActivationCode, "alias": alias, "iccId": iccId, "status": status, "installedReportedByAppOn": installedReportedByAppOn])
       }
 
       public var __typename: String {

--- a/ostelco-core/Models/SimProfile.swift
+++ b/ostelco-core/Models/SimProfile.swift
@@ -25,15 +25,18 @@ public struct SimProfile: Codable, Equatable {
     public let alias: String
     public let iccId: String
     public let status: SimProfileStatus
+    public let installedReportedByAppOn: String?
     
     public init(eSimActivationCode: String,
                 alias: String,
                 iccId: String,
-                status: SimProfileStatus) {
+                status: SimProfileStatus,
+                installedReportedByAppOn: String?) {
         self.eSimActivationCode = eSimActivationCode
         self.alias = alias
         self.iccId = iccId
         self.status = status
+        self.installedReportedByAppOn = installedReportedByAppOn
     }
     
     // Assumes that an eSimActivationCode contains three parts separated by "$" where
@@ -54,6 +57,10 @@ public struct SimProfile: Codable, Equatable {
     public var isDummyProfile: Bool {
         return eSimActivationCode.lowercased() == "dummy esim" || iccId.lowercased().starts(with: "test")
     }
+    
+    public var isInstalled: Bool {
+        return status == .INSTALLED || installedReportedByAppOn != nil
+    }
 }
 
 extension SimProfile {
@@ -62,7 +69,8 @@ extension SimProfile {
         self.init(eSimActivationCode: gqlSimProfile.eSimActivationCode,
                   alias: gqlSimProfile.alias,
                   iccId: gqlSimProfile.iccId,
-                  status: status
+                  status: status,
+                  installedReportedByAppOn: gqlSimProfile.installedReportedByAppOn
         )
     }
     

--- a/ostelco-core/Models/StageDecider.swift
+++ b/ostelco-core/Models/StageDecider.swift
@@ -115,7 +115,7 @@ public struct StageDecider {
             remove(.eSimInstructions)
         }
         
-        if let profile = region.getGraphQLModel().getSimProfile(), profile.status == .installed {
+        if let profiles = region.simProfiles, profiles.contains(where: { $0.isInstalled }) {
             remove(.eSimInstructions)
         }
         

--- a/ostelco-core/Network/APIEndpoint.swift
+++ b/ostelco-core/Network/APIEndpoint.swift
@@ -54,6 +54,7 @@ public enum RegionEndpoint: APIEndpoint {
     case simProfiles
     case scans
     case iccId(code: String)
+    case installed
     case resendEmail
     
     var value: String {
@@ -89,6 +90,8 @@ public enum RegionEndpoint: APIEndpoint {
             return code
         case .resendEmail:
             return "resendEmail"
+        case .installed:
+            return "installed"
         }
     }
 }

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -428,6 +428,25 @@ open class PrimeAPI: BasicNetwork {
         }
     }
     
+    /// Updates the user's eSIM profile status to show the app has installed it.
+    ///
+    /// - Parameters:
+    ///   - iccId: The identifier for the specific eSIM
+    /// - Returns: A promise which when fulfilled, indicates successful completion of the operation.
+    public func markESIMAsInstalled(iccId: String) -> PromiseKit.Promise<Void> {
+        let endpoints: [RegionEndpoint] = [
+            .iccId(code: iccId),
+            .installed
+        ]
+
+        let path = RootEndpoint.regions.pathByAddingEndpoints(endpoints)
+
+        return self.sendQuery(to: path, queryItems: nil, method: .PUT)
+        .map { data, response in
+            try APIHelper.validateAndLookForServerError(data: data, response: response, decoder: self.decoder)
+        }
+    }
+    
     // TODO: Load from GraphQL
     /// Validates the given NRIC.
     ///
@@ -581,7 +600,7 @@ open class PrimeAPI: BasicNetwork {
     ///   - method: The `HTTPMethod` to use to send it.
     /// - Returns: A promise, which when fulfilled, will contain any returned data and the URLResponse that came with it.
     public func sendQuery(to path: String,
-                          queryItems: [URLQueryItem],
+                          queryItems: [URLQueryItem]?,
                           method: HTTPMethod) -> PromiseKit.Promise<(data: Data, response: URLResponse)> {
         return self.tokenProvider.getToken()
             .map { token -> Request in

--- a/ostelco-core/Network/PrimeAPI.swift
+++ b/ostelco-core/Network/PrimeAPI.swift
@@ -433,9 +433,13 @@ open class PrimeAPI: BasicNetwork {
     /// - Parameters:
     ///   - iccId: The identifier for the specific eSIM
     /// - Returns: A promise which when fulfilled, indicates successful completion of the operation.
-    public func markESIMAsInstalled(iccId: String) -> PromiseKit.Promise<Void> {
+    public func markESIMAsInstalled(simProfile: SimProfile) -> PromiseKit.Promise<Void> {
+        if simProfile.isDummyProfile {
+            return .value(())
+        }
+        
         let endpoints: [RegionEndpoint] = [
-            .iccId(code: iccId),
+            .iccId(code: simProfile.iccId),
             .installed
         ]
 

--- a/ostelco-core/schema.json
+++ b/ostelco-core/schema.json
@@ -624,6 +624,66 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "requestedOn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "downloadedOn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "installedOn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "installedReportedByAppOn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedOn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1806,33 +1866,8 @@
     ],
     "directives": [
       {
-        "name": "skip",
-        "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "args": [
-          {
-            "name": "if",
-            "description": "Skipped when true.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "defaultValue": null
-          }
-        ]
-      },
-      {
         "name": "include",
-        "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+        "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
         "locations": [
           "FIELD",
           "FRAGMENT_SPREAD",
@@ -1856,8 +1891,33 @@
         ]
       },
       {
+        "name": "skip",
+        "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": "Skipped when true.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
         "name": "deprecated",
-        "description": "Marks an element of a GraphQL schema as no longer supported.",
+        "description": null,
         "locations": [
           "FIELD_DEFINITION",
           "ENUM_VALUE"
@@ -1865,7 +1925,7 @@
         "args": [
           {
             "name": "reason",
-            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",

--- a/ostelco-core/simProfilesForRegion.graphql
+++ b/ostelco-core/simProfilesForRegion.graphql
@@ -13,4 +13,5 @@ fragment simProfileFields on SimProfile {
     alias
     iccId
     status
+    installedReportedByAppOn
 }

--- a/ostelco-ios-client/Features/App/GlobalStore.swift
+++ b/ostelco-ios-client/Features/App/GlobalStore.swift
@@ -40,12 +40,16 @@ final class GlobalStore: ObservableObject {
         UserDefaultsWrapper.countryCode = country?.countryCode
     }
     
-    func simProfilesForCountry(country: Country) -> [PrimeGQL.SimProfileFields] {
+    func simProfilesForCountry(country: Country) -> [SimProfile] {
         if let regionDetailsList = regions, let regionCodes = countryCodeToRegionCodeMap[country.countryCode] {
             return regionDetailsList
                 .filter({ regionCodes.contains($0.region.id) })
                 .filter({ $0.simProfiles != nil })
-                .map({ $0.simProfiles!.map({ $0.fragments.simProfileFields }) })
+                .map({
+                    $0.simProfiles!.map({
+                        SimProfile(gqlSimProfile: $0.fragments.simProfileFields)
+                    })
+                })
                 .reduce([], +)
         }
         return []
@@ -54,7 +58,7 @@ final class GlobalStore: ObservableObject {
     func showCountryChangedMessage() -> Country? {
         if let previousCountry = previousCountry, let country = country {
             
-            if previousCountry.countryCode != country.countryCode && simProfilesForCountry(country: country).filter({ $0.status == .installed }).isEmpty {
+            if previousCountry.countryCode != country.countryCode && simProfilesForCountry(country: country).filter({ $0.isInstalled }).isEmpty {
                 return country
             }
         }

--- a/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionGroupView.swift
@@ -19,7 +19,7 @@ struct RegionGroupView: View {
     
     private func renderSimProfile(_ regionGroup: RegionGroupViewModel, country: Country) -> AnyView {
         
-        if store.simProfilesForCountry(country: country).filter({ $0.status == .installed }).isNotEmpty {
+        if store.simProfilesForCountry(country: country).filter({ SimProfile(gqlSimProfile: $0).isInstalled }).isNotEmpty {
             return AnyView(
                 ESimCountryView(image: country.image, country: country.nameOrPlaceholder, icon: "checkmark")
             )

--- a/ostelco-ios-client/Features/Coverage/RegionListByLocation.swift
+++ b/ostelco-ios-client/Features/Coverage/RegionListByLocation.swift
@@ -21,7 +21,7 @@ struct RegionListByLocation: View {
     
     private func renderSimProfile(_ regionDetails: PrimeGQL.RegionDetailsFragment, country: Country) -> AnyView {
         
-        if (regionDetails.simProfiles ?? []).contains(where: { $0.fragments.simProfileFields.status == .installed }) {
+        if (regionDetails.simProfiles ?? []).contains(where: { SimProfile(gqlSimProfile: $0.fragments.simProfileFields).isInstalled }) {
             return AnyView(
                 OstelcoContainer(state: .inactive) {
                     ESimCountryView(image: country.image, country: regionDetails.region.name, heading: "BASED ON LOCATION", icon: "checkmark")

--- a/ostelco-ios-client/ModelControllers/ESimManager.swift
+++ b/ostelco-ios-client/ModelControllers/ESimManager.swift
@@ -15,15 +15,15 @@ class ESimManager {
     /**
      Tries to download and install an eSIM on the device using apples eSIM APIs.
      */
-    func addPlan(address: String, matchingID: String, iccid: String) -> PromiseKit.Promise<String> {
+    func addPlan(address: String, matchingID: String, simProfile: SimProfile) -> PromiseKit.Promise<SimProfile> {
         let planObj = CTCellularPlanProvisioning()
         
         let request = CTCellularPlanProvisioningRequest()
         request.address = address
         request.matchingID = matchingID
-        request.iccid = iccid
+        request.iccid = simProfile.iccId
 
-        return PromiseKit.Promise<String> { seal in
+        return PromiseKit.Promise<SimProfile> { seal in
             planObj.addPlan(with: request) { (result: CTCellularPlanProvisioningAddPlanResult) in
                 switch result {
                 case .unknown:
@@ -32,7 +32,7 @@ class ESimManager {
                     seal.reject(ApplicationErrors.General.addPlanFailed(message: "Failed"))
                 case .success:
                     AppEvents.logEvent(.completedRegistration)
-                    seal.fulfill(iccid)
+                    seal.fulfill(simProfile)
                 @unknown default:
                     seal.reject(ApplicationErrors.General.addPlanFailed(message: "Unknown default"))
                 }

--- a/ostelco-ios-client/ModelControllers/ESimManager.swift
+++ b/ostelco-ios-client/ModelControllers/ESimManager.swift
@@ -12,12 +12,10 @@ import ostelco_core
 import FacebookCore
 
 class ESimManager {
-    static let shared = ESimManager()
-    
     /**
      Tries to download and install an eSIM on the device using apples eSIM APIs.
      */
-    func addPlan(address: String, matchingID: String, iccid: String) -> PromiseKit.Promise<Void> {
+    func addPlan(address: String, matchingID: String, iccid: String) -> PromiseKit.Promise<String> {
         let planObj = CTCellularPlanProvisioning()
         
         let request = CTCellularPlanProvisioningRequest()
@@ -25,7 +23,7 @@ class ESimManager {
         request.matchingID = matchingID
         request.iccid = iccid
 
-        return PromiseKit.Promise<Void> { seal in
+        return PromiseKit.Promise<String> { seal in
             planObj.addPlan(with: request) { (result: CTCellularPlanProvisioningAddPlanResult) in
                 switch result {
                 case .unknown:
@@ -34,7 +32,7 @@ class ESimManager {
                     seal.reject(ApplicationErrors.General.addPlanFailed(message: "Failed"))
                 case .success:
                     AppEvents.logEvent(.completedRegistration)
-                    seal.fulfill(())
+                    seal.fulfill(iccid)
                 @unknown default:
                     seal.reject(ApplicationErrors.General.addPlanFailed(message: "Unknown default"))
                 }


### PR DESCRIPTION
The backend is not always informed in a timely fashion, so this allows
the app to report that the eSim was successfully installed instead. The
app will look for either this report or the overal status from the
backend to decide if a sim is setup.